### PR TITLE
Capability registry (adversarial review finding 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.worktrees/
 kaizen
 /tmp/
 *.js.map

--- a/docs/plugin-migration-capability-registry.md
+++ b/docs/plugin-migration-capability-registry.md
@@ -1,0 +1,511 @@
+# Plugin Migration Guide: Capability Registry (v1 → v2)
+
+This guide is a mechanical walkthrough for migrating a Kaizen plugin from the v1
+plugin API (`provides` / `depends` with anonymous role strings) to the v2 API
+(owner-qualified capabilities with declared cardinality). It is self-contained:
+you do not need to read the design spec or core source to complete a migration.
+
+## 1. Overview
+
+### What changed
+
+- **v1** used two string arrays on the plugin manifest:
+  - `provides: string[]` — anonymous role tags the plugin implements
+    (`"lifecycle"`, `"ui"`, `"executor"`, `"events"`).
+  - `depends: string[]` — roles the plugin needs some other plugin to provide.
+- **v2** replaces both with a single `capabilities` field containing
+  `provides` and `consumes` arrays of **owner-qualified capability names**:
+  ```
+  "<defining-plugin-name>:<local-capability-name>"
+  ```
+  Every capability is also formally declared via `ctx.defineCapability()` with
+  an explicit cardinality (`"singleton"` or `"many"`) and optional JSON schema.
+
+### Why
+
+Anonymous role strings made conflicts silent (two plugins providing `"ui"`
+produced undefined behavior), did not scope ownership (anyone could claim any
+role), and hid cardinality from the loader. The capability registry makes each
+contract explicit, validates it at load time, and makes providers/consumers
+introspectable via `kaizen capability list`.
+
+### Who this affects
+
+Every plugin author. The `apiVersion` major must be bumped from `"1.0.0"` to
+`"2.0.0"`. Plugins declaring `apiVersion: "1.x.x"` will fail to load under v2
+core.
+
+## 2. Canonical capability rename table
+
+The four built-in v1 role strings map to these v2 capability names. Use these
+names verbatim — they are defined by the core plugins.
+
+| v1 role | v2 capability name | Cardinality | Provider plugin |
+|---|---|---|---|
+| `"lifecycle"` | `"core-lifecycle:lifecycle.drive"` | `singleton` | `core-lifecycle` |
+| `"ui"` (input) | `"core-lifecycle:ui.input"` | `many` | `core-lifecycle` (consumer of registered providers) |
+| `"ui"` (output) | `"core-lifecycle:ui.output"` | `many` | `core-lifecycle` (consumer of registered providers) |
+| `"executor"` | `"core-lifecycle:executor.send"` | `many` | `core-lifecycle` consumes; any plugin can provide |
+| `"events"` | `"core-events:service"` | `singleton` | `core-events` |
+
+Notes:
+
+- `"ui"` is split into `ui.input` and `ui.output`. If you only produce output
+  (e.g. a logger), declare only `ui.output`. If you only read user input,
+  declare only `ui.input`. Most UI plugins declare both.
+- `executor.send` has `many` cardinality: multiple executor plugins may be
+  loaded. Until routing lands, `core-lifecycle` picks the first registered
+  executor. Having multiple is not an error.
+- `lifecycle.drive` and `core-events:service` are singletons — the loader
+  errors if two plugins claim either.
+
+### `provides` rename (side-by-side)
+
+**Before (v1):**
+```typescript
+provides: ["lifecycle"]
+provides: ["ui"]
+provides: ["executor"]
+provides: ["events"]
+```
+
+**After (v2):**
+```typescript
+capabilities: { provides: ["core-lifecycle:lifecycle.drive"] }
+capabilities: { provides: ["core-lifecycle:ui.input", "core-lifecycle:ui.output"] }
+capabilities: { provides: ["core-lifecycle:executor.send"] }
+capabilities: { provides: ["core-events:service"] }
+```
+
+## 3. `depends` → `consumes` mapping
+
+A plugin that previously depended on a role now declares the canonical
+capability in `capabilities.consumes`. The loader uses `consumes` to compute
+load order (topological sort on provides/consumes edges) and to validate that
+every consumed capability is provided by some loaded plugin.
+
+**Before (v1):**
+```typescript
+depends: ["lifecycle"]
+depends: ["ui"]
+depends: ["executor"]
+depends: ["events"]
+```
+
+**After (v2):**
+```typescript
+capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] }
+capabilities: { consumes: ["core-lifecycle:ui.input", "core-lifecycle:ui.output"] }
+capabilities: { consumes: ["core-lifecycle:executor.send"] }
+capabilities: { consumes: ["core-events:service"] }
+```
+
+For `ui`, include only the directions you actually use. A plugin that reads
+user input but never writes output should list only `"core-lifecycle:ui.input"`.
+
+**Rule of thumb:** if your `setup()` calls `ctx.getService(CoreEventsServiceToken)`,
+you consume `"core-events:service"`. If it calls `ctx.registerUi(...)`, you
+provide `ui.input`/`ui.output`. If it calls lifecycle driver methods, you
+consume `"core-lifecycle:lifecycle.drive"`.
+
+## 4. Full manifest before/after
+
+Hypothetical logging plugin that subscribes to user messages via the events
+service.
+
+### Before (v1)
+
+```typescript
+import type { KaizenPlugin } from "@kaizen/core";
+import { CoreEventsServiceToken } from "@kaizen/core-events";
+
+const plugin: KaizenPlugin = {
+  name: "kaizen-plugin-logger",
+  apiVersion: "1.0.0",
+  provides: [],
+  depends: ["events", "lifecycle"],
+  async setup(ctx) {
+    const { events } = ctx.getService(CoreEventsServiceToken);
+    ctx.on(events.USER_MESSAGE, async (p) => {
+      console.log("[log]", p);
+    });
+  },
+};
+
+export default plugin;
+```
+
+### After (v2)
+
+```typescript
+import type { KaizenPlugin } from "@kaizen/core";
+import { CoreEventsServiceToken } from "@kaizen/core-events";
+
+const plugin: KaizenPlugin = {
+  name: "kaizen-plugin-logger",
+  apiVersion: "2.0.0",
+  capabilities: {
+    consumes: ["core-events:service", "core-lifecycle:lifecycle.drive"],
+  },
+  async setup(ctx) {
+    const { events } = ctx.getService(CoreEventsServiceToken);
+    ctx.on(events.USER_MESSAGE, async (p) => {
+      console.log("[log]", p);
+    });
+  },
+};
+
+export default plugin;
+```
+
+Notes on what changed:
+
+- `apiVersion` bumped to `"2.0.0"`.
+- `provides: []` removed (empty arrays are not required; omit them).
+- `depends: ["events", "lifecycle"]` replaced with
+  `capabilities.consumes: ["core-events:service", "core-lifecycle:lifecycle.drive"]`.
+- `setup()` body is unchanged — the service token API did not change.
+
+## 5. Defining a new capability (third-party plugins)
+
+Any plugin may define its own capabilities. The rules:
+
+1. The capability name **must** be owner-qualified with the plugin's own name:
+   `"{this-plugin-name}:{local-name}"`. Core throws at `defineCapability()` if
+   the prefix does not match the plugin's `name` field.
+2. Call `ctx.defineCapability(name, spec)` inside `setup()` **before** anything
+   consumes it.
+3. List the same name in `capabilities.provides` so the loader includes it in
+   the topological sort and cardinality check.
+4. Optional but recommended: provide a JSON schema describing the shape of
+   messages, config, or service objects associated with the capability.
+
+### Complete example: a metrics plugin exposing `counter.increment`
+
+```typescript
+import type { KaizenPlugin } from "@kaizen/core";
+
+const plugin: KaizenPlugin = {
+  name: "kaizen-plugin-metrics",
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["kaizen-plugin-metrics:counter.increment"],
+  },
+  async setup(ctx) {
+    ctx.defineCapability("kaizen-plugin-metrics:counter.increment", {
+      cardinality: "singleton",
+      description: "Increment a named counter by a delta.",
+      schema: {
+        type: "object",
+        required: ["name", "delta"],
+        properties: {
+          name: { type: "string", minLength: 1 },
+          delta: { type: "integer", minimum: 1 },
+        },
+        additionalProperties: false,
+      },
+    });
+
+    const counters = new Map<string, number>();
+    ctx.registerService("kaizen-plugin-metrics:counter.increment", {
+      increment(name: string, delta: number) {
+        counters.set(name, (counters.get(name) ?? 0) + delta);
+      },
+      get(name: string): number {
+        return counters.get(name) ?? 0;
+      },
+    });
+  },
+};
+
+export default plugin;
+```
+
+### A different plugin consuming it
+
+```typescript
+import type { KaizenPlugin } from "@kaizen/core";
+
+const plugin: KaizenPlugin = {
+  name: "kaizen-plugin-request-counter",
+  apiVersion: "2.0.0",
+  capabilities: {
+    consumes: [
+      "core-events:service",
+      "kaizen-plugin-metrics:counter.increment",
+    ],
+  },
+  async setup(ctx) {
+    const metrics = ctx.getService<{
+      increment(name: string, delta: number): void;
+    }>("kaizen-plugin-metrics:counter.increment");
+
+    ctx.on("request.completed", async () => {
+      metrics.increment("requests.total", 1);
+    });
+  },
+};
+
+export default plugin;
+```
+
+The loader now enforces that `kaizen-plugin-metrics` is loaded whenever
+`kaizen-plugin-request-counter` is loaded, and will order `metrics` before
+`request-counter` in `setup()`.
+
+## 6. Aliases (ergonomic short names)
+
+Fully qualified names get verbose. A plugin may declare aliases that the loader
+resolves before matching, validating, or sorting. Aliases are scoped to the
+declaring plugin only — they do not leak to other plugins.
+
+```typescript
+import type { KaizenPlugin } from "@kaizen/core";
+import { CoreEventsServiceToken } from "@kaizen/core-events";
+
+const plugin: KaizenPlugin = {
+  name: "kaizen-plugin-logger",
+  apiVersion: "2.0.0",
+  aliases: {
+    "lifecycle": "core-lifecycle:lifecycle.drive",
+    "events": "core-events:service",
+  },
+  capabilities: {
+    consumes: ["events", "lifecycle"],
+  },
+  async setup(ctx) {
+    const { events } = ctx.getService(CoreEventsServiceToken);
+    ctx.on(events.USER_MESSAGE, async (p) => {
+      console.log("[log]", p);
+    });
+  },
+};
+
+export default plugin;
+```
+
+Both the topological sort and the "is this capability defined?" check resolve
+aliases first, so `consumes: ["events"]` behaves identically to
+`consumes: ["core-events:service"]`.
+
+## 7. Authoring a `UiProvider`
+
+UI plugins provide `ui.input` and/or `ui.output` by registering a `UiProvider`
+during `setup()`. Lifecycle merges channels from every registered provider:
+input is **raced** (first input wins; others are ignored for that turn), output
+is **broadcast** (every output channel receives every message). The plugin
+author just yields channels — the racing/broadcasting logic lives in lifecycle.
+
+Complete working example: an in-memory UI provider backed by a queue, suitable
+for tests or headless drivers.
+
+```typescript
+import type {
+  KaizenPlugin,
+  UiProvider,
+  UiChannel,
+  UiMessage,
+} from "@kaizen/core";
+
+function makeQueueChannel(id: string): UiChannel {
+  const inbox: UiMessage[] = [];
+  let resolveNext: ((m: UiMessage) => void) | null = null;
+
+  return {
+    id,
+    async readInput(): Promise<UiMessage> {
+      const queued = inbox.shift();
+      if (queued) return queued;
+      return new Promise((resolve) => {
+        resolveNext = resolve;
+      });
+    },
+    async writeOutput(message: UiMessage): Promise<void> {
+      // In a real channel this would push to a terminal, websocket, etc.
+      console.log(`[${id}]`, message);
+    },
+    push(message: UiMessage): void {
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r(message);
+      } else {
+        inbox.push(message);
+      }
+    },
+  };
+}
+
+const plugin: KaizenPlugin = {
+  name: "kaizen-plugin-memory-ui",
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: [
+      "core-lifecycle:ui.input",
+      "core-lifecycle:ui.output",
+    ],
+  },
+  async setup(ctx) {
+    const provider: UiProvider = {
+      name: "memory-ui",
+      async *channels(): AsyncIterable<UiChannel> {
+        yield makeQueueChannel("memory-ui:main");
+      },
+    };
+    ctx.registerUi(provider);
+  },
+};
+
+export default plugin;
+```
+
+Key points:
+
+- Declare both `ui.input` and `ui.output` if the channel supports both
+  directions. If the channel only writes (e.g. a log sink), declare only
+  `ui.output`.
+- `ctx.registerUi(provider)` is idempotent within a single `setup()` call but
+  should only be called once per plugin.
+- Do not implement racing or broadcasting yourself; lifecycle handles it.
+
+## 8. Introspection
+
+Two CLI subcommands inspect the loaded capability graph. Use them to verify a
+migration landed correctly.
+
+### `kaizen capability list`
+
+Sample output:
+
+```
+$ kaizen capability list
+NAME                                    CARDINALITY  PROVIDERS                                CONSUMERS
+core-events:service                     singleton    core-events                              kaizen-plugin-logger
+core-lifecycle:executor.send            many         kaizen-plugin-anthropic                  core-lifecycle
+core-lifecycle:lifecycle.drive          singleton    core-lifecycle                           kaizen-plugin-logger
+core-lifecycle:ui.input                 many         kaizen-plugin-memory-ui                  core-lifecycle
+core-lifecycle:ui.output                many         kaizen-plugin-memory-ui                  core-lifecycle
+kaizen-plugin-metrics:counter.increment singleton    kaizen-plugin-metrics                    kaizen-plugin-request-counter
+```
+
+### `kaizen capability show <name>`
+
+Sample output:
+
+```
+$ kaizen capability show kaizen-plugin-metrics:counter.increment
+Name:         kaizen-plugin-metrics:counter.increment
+Owner:        kaizen-plugin-metrics
+Cardinality:  singleton
+Description:  Increment a named counter by a delta.
+Providers:
+  - kaizen-plugin-metrics
+Consumers:
+  - kaizen-plugin-request-counter
+Schema:
+  {
+    "type": "object",
+    "required": ["name", "delta"],
+    "properties": {
+      "name":  { "type": "string", "minLength": 1 },
+      "delta": { "type": "integer", "minimum": 1 }
+    },
+    "additionalProperties": false
+  }
+```
+
+**How to verify a migration:**
+
+1. Run `kaizen capability list` and confirm every capability your plugin
+   declares appears in the table.
+2. Confirm the `PROVIDERS` column lists your plugin for each name in
+   `capabilities.provides`.
+3. Confirm the `CONSUMERS` column lists your plugin for each name in
+   `capabilities.consumes`.
+4. For any capability you defined yourself, run `kaizen capability show <name>`
+   and verify the cardinality, description, and schema match what you passed
+   to `defineCapability()`.
+
+## 9. Failure modes and fixes
+
+Core emits fatal errors at load time for the conditions below. For each:
+cause, example, fix.
+
+### `Capability 'X:Y' must be prefixed with plugin name 'Z'`
+
+**Cause.** `ctx.defineCapability("X:Y", …)` was called from plugin `Z`, but the
+name does not start with `Z:`.
+
+**Fix.** Rename the capability to use the plugin's own name as prefix. If you
+genuinely want a different owner, move the `defineCapability` call into that
+plugin.
+
+```typescript
+// BAD — plugin name is "kaizen-plugin-metrics" but capability prefix is wrong.
+ctx.defineCapability("metrics:counter.increment", { cardinality: "singleton" });
+
+// GOOD
+ctx.defineCapability("kaizen-plugin-metrics:counter.increment", {
+  cardinality: "singleton",
+});
+```
+
+### `No plugin provides capability 'X:Y' (consumed by: A, B)`
+
+**Cause.** Plugins `A` and `B` declare `consumes: ["X:Y"]`, but no loaded
+plugin declares `provides: ["X:Y"]`.
+
+**Fix.** Add the providing plugin to `kaizen.json`. If the provider is a core
+plugin, ensure the harness loads it (the default harness already loads
+`core-lifecycle`, `core-events`, and `core-plugin-manager`).
+
+### `Multiple plugins provide capability 'X:Y': A, B`
+
+**Cause.** `X:Y` has `cardinality: "singleton"`, but plugins `A` and `B` both
+declare `provides: ["X:Y"]`.
+
+**Fix.** Remove one of the providers from `kaizen.json`. If both truly need to
+coexist, the capability is miscategorized — change its definition to
+`cardinality: "many"` (you can only do this in the plugin that defines it).
+
+### `Plugin(s) [A] consumes undefined capability 'Y:Z'`
+
+**Cause.** Plugin `A` declares `consumes: ["Y:Z"]` but no loaded plugin has
+called `defineCapability("Y:Z", …)`.
+
+**Fix.** One of:
+
+1. **Typo.** Check spelling against `kaizen capability list` output.
+2. **Defining plugin not loaded.** Add the defining plugin to `kaizen.json`.
+3. **Missing alias.** If you intended to use a short name, add it under the
+   plugin's `aliases` table (see section 6).
+
+## 10. Migration checklist
+
+Execute these steps in order. Each is independently verifiable.
+
+1. **Bump `apiVersion`** to `"2.0.0"` in the plugin manifest.
+2. **Translate `provides`.** Replace `provides: [...]` with
+   `capabilities: { provides: [...] }`, substituting each v1 role string with
+   its canonical name from the rename table in section 2. Remove the old
+   `provides` field entirely.
+3. **Translate `depends`.** Replace `depends: [...]` with
+   `capabilities: { consumes: [...] }` (merge into the same `capabilities`
+   object from step 2). Use the same canonical names. Remove the old `depends`
+   field.
+4. **Declare new capabilities.** If your plugin defines any new capability,
+   add `ctx.defineCapability("<your-plugin-name>:<local.name>", { cardinality, description, schema? })`
+   inside `setup()`, and also add `"<your-plugin-name>:<local.name>"` to
+   `capabilities.provides`.
+5. **(Optional) Add aliases.** If you want ergonomic short names in your
+   `provides`/`consumes` arrays, add an `aliases` table mapping short → fully
+   qualified.
+6. **Typecheck.** Run `bun run typecheck`. Expect 0 errors.
+7. **Test.** Run `bun test`. Expect all tests pass.
+8. **List.** Run `kaizen capability list` and verify every capability your
+   plugin declares appears with the expected providers and consumers.
+9. **Show.** For each capability you defined yourself, run
+   `kaizen capability show <name>` and verify the cardinality, description,
+   and schema are correct.
+
+If steps 6–9 all pass, the migration is complete.

--- a/docs/superpowers/plans/2026-04-17-capability-registry.md
+++ b/docs/superpowers/plans/2026-04-17-capability-registry.md
@@ -1,0 +1,1269 @@
+# Capability Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `provides`/`depends` role system with an owner-qualified capability registry, enabling multi-provider UI and executor capabilities while keeping `lifecycle.drive` singleton. Resolves adversarial-review finding 1.
+
+**Architecture:** New `CapabilityRegistry` core module tracks capability definitions (with cardinality and schema) plus per-capability provider/consumer sets. `KaizenPlugin` gains a `capabilities: { provides, consumes }` field and an `aliases` field; `provides`/`depends` are removed. Topological sort consumes the capability graph. Existing `UiRegistry` and `ExecutorRegistry` are generalized to hold multiple providers. Lifecycle races input across all registered UI providers. A migration doc ships for the one external plugin author.
+
+**Tech Stack:** TypeScript, Bun, ajv (schema validation, already a dependency).
+
+**Scope note — divergence from spec:** The spec proposed a new `registerInputSource()` primitive; actual code already models UI as `UiProvider` with `accept(): AsyncIterable<UiChannel>`. This plan keeps `registerUi` but changes its cardinality from singleton to many and makes the lifecycle race `accept()` iterators across all registered providers. No new primitive required.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/core/capability-registry.ts` — registry class, cardinality + schema enforcement
+- `src/core/capability-registry.test.ts` — unit tests
+- `src/commands/capability.ts` — `kaizen capability list/show` CLI handlers
+- `docs/plugin-migration-capability-registry.md` — migration guide for plugin authors
+
+**Modified files:**
+- `src/types/plugin.ts` — `KaizenPlugin` interface: add `capabilities`, `aliases`, `CapabilitySpec`; remove `provides`, `depends`
+- `src/core/context.ts` — add `defineCapability` to `PluginContext`
+- `src/core/plugin-manager.ts` — replace role validation + topo sort with capability-based versions
+- `src/core/ui-registry.ts` — multi-provider semantics
+- `src/core/executor-registry.ts` — multi-provider semantics (first-registered wins, documented)
+- `src/core/index.ts` — export `CapabilityRegistry`, wire into bootstrap
+- `src/cli.ts` — add `capability` subcommand
+- `plugins/core-lifecycle/**` — define foundational capabilities, consume input from all UI providers, migrate manifest
+- `plugins/core-ui-terminal/**` — migrate manifest
+- `plugins/core-executor-anthropic/**` — migrate manifest
+- `plugins/core-executor-openai/**` — migrate manifest
+- `plugins/core-executor-debug/**` — migrate manifest
+- `plugins/core-executor-shell/**` — migrate manifest
+- `plugins/core-cli/**` — migrate manifest
+- `plugins/core-events/**` — migrate manifest
+- `plugins/core-plugin-manager/**` — migrate manifest
+- `plugins/kaizen-plugin-timestamps/**` — migrate manifest
+
+---
+
+## Phase 1 — Capability Registry Core
+
+### Task 1: Define capability types
+
+**Files:**
+- Modify: `src/types/plugin.ts`
+
+- [ ] **Step 1: Add capability-related types to `src/types/plugin.ts`**
+
+Append to `src/types/plugin.ts` (before the `KaizenPlugin` interface):
+
+```typescript
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+export type Cardinality = "one" | "many";
+
+export interface CapabilitySpec {
+  /** "one": exactly one provider required when consumed. "many": any count, including zero. */
+  cardinality: Cardinality;
+  /** Optional JSON schema validated against provider registrations. */
+  schema?: JsonSchema;
+  /** Optional semver string — future-proofing; currently informational only. */
+  version?: string;
+  /** Human-readable; shown by `kaizen capability show`. */
+  description: string;
+}
+
+export interface PluginCapabilities {
+  provides?: string[];
+  consumes?: string[];
+}
+```
+
+- [ ] **Step 2: Replace `provides`/`depends` on `KaizenPlugin`**
+
+In `src/types/plugin.ts`, replace the `KaizenPlugin` interface:
+
+```typescript
+export interface KaizenPlugin {
+  /** kebab-case. Must match the config namespace key in kaizen.json. */
+  name: string;
+
+  /** semver. Core warns if major != PLUGIN_API_VERSION. */
+  apiVersion: string;
+
+  /** What this plugin provides and consumes in the capability registry. */
+  capabilities?: PluginCapabilities;
+
+  /**
+   * Map short or alternative capability names to canonical owner-qualified names.
+   * Resolved when reading the `capabilities` lists above.
+   * e.g. { "ui.input": "core-lifecycle:ui.input" }
+   */
+  aliases?: Record<string, string>;
+
+  setup(ctx: PluginContext): Promise<void>;
+  start?(ctx: PluginContext): Promise<void>;
+}
+```
+
+Also remove `provides: string[]` from `PluginEntry` and replace with `capabilities: PluginCapabilities`:
+
+```typescript
+export interface PluginEntry {
+  name: string;
+  apiVersion: string;
+  capabilities: PluginCapabilities;
+  status: "loaded" | "unloaded" | "failed";
+}
+```
+
+- [ ] **Step 3: Bump `PLUGIN_API_VERSION` to `"2"`**
+
+In `src/types/plugin.ts`:
+
+```typescript
+export const PLUGIN_API_VERSION = "2";
+```
+
+This is a breaking manifest change; major bump is correct.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bun run typecheck`
+
+Expected: many errors — built-in plugins and plugin-manager reference removed fields. Do NOT fix yet; these are addressed in later tasks. Record the error count and move on. This step just establishes the baseline.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/plugin.ts
+git commit -m "feat(types): add capability types to plugin API; bump API version to 2"
+```
+
+### Task 2: CapabilityRegistry class (tests first)
+
+**Files:**
+- Create: `src/core/capability-registry.ts`
+- Test: `src/core/capability-registry.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/core/capability-registry.test.ts`:
+
+```typescript
+import { describe, test, expect } from "bun:test";
+import { CapabilityRegistry } from "./capability-registry.js";
+
+describe("CapabilityRegistry", () => {
+  test("define + getSpec round-trips", () => {
+    const r = new CapabilityRegistry();
+    r.define("core-lifecycle:ui.input", "core-lifecycle", {
+      cardinality: "many", description: "User input source"
+    });
+    const spec = r.getSpec("core-lifecycle:ui.input");
+    expect(spec?.cardinality).toBe("many");
+    expect(spec?.description).toBe("User input source");
+  });
+
+  test("owner prefix must match defining plugin", () => {
+    const r = new CapabilityRegistry();
+    expect(() => r.define("foo:bar", "not-foo", {
+      cardinality: "one", description: ""
+    })).toThrow(/must be prefixed with plugin name 'not-foo'/);
+  });
+
+  test("duplicate define logs and ignores second", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "one", description: "first" });
+    r.define("p:x", "p", { cardinality: "many", description: "second" });
+    expect(r.getSpec("p:x")?.description).toBe("first");
+  });
+
+  test("provider + consumer tracking", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "many", description: "" });
+    r.addProvider("p:x", "a");
+    r.addProvider("p:x", "b");
+    r.addConsumer("p:x", "c");
+    expect(r.providersOf("p:x")).toEqual(["a", "b"]);
+    expect(r.consumersOf("p:x")).toEqual(["c"]);
+  });
+
+  test("validateCardinality one: exactly one ok", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "one", description: "" });
+    r.addProvider("p:x", "a");
+    r.addConsumer("p:x", "c");
+    expect(() => r.validateAll()).not.toThrow();
+  });
+
+  test("validateCardinality one: zero providers throws if consumed", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "one", description: "" });
+    r.addConsumer("p:x", "c");
+    expect(() => r.validateAll()).toThrow(/No plugin provides/);
+  });
+
+  test("validateCardinality one: two providers throws", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "one", description: "" });
+    r.addProvider("p:x", "a");
+    r.addProvider("p:x", "b");
+    r.addConsumer("p:x", "c");
+    expect(() => r.validateAll()).toThrow(/Multiple plugins provide/);
+  });
+
+  test("validateCardinality many: zero/one/two all ok", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "many", description: "" });
+    r.addConsumer("p:x", "c");
+    expect(() => r.validateAll()).not.toThrow();
+    r.addProvider("p:x", "a");
+    expect(() => r.validateAll()).not.toThrow();
+    r.addProvider("p:x", "b");
+    expect(() => r.validateAll()).not.toThrow();
+  });
+
+  test("validateAll: undefined capability in consumer throws", () => {
+    const r = new CapabilityRegistry();
+    r.addConsumer("p:undefined", "c");
+    expect(() => r.validateAll()).toThrow(/undefined capability 'p:undefined'/);
+  });
+
+  test("validateAll: undefined capability in provider throws", () => {
+    const r = new CapabilityRegistry();
+    r.addProvider("p:undefined", "a");
+    expect(() => r.validateAll()).toThrow(/undefined capability 'p:undefined'/);
+  });
+
+  test("resolveName: canonical passes through", () => {
+    const r = new CapabilityRegistry();
+    expect(r.resolveName("core-lifecycle:ui.input", {})).toBe("core-lifecycle:ui.input");
+  });
+
+  test("resolveName: alias resolves", () => {
+    const r = new CapabilityRegistry();
+    const aliases = { "ui.input": "core-lifecycle:ui.input" };
+    expect(r.resolveName("ui.input", aliases)).toBe("core-lifecycle:ui.input");
+  });
+
+  test("list: returns all defined capabilities", () => {
+    const r = new CapabilityRegistry();
+    r.define("a:x", "a", { cardinality: "one", description: "X" });
+    r.define("b:y", "b", { cardinality: "many", description: "Y" });
+    const names = r.list().map((c) => c.name).sort();
+    expect(names).toEqual(["a:x", "b:y"]);
+  });
+
+  test("deregisterByPlugin removes defines/providers/consumers", () => {
+    const r = new CapabilityRegistry();
+    r.define("a:x", "a", { cardinality: "many", description: "" });
+    r.addProvider("a:x", "a");
+    r.addConsumer("a:x", "b");
+    r.deregisterByPlugin("a");
+    expect(r.getSpec("a:x")).toBeUndefined();
+    expect(r.providersOf("a:x")).toEqual([]);
+    r.deregisterByPlugin("b");
+    expect(r.consumersOf("a:x")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+Run: `bun test src/core/capability-registry.test.ts`
+
+Expected: all tests fail — module does not exist.
+
+- [ ] **Step 3: Implement `CapabilityRegistry`**
+
+Create `src/core/capability-registry.ts`:
+
+```typescript
+import type { CapabilitySpec } from "../types/plugin.js";
+import { warn } from "./errors.js";
+
+export interface CapabilityEntry {
+  name: string;
+  spec: CapabilitySpec;
+  definedBy: string;
+  providers: string[];
+  consumers: string[];
+}
+
+export class CapabilityRegistry {
+  private readonly entries = new Map<string, CapabilityEntry>();
+  private readonly providers = new Map<string, Set<string>>();
+  private readonly consumers = new Map<string, Set<string>>();
+
+  define(name: string, pluginName: string, spec: CapabilitySpec): void {
+    const colon = name.indexOf(":");
+    if (colon < 0 || name.slice(0, colon) !== pluginName) {
+      throw new Error(
+        `Capability '${name}' must be prefixed with plugin name '${pluginName}' ` +
+        `(e.g. '${pluginName}:...').`,
+      );
+    }
+    if (this.entries.has(name)) {
+      warn(`Capability '${name}' already defined. Ignoring duplicate from '${pluginName}'.`);
+      return;
+    }
+    this.entries.set(name, {
+      name, spec, definedBy: pluginName,
+      providers: [], consumers: [],
+    });
+  }
+
+  addProvider(name: string, pluginName: string): void {
+    const set = this.providers.get(name) ?? new Set<string>();
+    set.add(pluginName);
+    this.providers.set(name, set);
+  }
+
+  addConsumer(name: string, pluginName: string): void {
+    const set = this.consumers.get(name) ?? new Set<string>();
+    set.add(pluginName);
+    this.consumers.set(name, set);
+  }
+
+  providersOf(name: string): string[] {
+    return Array.from(this.providers.get(name) ?? []);
+  }
+
+  consumersOf(name: string): string[] {
+    return Array.from(this.consumers.get(name) ?? []);
+  }
+
+  getSpec(name: string): CapabilitySpec | undefined {
+    return this.entries.get(name)?.spec;
+  }
+
+  resolveName(name: string, aliases: Record<string, string>): string {
+    return aliases[name] ?? name;
+  }
+
+  list(): CapabilityEntry[] {
+    return Array.from(this.entries.values()).map((e) => ({
+      ...e,
+      providers: this.providersOf(e.name),
+      consumers: this.consumersOf(e.name),
+    }));
+  }
+
+  validateAll(): void {
+    // Detect undefined capabilities referenced by any plugin.
+    const referenced = new Set<string>([
+      ...this.providers.keys(),
+      ...this.consumers.keys(),
+    ]);
+    for (const name of referenced) {
+      if (!this.entries.has(name)) {
+        const where = this.providers.has(name) ? "provides" : "consumes";
+        const plugins = where === "provides"
+          ? this.providersOf(name) : this.consumersOf(name);
+        throw new Error(
+          `Plugin(s) [${plugins.join(", ")}] ${where} undefined capability '${name}'. ` +
+          `Typo, missing plugin dependency, or missing alias?`,
+        );
+      }
+    }
+
+    // Cardinality enforcement.
+    for (const entry of this.entries.values()) {
+      if (entry.spec.cardinality !== "one") continue;
+      const consumers = this.consumersOf(entry.name);
+      if (consumers.length === 0) continue;  // not consumed → no enforcement
+      const providers = this.providersOf(entry.name);
+      if (providers.length === 0) {
+        throw new Error(
+          `No plugin provides capability '${entry.name}' (consumed by: ${consumers.join(", ")}).`,
+        );
+      }
+      if (providers.length > 1) {
+        throw new Error(
+          `Multiple plugins provide capability '${entry.name}': ${providers.join(", ")}. Remove one.`,
+        );
+      }
+    }
+  }
+
+  deregisterByPlugin(pluginName: string): void {
+    for (const [name, entry] of this.entries) {
+      if (entry.definedBy === pluginName) this.entries.delete(name);
+    }
+    for (const [name, set] of this.providers) {
+      set.delete(pluginName);
+      if (set.size === 0) this.providers.delete(name);
+    }
+    for (const [name, set] of this.consumers) {
+      set.delete(pluginName);
+      if (set.size === 0) this.consumers.delete(name);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `bun test src/core/capability-registry.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/capability-registry.ts src/core/capability-registry.test.ts
+git commit -m "feat(core): add CapabilityRegistry with cardinality enforcement"
+```
+
+### Task 3: Wire CapabilityRegistry into PluginContext
+
+**Files:**
+- Modify: `src/types/plugin.ts`, `src/core/context.ts`, `src/core/plugin-manager.ts`, `src/core/index.ts`
+
+- [ ] **Step 1: Add `defineCapability` to `PluginContext`**
+
+In `src/types/plugin.ts`, add to the `PluginContext` interface (grouped with other registration methods):
+
+```typescript
+  // --- Capability registry (INITIALIZING state only) -----------------------
+  /** Declare a capability. Name must be prefixed with the calling plugin's name. */
+  defineCapability(name: string, spec: CapabilitySpec): void;
+```
+
+- [ ] **Step 2: Implement in `createPluginContext`**
+
+Modify `src/core/context.ts`:
+
+Add the `CapabilityRegistry` import and constructor parameter:
+
+```typescript
+import type { CapabilityRegistry } from "./capability-registry.js";
+```
+
+Add `capabilityRegistry: CapabilityRegistry` to the parameters of `createPluginContext` (placed alongside the other registries). Inside the returned object, add:
+
+```typescript
+    defineCapability(name, spec) {
+      assertInitializing(getState(), "define capabilities");
+      capabilityRegistry.define(name, pluginName, spec);
+    },
+```
+
+- [ ] **Step 3: Thread registry through `PluginManager`**
+
+Modify `src/core/plugin-manager.ts`:
+
+- Import `CapabilityRegistry`.
+- Add a `capabilityRegistry: CapabilityRegistry` constructor parameter (alongside the other registries).
+- Pass it through to `createPluginContext` in `setupPlugin()`.
+- Add `this.capabilityRegistry.deregisterByPlugin(name)` inside `unload()`, next to the other `deregisterByPlugin` calls.
+
+- [ ] **Step 4: Construct + expose in `src/core/index.ts`**
+
+In `src/core/index.ts`, instantiate `new CapabilityRegistry()` during bootstrap, wire it into `PluginManager`, and re-export it. (Read the file first to see the existing bootstrap pattern and match it; no structural changes needed beyond adding this registry next to the others.)
+
+- [ ] **Step 5: Run core tests**
+
+Run: `bun test src/core/`
+
+Expected: existing core tests still pass. Capability registry tests still pass. Manifest-level compile errors in built-ins are still present; that's expected — Task 4 addresses it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/plugin.ts src/core/context.ts src/core/plugin-manager.ts src/core/index.ts
+git commit -m "feat(core): thread CapabilityRegistry through PluginContext + PluginManager"
+```
+
+### Task 4: Migration-pass — switch PluginManager to capability-based orchestration
+
+**Files:**
+- Modify: `src/core/plugin-manager.ts`
+
+- [ ] **Step 1: Rewrite `topoSort` to use `consumes` graph**
+
+Replace the `topoSort` function in `plugin-manager.ts` with a version that sorts by `capabilities.consumes` rather than `depends`. Resolve aliases, build provider-of-capability map, then order consumers after providers.
+
+```typescript
+function resolveCapName(name: string, aliases: Record<string, string>): string {
+  return aliases[name] ?? name;
+}
+
+function topoSort(plugins: KaizenPlugin[]): KaizenPlugin[] {
+  const nameToPlugin = new Map(plugins.map((p) => [p.name, p]));
+
+  // Map canonical capability name → list of plugins that provide it.
+  const capToProviders = new Map<string, string[]>();
+  for (const p of plugins) {
+    const aliases = p.aliases ?? {};
+    for (const raw of p.capabilities?.provides ?? []) {
+      const cap = resolveCapName(raw, aliases);
+      const existing = capToProviders.get(cap) ?? [];
+      existing.push(p.name);
+      capToProviders.set(cap, existing);
+    }
+  }
+
+  const inDegree = new Map(plugins.map((p) => [p.name, 0]));
+  const edges = new Map<string, string[]>();
+
+  for (const p of plugins) {
+    const aliases = p.aliases ?? {};
+    const seen = new Set<string>();
+    for (const raw of p.capabilities?.consumes ?? []) {
+      const cap = resolveCapName(raw, aliases);
+      for (const providerName of capToProviders.get(cap) ?? []) {
+        if (providerName === p.name) continue;
+        if (seen.has(providerName)) continue;
+        seen.add(providerName);
+        const existing = edges.get(providerName) ?? [];
+        existing.push(p.name);
+        edges.set(providerName, existing);
+        inDegree.set(p.name, (inDegree.get(p.name) ?? 0) + 1);
+      }
+    }
+  }
+
+  const queue = plugins.filter((p) => (inDegree.get(p.name) ?? 0) === 0);
+  const sorted: KaizenPlugin[] = [];
+  while (queue.length > 0) {
+    const p = queue.shift()!;
+    sorted.push(p);
+    for (const dependent of edges.get(p.name) ?? []) {
+      const newDegree = (inDegree.get(dependent) ?? 0) - 1;
+      inDegree.set(dependent, newDegree);
+      if (newDegree === 0) {
+        const plugin = nameToPlugin.get(dependent);
+        if (plugin) queue.push(plugin);
+      }
+    }
+  }
+  if (sorted.length !== plugins.length) {
+    fatal("Cycle detected in plugin dependencies. Check your kaizen.json 'plugins' list.");
+  }
+  return sorted;
+}
+```
+
+- [ ] **Step 2: Rewrite `initialize()` to use capabilities**
+
+Replace the body of `initialize()` to:
+
+1. Resolve plugins (unchanged).
+2. Topo-sort (with the new `topoSort`).
+3. For each plugin in order:
+   - API version warn (unchanged).
+   - Before calling `setup()`: **pre-register** every `capabilities.provides` entry of this plugin with the `CapabilityRegistry` via `addProvider`, resolving aliases. This lets dependents see the provider even if `setup()` hasn't registered a runtime value yet.
+   - After `setup()` returns successfully: register every `capabilities.consumes` entry via `addConsumer`.
+   - Error handling rule: a plugin whose `capabilities.provides` includes any **singleton** capability that some other plugin consumes is "critical" — failure is fatal. Otherwise, log + continue.
+4. After all plugins are initialized, call `capabilityRegistry.validateAll()`. Failure → fatal.
+5. Warn on unclaimed config keys (unchanged).
+6. Resolve the lifecycle provider by looking up the sole provider of `core-lifecycle:lifecycle.drive`. If missing: fatal `"No lifecycle plugin found. Add one to kaizen.json."` If its `start()` is not a function: same fatal.
+
+Use a helper to determine "critical":
+
+```typescript
+function isCritical(plugin: KaizenPlugin, reg: CapabilityRegistry): boolean {
+  const aliases = plugin.aliases ?? {};
+  for (const raw of plugin.capabilities?.provides ?? []) {
+    const cap = resolveCapName(raw, aliases);
+    const spec = reg.getSpec(cap);
+    if (spec?.cardinality === "one" && reg.consumersOf(cap).length > 0) return true;
+  }
+  return false;
+}
+```
+
+Because critical detection depends on consumers being registered, run **two passes**: first pass registers all `provides` and `consumes` with no `setup()` calls (metadata-only), so the registry has a complete view. Second pass calls `setup()` in topo order. This ordering is the reason for splitting register-metadata and setup.
+
+Concrete structure:
+
+```typescript
+// Pass 1: register all metadata.
+for (const plugin of sorted) {
+  const aliases = plugin.aliases ?? {};
+  for (const raw of plugin.capabilities?.provides ?? []) {
+    this.capabilityRegistry.addProvider(resolveCapName(raw, aliases), plugin.name);
+  }
+  for (const raw of plugin.capabilities?.consumes ?? []) {
+    this.capabilityRegistry.addConsumer(resolveCapName(raw, aliases), plugin.name);
+  }
+}
+
+// Pass 2: call setup() per plugin in order.
+for (const plugin of sorted) { /* setup, error handling as above */ }
+
+// Pass 3: validate cardinalities.
+try { this.capabilityRegistry.validateAll(); }
+catch (err) { fatal(err instanceof Error ? err.message : String(err)); }
+```
+
+Also: in the existing `load()` method (hot-reload path), do the same metadata registration before calling `setupPlugin`, and the validation after.
+
+- [ ] **Step 3: Update `PluginEntry` population**
+
+Update both `initialize()` and `load()` to populate `entry.capabilities` (instead of `entry.provides`) from `plugin.capabilities ?? {}`. Match the new `PluginEntry` shape from Task 1.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bun run typecheck`
+
+Expected: `plugin-manager.ts` compiles. Built-in plugin packages still fail — they still use `provides`/`depends`. That's expected.
+
+- [ ] **Step 5: Run core tests**
+
+Run: `bun test src/core/`
+
+Expected: capability-registry tests pass; plugin-manager tests may fail because test fixtures use `provides`/`depends`. Task 5 fixes them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/plugin-manager.ts
+git commit -m "feat(core): plugin-manager orchestrates via CapabilityRegistry"
+```
+
+### Task 5: Update plugin-manager tests
+
+**Files:**
+- Modify: `src/core/plugin-manager.test.ts`
+
+- [ ] **Step 1: Read the existing test file**
+
+Open `src/core/plugin-manager.test.ts` and enumerate every use of `provides`/`depends` in fixture plugins. For each, plan the capability equivalent. Typical conversions:
+
+- A fixture plugin that uses `provides: ['lifecycle']` becomes a plugin that defines `core-lifecycle:lifecycle.drive` in `setup()` and declares `capabilities: { provides: ['core-lifecycle:lifecycle.drive'] }`. For test ergonomics, prefer fixtures that define and own their own capabilities (e.g. `test-plugin:foo`).
+- A fixture with `depends: ['lifecycle']` becomes `capabilities: { consumes: ['core-lifecycle:lifecycle.drive'] }`.
+
+- [ ] **Step 2: Add new tests for capability behavior**
+
+Add test cases covering:
+- Zero providers for a consumed singleton capability → fatal.
+- Two providers for a consumed singleton capability → fatal.
+- Zero providers for a consumed `many` capability → ok (no error).
+- Cycle in `consumes` graph → fatal.
+- Alias resolution in consumes (short name resolves to canonical provided by another plugin).
+- Owner-prefix mismatch in `defineCapability` → plugin fails critically when it provides a consumed singleton, else continues.
+
+- [ ] **Step 3: Update existing tests to capability-based fixtures**
+
+Rewrite every `provides`/`depends` fixture to use `capabilities: { ... }`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/plugin-manager.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-manager.test.ts
+git commit -m "test(core): migrate plugin-manager tests to capability fixtures"
+```
+
+---
+
+## Phase 2 — Multi-provider Registries
+
+### Task 6: UiRegistry supports multiple providers
+
+**Files:**
+- Modify: `src/core/ui-registry.ts`, `src/core/ui-registry.test.ts`, `src/types/plugin.ts`, `src/core/context.ts`
+
+- [ ] **Step 1: Update tests for multi-provider behavior**
+
+Edit `src/core/ui-registry.test.ts`:
+
+- Remove the "two registrations → fatal" test.
+- Add a test: two registrations → both are stored and returned by `list()` in registration order.
+- Add a test: `getFirst()` returns the first registered provider.
+- Add a test: `deregisterByPlugin` removes only the targeted plugin's provider.
+- Add a test: `isRegistered()` returns true when at least one is registered.
+
+- [ ] **Step 2: Run tests, expect failures**
+
+Run: `bun test src/core/ui-registry.test.ts`
+
+Expected: failures matching the new API surface.
+
+- [ ] **Step 3: Update implementation**
+
+Replace `src/core/ui-registry.ts` with:
+
+```typescript
+import type { UiProvider } from "../types/plugin.js";
+import { fatal } from "./errors.js";
+
+interface Entry { impl: UiProvider; pluginName: string; }
+
+export class UiRegistry {
+  private readonly entries: Entry[] = [];
+
+  register(impl: UiProvider, pluginName: string): void {
+    this.entries.push({ impl, pluginName });
+  }
+
+  /** All registered providers, in registration order. */
+  list(): UiProvider[] {
+    return this.entries.map((e) => e.impl);
+  }
+
+  /** First-registered provider, for back-compat with single-provider code paths. */
+  getFirst(): UiProvider {
+    if (this.entries.length === 0) fatal("No UI provider registered.");
+    return this.entries[0]!.impl;
+  }
+
+  isRegistered(): boolean { return this.entries.length > 0; }
+
+  deregisterByPlugin(pluginName: string): void {
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      if (this.entries[i]!.pluginName === pluginName) this.entries.splice(i, 1);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Update `PluginContext.runtime.ui` shape**
+
+In `src/types/plugin.ts`, change the shape of `runtime.ui`:
+
+```typescript
+    /** All registered UI providers, in registration order. */
+    ui: {
+      list(): UiProvider[];
+      getFirst(): UiProvider;
+    };
+```
+
+In `src/core/context.ts`, replace the `runtime.ui` getter with:
+
+```typescript
+      ui: {
+        list: () => uiRegistry.list(),
+        getFirst: () => uiRegistry.getFirst(),
+      },
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `bun test src/core/ui-registry.test.ts`
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/ui-registry.ts src/core/ui-registry.test.ts src/types/plugin.ts src/core/context.ts
+git commit -m "feat(core): UiRegistry supports multiple providers"
+```
+
+### Task 7: ExecutorRegistry supports multiple providers
+
+**Files:**
+- Modify: `src/core/executor-registry.ts`, `src/core/executor-registry.test.ts`, `src/types/plugin.ts`, `src/core/context.ts`
+
+- [ ] **Step 1: Update tests**
+
+Edit `src/core/executor-registry.test.ts` following the same pattern as Task 6:
+- Two registrations → both stored (no fatal).
+- `list()` returns providers in registration order.
+- `getFirst()` returns first provider, used by existing `runtime.executor` for back-compat.
+- `deregisterByPlugin` removes only the targeted plugin.
+
+- [ ] **Step 2: Run tests, expect failures.**
+
+Run: `bun test src/core/executor-registry.test.ts`
+
+- [ ] **Step 3: Update implementation**
+
+Replace `src/core/executor-registry.ts` with the analog of the new `UiRegistry` — store an array of `{ impl, pluginName }` entries, expose `list()`, `getFirst()`, `isRegistered()`, `deregisterByPlugin()`.
+
+- [ ] **Step 4: Update `PluginContext.runtime.executor` back-compat shim**
+
+In `src/types/plugin.ts`, leave `runtime.executor: Executor` as-is for now (first-wins semantics). Add a parallel `runtime.executors` shape:
+
+```typescript
+    /** All registered executors; routing mechanism deferred. */
+    executors: {
+      list(): Executor[];
+      getFirst(): Executor;
+    };
+    /** First-registered executor — preserved for back-compat. Deprecated once routing lands. */
+    executor: Executor;
+```
+
+In `src/core/context.ts`, replace the `runtime.executor` getter to call `executorRegistry.getFirst()` and add the new `runtime.executors` block.
+
+- [ ] **Step 5: Run tests**
+
+Run: `bun test src/core/executor-registry.test.ts`
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/executor-registry.ts src/core/executor-registry.test.ts src/types/plugin.ts src/core/context.ts
+git commit -m "feat(core): ExecutorRegistry supports multiple providers"
+```
+
+---
+
+## Phase 3 — Built-in Plugin Migrations
+
+> For each plugin: update the default export (`capabilities` replaces `provides`/`depends`, alias table added), and — where applicable — call `ctx.defineCapability` during `setup()`. Bump each plugin's `apiVersion` to `"2.0.0"`.
+
+### Task 8: Migrate core-lifecycle
+
+**Files:**
+- Modify: `plugins/core-lifecycle/src/index.ts` (or equivalent entry)
+- Modify: `plugins/core-lifecycle/package.json` — no version-field changes required beyond apiVersion inside the plugin export
+
+- [ ] **Step 1: Read the current `core-lifecycle` plugin**
+
+Read `plugins/core-lifecycle/src/index.ts` (or whichever file exports the default plugin). Identify the current `provides`/`depends` lists and any event definitions.
+
+- [ ] **Step 2: Update the plugin export**
+
+Change the plugin export to:
+
+```typescript
+import type { KaizenPlugin, CapabilitySpec } from "../../../src/types/plugin.js";
+// (or whatever the existing import path for plugin types is in this workspace)
+
+const UI_INPUT: CapabilitySpec = {
+  cardinality: "many",
+  description: "Provides user-input channels to the session loop.",
+};
+const UI_OUTPUT: CapabilitySpec = {
+  cardinality: "many",
+  description: "Renders session output to a destination.",
+};
+const LIFECYCLE_DRIVE: CapabilitySpec = {
+  cardinality: "one",
+  description: "Drives the session loop via start(ctx).",
+};
+const EXECUTOR_SEND: CapabilitySpec = {
+  cardinality: "many",
+  description: "Sends messages/tools to an executor backend.",
+};
+
+const plugin: KaizenPlugin = {
+  name: "core-lifecycle",
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["core-lifecycle:lifecycle.drive"],
+    consumes: [
+      "core-lifecycle:executor.send",
+      "core-lifecycle:ui.input",
+      "core-lifecycle:ui.output",
+    ],
+  },
+  async setup(ctx) {
+    ctx.defineCapability("core-lifecycle:lifecycle.drive", LIFECYCLE_DRIVE);
+    ctx.defineCapability("core-lifecycle:ui.input", UI_INPUT);
+    ctx.defineCapability("core-lifecycle:ui.output", UI_OUTPUT);
+    ctx.defineCapability("core-lifecycle:executor.send", EXECUTOR_SEND);
+    // ... existing event definitions
+  },
+  async start(ctx) {
+    // ... existing session loop, updated per Task 14
+  },
+};
+export default plugin;
+```
+
+Keep the existing event defineEvent/on/emit calls intact. Only replace the manifest fields and the new `defineCapability` calls.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run typecheck`
+
+Expected: this plugin's types compile. Other built-ins still have errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/core-lifecycle
+git commit -m "feat(core-lifecycle): migrate to capability registry; define foundational capabilities"
+```
+
+### Task 9: Migrate core-ui-terminal
+
+**Files:**
+- Modify: `plugins/core-ui-terminal/src/index.ts`
+
+- [ ] **Step 1: Read the current plugin**
+
+Enumerate current `provides`/`depends` and `registerUi` usage.
+
+- [ ] **Step 2: Update the manifest**
+
+```typescript
+const plugin: KaizenPlugin = {
+  name: "core-ui-terminal",
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["core-lifecycle:ui.input", "core-lifecycle:ui.output"],
+    consumes: [],
+  },
+  async setup(ctx) {
+    // existing registerUi() call stays unchanged
+    ctx.registerUi(terminalUiProvider);
+  },
+};
+export default plugin;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/core-ui-terminal
+git commit -m "feat(core-ui-terminal): migrate to capability registry"
+```
+
+### Task 10: Migrate core-executor-anthropic
+
+**Files:**
+- Modify: `plugins/core-executor-anthropic/src/index.ts`
+
+- [ ] **Step 1: Update the manifest**
+
+```typescript
+const plugin: KaizenPlugin = {
+  name: "core-executor-anthropic",
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["core-lifecycle:executor.send"],
+    consumes: [],
+  },
+  async setup(ctx) {
+    ctx.registerExecutor(anthropicExecutor);
+  },
+};
+export default plugin;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/core-executor-anthropic
+git commit -m "feat(core-executor-anthropic): migrate to capability registry"
+```
+
+### Task 11: Migrate core-executor-openai, core-executor-debug, core-executor-shell
+
+**Files:**
+- Modify: `plugins/core-executor-openai/src/index.ts`
+- Modify: `plugins/core-executor-debug/src/index.ts`
+- Modify: `plugins/core-executor-shell/src/index.ts`
+
+- [ ] **Step 1: Apply identical pattern to Task 10 to each plugin**
+
+Each: add `capabilities: { provides: ["core-lifecycle:executor.send"] }`. Keep existing `registerExecutor` call. Bump `apiVersion` to `"2.0.0"`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugins/core-executor-openai plugins/core-executor-debug plugins/core-executor-shell
+git commit -m "feat(executors): migrate openai/debug/shell to capability registry"
+```
+
+### Task 12: Migrate core-cli, core-events, core-plugin-manager, kaizen-plugin-timestamps
+
+**Files:**
+- Modify: `plugins/core-cli/src/index.ts`
+- Modify: `plugins/core-events/src/index.ts`
+- Modify: `plugins/core-plugin-manager/src/index.ts`
+- Modify: `plugins/kaizen-plugin-timestamps/src/index.ts`
+
+- [ ] **Step 1: Migrate each plugin's manifest**
+
+For each, inspect current `provides`/`depends`:
+- `core-cli` currently `depends: ['lifecycle']`. New: `capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] }`.
+- `core-events` defines event-payload types (reference-only). Current `provides`/`depends` likely empty. New: `capabilities: {}` (empty block).
+- `core-plugin-manager` registers tools for load/unload/reload. New: `capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] }` to ensure it initializes after lifecycle.
+- `kaizen-plugin-timestamps` hooks events. New: `capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] }`.
+
+Bump each `apiVersion` to `"2.0.0"`.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run typecheck`
+
+Expected: all built-in plugins compile. No more `provides`/`depends` references.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/core-cli plugins/core-events plugins/core-plugin-manager plugins/kaizen-plugin-timestamps
+git commit -m "feat(plugins): migrate remaining built-ins to capability registry"
+```
+
+---
+
+## Phase 4 — Multi-UI Lifecycle Support
+
+### Task 13: Lifecycle races input across all registered UI providers
+
+**Files:**
+- Modify: `plugins/core-lifecycle/src/index.ts` (or wherever the session loop lives)
+- Modify: `plugins/core-lifecycle/src/*.test.ts` or similar
+
+- [ ] **Step 1: Read the existing session loop**
+
+Locate the code that currently calls `ctx.runtime.ui.accept()` (or `ctx.runtime.ui.getFirst().accept()` after Task 6). Understand how channels are iterated and how input is read.
+
+- [ ] **Step 2: Write failing test for multi-UI input race**
+
+Create a test that registers two mock UI providers, each yielding one `UiChannel`. The first channel sends "hello from A", the second sends "hello from B" with a small delay. Run one session-loop turn. Assert: the first message received is "hello from A" (it arrived first), and the other channel receives the agent's response (output is broadcast).
+
+Target file: a new `plugins/core-lifecycle/src/multi-ui.test.ts` or add to existing test.
+
+Concrete test sketch (pseudo-code — adapt to existing test infra):
+
+```typescript
+test("lifecycle races input from multiple UI providers", async () => {
+  const a = new MockUiProvider([mockChannel("hello from A", 0)]);
+  const b = new MockUiProvider([mockChannel("hello from B", 50)]);
+  const ctx = buildTestContext({ uiProviders: [a, b] });
+  const turn = await runOneTurn(ctx);
+  expect(turn.firstUserMessage).toBe("hello from A");
+  expect(a.sent).toContainEqual({ type: "text", content: expect.any(String) });
+  expect(b.sent).toContainEqual({ type: "text", content: expect.any(String) });
+});
+```
+
+- [ ] **Step 3: Run test, expect failure**
+
+Run: `bun test plugins/core-lifecycle`
+
+Expected: fail — loop only consumes from `getFirst()`.
+
+- [ ] **Step 4: Update the session loop**
+
+Replace the single-provider consumption pattern with a cross-provider pattern:
+
+1. On session start, call `accept()` on every provider (`ctx.runtime.ui.list().map(p => p.accept())`). Merge channels as they appear. A simple pattern: for each provider, spawn a background task that pulls channels from its iterator and pushes them onto a shared `channels: UiChannel[]` array.
+2. When gathering input for a turn:
+   - Call `receive()` on every channel in parallel: `channels.map(c => c.receive().then(msg => ({ msg, channel: c })))`.
+   - Use `Promise.race` to get the first one. That's the driving input for this turn.
+   - Cancel or abandon the other pending `receive()` calls. (Simplest: leave them pending; next turn's race will pick up whatever arrives next, including the second user's message if still unread.)
+3. When sending output: call `send()` on every channel in parallel (`Promise.all(channels.map(c => c.send(msg)))`).
+4. If zero channels are present and the capability `core-lifecycle:ui.input` has no declared consumer (check via a new helper or via the presence of registered UI providers), run headlessly — no blocking receive.
+
+Write the implementation carefully; this is the core change of finding 1. Keep a single-turn driver function that takes the channel set and returns after one complete interaction (input → executor → tools → output), so tests can step through one turn at a time.
+
+- [ ] **Step 5: Run test, verify pass**
+
+Run: `bun test plugins/core-lifecycle`
+
+Expected: pass.
+
+- [ ] **Step 6: Run all tests**
+
+Run: `bun test`
+
+Expected: all tests pass. Existing single-UI tests still work because the race with one channel is a no-op.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugins/core-lifecycle
+git commit -m "feat(core-lifecycle): race input across all registered UI providers (finding 1)"
+```
+
+### Task 14: Integration test — two UIs driving one session
+
+**Files:**
+- Create: `plugins/core-lifecycle/src/two-ui-integration.test.ts` (or similar path)
+
+- [ ] **Step 1: Write integration test**
+
+Use two in-memory UI providers and an in-memory executor. Feed one input through UI-A, verify both UIs receive the agent response. Feed a second input through UI-B, verify first UI and second UI both receive the next response. This exercises the full race + broadcast.
+
+- [ ] **Step 2: Run, pass, commit**
+
+```bash
+bun test plugins/core-lifecycle/src/two-ui-integration.test.ts
+git add plugins/core-lifecycle
+git commit -m "test(core-lifecycle): integration test for two UIs driving one session"
+```
+
+---
+
+## Phase 5 — Introspection CLI
+
+### Task 15: `kaizen capability list/show` commands
+
+**Files:**
+- Create: `src/commands/capability.ts`
+- Modify: `src/cli.ts`
+
+- [ ] **Step 1: Read `src/cli.ts` to understand command dispatch**
+
+Identify how other subcommands (`run`, `init`, `plugin`) are wired.
+
+- [ ] **Step 2: Implement `capability.ts`**
+
+```typescript
+import type { CapabilityRegistry } from "../core/capability-registry.js";
+
+export function capabilityList(reg: CapabilityRegistry): void {
+  const entries = reg.list().sort((a, b) => a.name.localeCompare(b.name));
+  if (entries.length === 0) {
+    console.log("No capabilities defined.");
+    return;
+  }
+  for (const e of entries) {
+    console.log(`${e.name}  (${e.spec.cardinality})  — ${e.spec.description}`);
+    console.log(`    defined by: ${e.definedBy}`);
+    console.log(`    providers:  ${e.providers.join(", ") || "(none)"}`);
+    console.log(`    consumers:  ${e.consumers.join(", ") || "(none)"}`);
+  }
+}
+
+export function capabilityShow(reg: CapabilityRegistry, name: string): void {
+  const entry = reg.list().find((e) => e.name === name);
+  if (!entry) {
+    console.error(`Capability '${name}' not defined.`);
+    process.exit(1);
+  }
+  console.log(`Name:        ${entry.name}`);
+  console.log(`Cardinality: ${entry.spec.cardinality}`);
+  console.log(`Defined by:  ${entry.definedBy}`);
+  console.log(`Description: ${entry.spec.description}`);
+  if (entry.spec.version) console.log(`Version:     ${entry.spec.version}`);
+  console.log(`Providers:   ${entry.providers.join(", ") || "(none)"}`);
+  console.log(`Consumers:   ${entry.consumers.join(", ") || "(none)"}`);
+  if (entry.spec.schema) {
+    console.log("Schema:");
+    console.log(JSON.stringify(entry.spec.schema, null, 2));
+  }
+}
+```
+
+- [ ] **Step 3: Wire into `src/cli.ts`**
+
+Add a `capability` subcommand branching on `list` / `show <name>`. It must run the full plugin initialization path (so the registry is populated) and then invoke the command.
+
+- [ ] **Step 4: Manual verification**
+
+Run: `bun src/cli.ts capability list`
+
+Expected: prints all capabilities defined by built-ins (from `core-lifecycle`) plus any plugin-defined ones, with providers and consumers listed.
+
+Run: `bun src/cli.ts capability show core-lifecycle:ui.input`
+
+Expected: detailed view.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/capability.ts src/cli.ts
+git commit -m "feat(cli): add 'kaizen capability list' and 'kaizen capability show'"
+```
+
+---
+
+## Phase 6 — Migration Documentation
+
+### Task 16: Plugin migration guide
+
+**Files:**
+- Create: `docs/plugin-migration-capability-registry.md`
+
+- [ ] **Step 1: Write the migration guide**
+
+Create `docs/plugin-migration-capability-registry.md` with exactly these sections (no placeholders; each must contain working copy-pasteable content):
+
+1. **Overview** — what changed, why, who it affects.
+2. **Rename table** — side-by-side: `provides: ['ui']` → `capabilities: { provides: ['core-lifecycle:ui.input', 'core-lifecycle:ui.output'] }`, and equivalents for `'lifecycle'`, `'executor'`.
+3. **`depends` → `consumes` mapping** — for every built-in role a plugin might depend on today, give the canonical capability name.
+4. **Manifest before/after diff** — a realistic plugin showing the full transformation.
+5. **Third-party capability definition recipe** — how to define a new capability with `ctx.defineCapability(...)`, including an owner-qualified name example and a JSON schema example.
+6. **Alias declaration recipe** — when to add an `aliases` map and how consumers reference short names.
+7. **`UiProvider` authoring recipe** — if the plugin provides a UI, include a complete working `UiProvider` with a `UiChannel` backed by a mock queue, showing the shape agents must produce. (Input-racing is transparent — the plugin just provides a `UiProvider`; lifecycle handles multi-provider racing.)
+8. **Introspection** — how to run `kaizen capability list` and `kaizen capability show <name>` to verify migration.
+9. **Failure modes and fixes** — for each fatal message core now emits (`Capability 'X' must be prefixed ...`, `No plugin provides capability ...`, `Multiple plugins provide capability ...`, `Plugin(s) [...] consumes undefined capability ...`), show the cause and the exact diff.
+10. **Migration checklist** — an ordered checklist an agent can execute: (a) bump `apiVersion` to `2.0.0`; (b) replace `provides` with `capabilities.provides` using canonical names; (c) replace `depends` with `capabilities.consumes`; (d) if defining a new capability, add a `defineCapability` call and put the owner-qualified name in `capabilities.provides`; (e) run `bun run typecheck`; (f) run `bun test`; (g) run `kaizen capability show <your-capability>` to verify.
+
+Target audience is a coding agent doing a mechanical migration. Prioritize copy-pasteable snippets over prose. Keep the doc self-contained — do not assume the agent has read the spec or core source.
+
+- [ ] **Step 2: Manual review**
+
+Read through the doc. For each section, confirm: could an agent, starting from only this file + a pre-migration plugin, complete the migration? If any step requires information not in the doc, add it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/plugin-migration-capability-registry.md
+git commit -m "docs: plugin migration guide for capability registry"
+```
+
+---
+
+## Phase 7 — End-to-end Verification
+
+### Task 17: Full default-stack smoke test
+
+**Files:**
+- None (manual verification).
+
+- [ ] **Step 1: Run typecheck**
+
+Run: `bun run typecheck`
+
+Expected: zero errors across workspace.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `bun test`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run integration**
+
+Run: `bun run test:core`
+
+Expected: all integration tests pass.
+
+- [ ] **Step 4: Run default harness end-to-end**
+
+Run: `bun src/cli.ts --harness core-anthropic` (or `core-debug` if no API key locally).
+
+Expected: session opens, accepts input, LLM responds. No capability-related errors in output.
+
+- [ ] **Step 5: Run `kaizen capability list`**
+
+Run: `bun src/cli.ts capability list`
+
+Expected: lists `core-lifecycle:lifecycle.drive`, `core-lifecycle:ui.input`, `core-lifecycle:ui.output`, `core-lifecycle:executor.send`, with correct providers and consumers populated from the loaded built-ins.
+
+- [ ] **Step 6: Commit any final fixes and create checkpoint commit**
+
+```bash
+git commit --allow-empty -m "chore: capability registry — end-to-end verified"
+```
+
+---
+
+## Deferred Work (not in this plan)
+
+From the design spec, sections D1–D5:
+
+- **D1:** Install-time consent UX (blocked by plugin-installer redesign)
+- **D2:** Runtime sandboxing / enforcement (separate large effort)
+- **D3:** Multi-executor routing mechanism (cardinality opens up here, but routing is a follow-up design)
+- **D4:** Other adversarial-review findings (4–8, 10, 12–20)
+- **D5:** Parallel event handler execution
+
+---
+
+## Notes for the Implementing Engineer
+
+1. **Read the file before editing.** `plugin-manager.ts` has a hot-reload path (`load()`, `unload()`, `reload()`) that mirrors the startup path. Every change to registration/validation logic must be mirrored in both.
+2. **Run tests after every task.** The codebase has a `bun test` suite; use it as the regression guard.
+3. **Preserve back-compat shims** inside core (`runtime.executor`, `runtime.ui.getFirst()`) so that plugins migrating one at a time don't break the default stack mid-migration.
+4. **If a plugin's current `provides: ['ui']` implies both input and output**, split it into both canonical capabilities (`core-lifecycle:ui.input` AND `core-lifecycle:ui.output`). The terminal UI does both; a log-only web viewer would only declare `ui.output`.
+5. **If you find a built-in plugin declaring `depends: ['some-role-string']` that doesn't match one of the canonical capabilities documented above**, pause and raise a question rather than guessing — there may be a capability the spec didn't anticipate.

--- a/docs/superpowers/specs/2026-04-17-capability-registry-design.md
+++ b/docs/superpowers/specs/2026-04-17-capability-registry-design.md
@@ -1,0 +1,378 @@
+# Design: Capability Registry (Addresses Adversarial Review Finding 1)
+
+Date: 2026-04-17
+Status: DRAFT — awaiting user review
+Supersedes: N/A
+Related: `docs/adversarial-review.md` (findings 1, 2, 3)
+
+## Problem Statement
+
+The adversarial review identifies the exactly-one-provider-per-role constraint as
+fundamentally at odds with kaizen's "build anything" positioning:
+
+> Only one plugin may provide 'ui', one 'executor', one 'lifecycle'. You cannot run
+> web + terminal UIs simultaneously, route between two LLMs, or layer lifecycle
+> concerns. This is not a composable platform — it is a slot-filling system.
+
+The root cause is that `provides`/`depends` is a coarse role system with
+global singleton semantics. The three affected roles have different natural
+cardinalities:
+
+- `lifecycle` is structurally a singleton (one loop driver; two is chaos)
+- `ui` has a legitimate multi-provider use case (web + terminal mirroring a session)
+- `executor` has a legitimate multi-provider use case (routing, fallback, cost/quality tradeoffs)
+
+The role system also cannot express *what* a plugin extends — it only controls
+init ordering. Finding 3 in the review observes the same limitation from a
+security angle: roles provide zero access control and create a false impression
+of capability containment.
+
+## Scope
+
+### In Scope
+
+- Replace the `provides`/`depends` role system with a **capability registry**: plugins
+  declare what capabilities they provide and consume; core enforces per-capability
+  cardinality.
+- Migrate the three existing built-in roles (`lifecycle`, `ui`, `executor`) to
+  capabilities, splitting `ui` into `ui.input` and `ui.output`.
+- Add a new context primitive `registerInputSource()` so multiple UIs can drive
+  session input concurrently (resolves finding 1 for UI).
+- Change `executor` capability cardinality from singleton to many; defer the *routing
+  mechanism* decision (but unblock multi-provider at the registry level).
+- Capability declarations include a JSON schema describing the contract they expect
+  providers to fulfill or consumers to receive.
+- Owner-qualified capability names (`<defining-plugin>:<capability>`) with opt-in
+  aliases for ergonomics and fork compatibility.
+- Introspection CLI: `kaizen capability list` / `kaizen capability show <name>`.
+- TypeScript type exports from capability-defining plugins (same pattern as
+  `core-lifecycle` already uses for event payload types).
+
+### Explicitly Deferred (see "Deferred Work" section)
+
+- Install-time capability consent UX (requires plugin installer redesign).
+- Runtime enforcement / sandboxing (requires `worker_threads` or `vm` isolation;
+  separate large effort).
+- Multi-executor *routing mechanism* (cardinality opens up, but how lifecycle
+  picks among executors — explicit dispatch, policy plugin, round-robin,
+  fallback chain — is left to a follow-up design).
+- Fixes for findings 2, 4–20 in the adversarial review.
+
+## Premises
+
+1. Capability declaration is a product deliverable on its own. Even without runtime
+   enforcement or install-time consent, a declared capability contract is dramatically
+   better than "read the source" for third-party integration.
+2. Owner-qualified names piggyback on npm's existing global uniqueness — no governance
+   body, no reserved-prefix policing.
+3. Cardinality is a property of each capability, not a global rule. Role authors
+   decide.
+4. Input-driving is a capability (`registerInputSource`), not a side-effect of
+   hooking an event. This matches the existing pattern for `registerExecutor` and
+   `registerTool` — first-class primitives for first-class capabilities.
+
+## Design
+
+### Capability Registry
+
+Capabilities are named, typed extension points. Any plugin can define one; any
+plugin can provide or consume one.
+
+```typescript
+// During setup() (INITIALIZING state only):
+ctx.defineCapability(name: string, spec: CapabilitySpec): void;
+
+interface CapabilitySpec {
+  cardinality: 'one' | 'many';
+  // 'one': exactly one provider required when consumed. Zero or two → fatal.
+  // 'many': any number of providers, including zero (graceful no-op if none).
+
+  schema?: JsonSchema;
+  // Describes the shape of what providers register (for registry-shaped capabilities)
+  // or what consumers receive (for data-shaped capabilities). Optional — capabilities
+  // without a schema are opaque.
+
+  description: string;
+  // Human-readable. Shown by `kaizen capability show`.
+}
+```
+
+Capability names are **owner-qualified**: `<defining-plugin-name>:<capability-path>`.
+The defining plugin's `name` field must be the prefix. Core rejects definitions
+whose name does not match.
+
+Examples:
+- `core-lifecycle:lifecycle.drive`
+- `core-lifecycle:ui.input`
+- `core-lifecycle:ui.output`
+- `core-executor-anthropic:executor.send`
+- `kaizen-plugin-godot:project-inspector`
+
+### Plugin Manifest
+
+The `KaizenPlugin` interface gains two fields replacing `provides`/`depends`:
+
+```typescript
+interface KaizenPlugin {
+  name: string;
+  apiVersion: string;
+
+  capabilities?: {
+    provides?: string[];   // canonical or aliased capability names
+    consumes?: string[];   // canonical or aliased capability names
+  };
+
+  aliases?: Record<string, string>;
+  // Map short/alternative names to canonical. e.g.
+  //   { 'ui.input': 'core-lifecycle:ui.input' }
+  // Aliases resolve during load. A fork of core-lifecycle can declare
+  //   aliases: { 'core-lifecycle:ui.input': 'my-fork:ui.input' }
+  // for drop-in compatibility.
+
+  setup(ctx: PluginContext): Promise<void>;
+  start?(ctx: PluginContext): Promise<void>;
+}
+```
+
+The old `provides`/`depends` fields are removed. Migration is mechanical (see
+Migration section).
+
+### Cardinality Enforcement
+
+After all `setup()` calls complete, core validates:
+
+- For every capability in any plugin's `consumes`: the capability must be defined,
+  and the number of providers must match its declared cardinality.
+  - `cardinality: 'one'`: exactly one provider. Zero or two+ → fatal startup error.
+  - `cardinality: 'many'`: any count including zero (consumer must handle empty).
+- For every capability in any plugin's `provides`: the capability must be defined.
+  Undefined → fatal error (typo protection).
+- Providers' registered values are validated against the capability's `schema`
+  (via ajv) if one is declared. Validation failure → fatal error for singleton
+  capabilities, skip + warn for `many` capabilities.
+
+### Dependency Ordering
+
+Topological sort replaces `depends[]`-on-role with `consumes[]`-on-capability.
+A plugin that consumes `X` initializes after all plugins that provide `X`. Cycles
+produce a fatal error (same behavior as today).
+
+### New Primitive: `registerInputSource`
+
+Replaces the session-loop-event-return mechanism for UI input. Enables multiple
+concurrent input sources.
+
+```typescript
+interface InputSource {
+  next(): Promise<InputEvent>;
+  // Resolves when this source has input for the lifecycle. Called in a race
+  // against other sources. Should be cancellable — if another source wins,
+  // the loser's pending next() is abandoned.
+
+  cancel?(): void;
+  // Optional. Called by lifecycle when another source has won the race, to
+  // allow cleanup (e.g., stop reading stdin mid-read).
+}
+
+interface InputEvent {
+  type: 'continue' | 'yield' | 'end';
+  prompt?: string;
+  source: string;  // which plugin produced this input (for logging/audit)
+}
+
+// On PluginContext:
+ctx.registerInputSource(source: InputSource): void;
+```
+
+Providers of `core-lifecycle:ui.input` call `registerInputSource()` during
+`setup()`. The lifecycle loop does:
+
+```typescript
+const sources = ctx.runtime.inputSources;  // array of registered sources
+while (running) {
+  const event = await Promise.race(sources.map(s => s.next()));
+  sources.forEach(s => s.cancel?.());
+  // ... handle event
+}
+```
+
+If zero input sources are registered *and* no plugin consumes `ui.input` (headless
+mode), lifecycle proceeds without waiting — matches the autonomous Pattern B use
+case already documented in DESIGN.md.
+
+`response:before` and `response:after` events stay as-is. Multiple UIs rendering
+output concurrently is already supported through the existing serial-handler
+event bus — every UI gets a chance to render.
+
+### Multi-Provider Executor (Cardinality Only)
+
+`executor.send` / `executor.stream` cardinality changes from `one` to `many`.
+Multiple executor plugins may register. This plan stops there: **the routing
+mechanism is deferred** to a follow-up design.
+
+Until routing lands, the lifecycle's `ctx.runtime.executor` resolves to the first
+registered provider (documented behavior, stable for existing single-executor
+harnesses). Introducing a router in a later revision does not break existing
+single-provider setups.
+
+### Migration of Existing Built-in Roles
+
+| Today | After |
+|-------|-------|
+| `core-lifecycle` provides `lifecycle`, depends `['executor']` | Defines `core-lifecycle:lifecycle.drive` (one), `core-lifecycle:ui.input` (many), `core-lifecycle:ui.output` (many). Provides `lifecycle.drive`. Consumes `executor.send`. |
+| `core-ui-terminal` provides `ui` | Provides `core-lifecycle:ui.input` and `core-lifecycle:ui.output`. Calls `registerInputSource()` instead of hooking `session:loop` for input. |
+| `core-executor-anthropic` provides `executor`, calls `registerExecutor()` | Defines `core-executor-anthropic:executor.send` (many) — or imports a shared definition from a `core-executor-types` package if we choose to hoist it. Provides that capability. |
+| `core-cli` depends `['lifecycle']` | Consumes `core-lifecycle:lifecycle.drive`. |
+
+Open decision (to surface in planning): whether the `executor.send` capability
+should be defined by each executor plugin independently (natural under owner-qualified
+naming, but means every consumer needs aliases) or hoisted into a shared
+`core-executor-protocol` package. Leaning toward hoisted — this is a protocol
+that predates any specific executor.
+
+### Introspection CLI
+
+```
+kaizen capability list
+  # Prints all defined capabilities across loaded plugins:
+  #   core-lifecycle:lifecycle.drive  (one)   — drives the session loop
+  #   core-lifecycle:ui.input         (many)  — provides user input to the session
+  #   core-lifecycle:ui.output        (many)  — renders session output
+  #   core-executor-anthropic:executor.send (many) — sends messages to an LLM
+  #   ...
+
+kaizen capability show core-lifecycle:ui.input
+  # Prints: cardinality, description, schema, providers loaded,
+  # consumers loaded, aliases.
+```
+
+Implemented by a new `core-capability-cli` plugin (or folded into `core-cli`).
+Reads from the capability registry. No new core API required beyond exposing the
+registry to plugins for introspection (read-only).
+
+### Event Bus: Unchanged
+
+The event bus stays as-is. Capabilities are for *registered extension points*
+(things plugins call `register*()` for); events are for *notifications* (things
+plugins `emit()`). Both systems coexist. This design does not touch `defineEvent`,
+`on`, or `emit`.
+
+## Error Handling
+
+- Capability name with wrong owner prefix → fatal error at `defineCapability()`
+  call: `"Capability 'foo:bar' must be prefixed with plugin name 'baz'."`
+- Undefined capability in `consumes` → fatal: `"Plugin '<X>' consumes undefined
+  capability '<cap>'. Typo? Missing plugin dependency?"`
+- Cardinality violation for `one` capability → fatal with list of offenders.
+- Provider registers a value failing schema validation:
+  - For `one`: fatal.
+  - For `many`: warn + skip that provider's registration, continue.
+- Cycle in `consumes` graph → fatal (same as today's `depends` cycle).
+- Alias conflict (two plugins alias the same short name to different canonicals)
+  → warn; first wins.
+
+## Testing Strategy
+
+Unit:
+- Capability name validation (owner-prefix enforcement).
+- Cardinality enforcement (zero/one/many combinations for both `one` and `many`).
+- Schema validation paths (valid, invalid, missing schema).
+- Alias resolution, including the fork-compatibility case.
+- Topological sort using `consumes` graph.
+
+Integration:
+- Default stack still boots end-to-end after migration.
+- A second UI plugin (`core-ui-mock`) loads alongside `core-ui-terminal` and both
+  register input sources. Lifecycle races them correctly.
+- Headless lifecycle (no `ui.input` consumer, no input sources registered) runs
+  the autonomous Pattern B harness without hanging.
+- `kaizen capability list` / `show` output matches the loaded registry.
+
+Contract:
+- `kaizen-plugin-noop` continues to load without changes beyond the one-line
+  `provides`/`depends` → `capabilities` rename.
+
+## Success Criteria
+
+1. Two UI plugins (`core-ui-terminal` + a mock web UI) load simultaneously. Either
+   can submit a prompt; the session uses whichever submits first for each turn.
+   Zero changes to `core-lifecycle` or `core-executor-*` beyond the migration.
+2. Multiple `executor.send` providers load without a cardinality error. (Routing
+   not yet implemented — first-registered wins, documented.)
+3. A third-party plugin author can integrate with `acme-lifecycle` by reading
+   `kaizen capability show` output and the exported TypeScript types, without
+   reading `acme-lifecycle`'s source.
+4. `kaizen capability list` surfaces every capability across every loaded plugin.
+5. All existing tests pass after migration. The autonomous Pattern B harness runs
+   headlessly.
+
+## Deferred Work
+
+Captured here so the trail is clear for follow-up design sessions. None of these
+block this plan; all of them are unlocked or eased by it.
+
+### D1. Install-Time Consent UX (Layer 1 security model)
+
+Display a UAC-style prompt at plugin install time showing declared capabilities,
+sensitive consumes (fs, network, env, subprocess), and recording consent. Requires
+a broader plugin-installer redesign (version pinning, provenance, uninstall/update
+flows, consent persistence). The capability manifest declared by this plan is the
+input to that UX — data is already there, just not displayed or gated.
+
+**Partially addresses:** review findings 2, 3, 9.
+
+### D2. Runtime Enforcement / Sandboxing (Layer 2 security model)
+
+Actually prevent a plugin from reading `/etc/shadow` when it didn't declare
+`fs.read:/etc/**`. Requires `worker_threads`, a `vm` context, or SES. Substantial
+effort. The declared manifest from this plan becomes the enforcement policy.
+
+**Addresses:** review findings 2, 3, 4, 11 (partially).
+
+### D3. Multi-Executor Routing Mechanism
+
+Cardinality opens up in this plan, but how lifecycle selects among multiple
+registered executors (explicit dispatch by name, policy plugin, fallback chain,
+cost/quality routing) is a separate design. Options to explore:
+- `ctx.runtime.executors` as `Map<string, Executor>`; lifecycle dispatches by name
+  or configured policy.
+- A dedicated `executor-router` capability that wraps the multi-provider selection.
+- Per-tool-call routing metadata.
+
+### D4. Adversarial Review Findings Not Addressed
+
+This plan is scoped to finding 1 with foundations for 2/3. Other findings
+(4–8, 10, 12–20) are untouched. Explicit non-goals for this plan:
+- Namespace isolation for events (finding 13) — related, but a separate refactor.
+- Tool name namespacing (finding 6) — analogous solution (owner-qualified) could
+  apply in a future plan.
+- Harness extends-chain validation (finding 8).
+- apiVersion hard failure (finding 12).
+- Supply chain / version pinning (finding 9) — paired with D1.
+- README and developer SDK (findings 16, 18).
+
+### D5. Parallel Handler Execution
+
+Current event bus runs handlers serially. `response:before` rendering across
+multiple UIs works but is sequential. A follow-up could opt certain events into
+parallel handler execution. Not required by this plan.
+
+## Open Questions
+
+1. Should `executor.send` / `executor.stream` be defined by a shared
+   `core-executor-protocol` package, or independently per executor plugin with
+   aliases? Leaning shared. Decide during planning.
+2. Should `registerInputSource` support priority / fallback semantics (e.g., a
+   "backup" source used only when primary sources have been idle for N ms)? Out
+   of scope for MVP of this plan; easy to add later.
+3. Do we version capability schemas? A plugin declaring a capability today may
+   evolve the schema. Adding a `version` field to `CapabilitySpec` is cheap and
+   future-proof. Recommend yes; decide during planning.
+
+## Rollback
+
+The migration is additive up to the point of removing `provides`/`depends`. A
+phased rollout (capability system lives alongside roles for one version, roles
+deprecated with warning, roles removed) is possible but adds complexity. Given
+there are no third-party plugins in the ecosystem yet, a hard cutover is
+acceptable and is the recommended approach.

--- a/docs/superpowers/specs/2026-04-17-capability-registry-design.md
+++ b/docs/superpowers/specs/2026-04-17-capability-registry-design.md
@@ -47,6 +47,10 @@ of capability containment.
 - Introspection CLI: `kaizen capability list` / `kaizen capability show <name>`.
 - TypeScript type exports from capability-defining plugins (same pattern as
   `core-lifecycle` already uses for event payload types).
+- **Plugin migration guide** (`docs/plugin-migration-capability-registry.md`)
+  written for coding agents to mechanically migrate existing plugins from the
+  `provides`/`depends` role system to the capability system. See
+  "Plugin Migration Guide" section below for required contents.
 
 ### Explicitly Deferred (see "Deferred Work" section)
 
@@ -250,6 +254,41 @@ Implemented by a new `core-capability-cli` plugin (or folded into `core-cli`).
 Reads from the capability registry. No new core API required beyond exposing the
 registry to plugins for introspection (read-only).
 
+### Plugin Migration Guide
+
+A dedicated migration document (`docs/plugin-migration-capability-registry.md`)
+ships as part of this work. Context: there is currently one external plugin
+author building against kaizen. Their agents will use this doc to perform the
+migration mechanically, without reading core source or this spec.
+
+The migration doc must contain:
+
+1. **The rename table** — `provides: ['ui']` → `capabilities: { provides:
+   ['core-lifecycle:ui.input', 'core-lifecycle:ui.output'] }`, etc. Full
+   mapping for every built-in role, copy-pasteable.
+2. **`depends` → `consumes` mapping** for every built-in role, including
+   capability names the plugin must now reference.
+3. **Input-source migration recipe** — if the plugin hooked `session:loop` to
+   provide input: concrete before/after code snippets showing the shift to
+   `ctx.registerInputSource(source)`. Must include a complete working
+   `InputSource` implementation as a template.
+4. **Third-party capability definition recipe** — how a plugin defines its own
+   capabilities, including owner-qualified naming rules and an example.
+5. **Alias declaration recipe** — when to declare `aliases` (fork compatibility,
+   short-name ergonomics), with examples.
+6. **Introspection commands** — `kaizen capability list` and
+   `kaizen capability show` for verifying the migration succeeded.
+7. **Failure modes and fixes** — the exact fatal-error strings core emits
+   (unknown capability, cardinality violation, owner-prefix mismatch, schema
+   validation failure) and the diff needed to resolve each.
+8. **Migration checklist** — ordered steps an agent can execute end-to-end:
+   update manifest → rename fields → wire `registerInputSource` if applicable
+   → run tests → verify with introspection CLI.
+
+Acceptance criterion: a capable agent, given only the migration doc and a
+pre-migration plugin, can produce a working post-migration plugin without
+reading this spec or core source.
+
 ### Event Bus: Unchanged
 
 The event bus stays as-is. Capabilities are for *registered extension points*
@@ -305,6 +344,9 @@ Contract:
 4. `kaizen capability list` surfaces every capability across every loaded plugin.
 5. All existing tests pass after migration. The autonomous Pattern B harness runs
    headlessly.
+6. `docs/plugin-migration-capability-registry.md` is published. A capable coding
+   agent, given only that doc and a pre-migration plugin, produces a working
+   post-migration plugin with no access to this spec or core source.
 
 ## Deferred Work
 

--- a/plugins/core-cli/index.ts
+++ b/plugins/core-cli/index.ts
@@ -166,9 +166,8 @@ function createCliTool(
 
 const plugin: KaizenPlugin = {
   name: "core-cli",
-  apiVersion: "1.0.0",
-  provides: [],
-  depends: ["lifecycle"],
+  apiVersion: "2.0.0",
+  capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] },
 
   async setup(ctx) {
     const clis = (ctx.config["clis"] as string[] | undefined) ?? [];

--- a/plugins/core-events/index.ts
+++ b/plugins/core-events/index.ts
@@ -71,8 +71,15 @@ export const CoreEventsServiceToken = new ServiceToken<CoreEventsService>("CoreE
 const plugin: KaizenPlugin = {
   name: "core-events",
   apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["core-events:service"],
+  },
 
   async setup(ctx) {
+    ctx.defineCapability("core-events:service", {
+      cardinality: "one",
+      description: "CoreEventsService (event payload types + event-name constants).",
+    });
     for (const name of Object.values(EVENTS)) {
       ctx.defineEvent(name);
     }

--- a/plugins/core-events/index.ts
+++ b/plugins/core-events/index.ts
@@ -70,9 +70,7 @@ export const CoreEventsServiceToken = new ServiceToken<CoreEventsService>("CoreE
 
 const plugin: KaizenPlugin = {
   name: "core-events",
-  apiVersion: "1.0.0",
-  provides: ["events"],
-  depends: [],
+  apiVersion: "2.0.0",
 
   async setup(ctx) {
     for (const name of Object.values(EVENTS)) {

--- a/plugins/core-executor-anthropic/index.ts
+++ b/plugins/core-executor-anthropic/index.ts
@@ -3,9 +3,8 @@ import { createLLMRuntime } from "../../src/core/llm.js";
 
 const plugin: KaizenPlugin = {
   name: "core-executor-anthropic",
-  apiVersion: "1.0.0",
-  provides: ["executor"],
-  depends: [],
+  apiVersion: "2.0.0",
+  capabilities: { provides: ["core-lifecycle:executor.send"] },
 
   async setup(ctx) {
     const cfg = ctx.config as {

--- a/plugins/core-executor-debug/index.ts
+++ b/plugins/core-executor-debug/index.ts
@@ -119,9 +119,8 @@ async function promptForResponse(
 
 const plugin: KaizenPlugin = {
   name: "core-executor-debug",
-  apiVersion: "1.0.0",
-  provides: ["executor"],
-  depends: ["events"],
+  apiVersion: "2.0.0",
+  capabilities: { provides: ["core-lifecycle:executor.send"] },
 
   async setup(ctx) {
     const useColor = (ctx.config["color"] as boolean | undefined) ?? true;

--- a/plugins/core-executor-openai/index.ts
+++ b/plugins/core-executor-openai/index.ts
@@ -2,9 +2,8 @@ import type { KaizenPlugin } from "../../src/types/plugin.js";
 
 const plugin: KaizenPlugin = {
   name: "core-executor-openai",
-  apiVersion: "1.0.0",
-  provides: ["executor"],
-  depends: [],
+  apiVersion: "2.0.0",
+  capabilities: { provides: ["core-lifecycle:executor.send"] },
 
   async setup(_ctx) {
     throw new Error("core-executor-openai: not implemented");

--- a/plugins/core-executor-shell/index.ts
+++ b/plugins/core-executor-shell/index.ts
@@ -37,9 +37,8 @@ function runCommand(command: string, cwd: string, shell: string): string {
 
 const plugin: KaizenPlugin = {
   name: "core-executor-shell",
-  apiVersion: "1.0.0",
-  provides: ["executor"],
-  depends: [],
+  apiVersion: "2.0.0",
+  capabilities: { provides: ["core-lifecycle:executor.send"] },
 
   async setup(ctx) {
     const cwd = (ctx.config["cwd"] as string | undefined) ?? process.cwd();

--- a/plugins/core-lifecycle/index.ts
+++ b/plugins/core-lifecycle/index.ts
@@ -46,6 +46,7 @@ const plugin: KaizenPlugin = {
     // Accumulate channels from all providers. A provider's accept() may yield
     // lazily (terminal yields once; web could yield per-connection indefinitely).
     const activeChannels = new Set<UiChannel>();
+    const knownChannels = new Set<UiChannel>();
     let stopAccepting = false;
     let pumpsDone = false;
 
@@ -65,6 +66,7 @@ const plugin: KaizenPlugin = {
             break;
           }
           activeChannels.add(channel);
+          knownChannels.add(channel);
           notifyChannelAdded();
         }
       } catch (err) {
@@ -185,8 +187,9 @@ const plugin: KaizenPlugin = {
     } finally {
       stopAccepting = true;
       await ctx.emit(events.SESSION_END, { sessionId });
-      await Promise.all([...activeChannels].map((c) => c.close().catch(() => {})));
+      await Promise.all([...knownChannels].map((c) => c.close().catch(() => {})));
       activeChannels.clear();
+      knownChannels.clear();
       await pumpsSettled;
     }
   },

--- a/plugins/core-lifecycle/index.ts
+++ b/plugins/core-lifecycle/index.ts
@@ -1,67 +1,9 @@
 import { randomUUID } from "crypto";
-import type { KaizenPlugin, PluginContext, UiChannel, Message } from "../../src/types/plugin.js";
-import { CoreEventsServiceToken, type CoreEventsService, type UserMessageContext, type ResponseContext } from "../core-events/index.js";
+import type { KaizenPlugin, UiChannel, AgentMessage, Message } from "../../src/types/plugin.js";
+import { CoreEventsServiceToken, type UserMessageContext, type ResponseContext } from "../core-events/index.js";
 
-async function runSession(channel: UiChannel, ctx: PluginContext, events: CoreEventsService["events"]): Promise<void> {
-  const sessionId = randomUUID();
-  const history: Message[] = [];
-
-  const systemPrompt = ctx.config["systemPrompt"];
-  if (typeof systemPrompt === "string") {
-    history.push({ role: "system", content: systemPrompt });
-  }
-
-  await ctx.emit(events.SESSION_START, { sessionId, config: ctx.config });
-
-  try {
-    while (true) {
-      let userMsg;
-      try {
-        userMsg = await channel.receive();
-      } catch {
-        break;
-      }
-
-      const msgPayload: UserMessageContext = { sessionId, content: userMsg.content };
-      await ctx.emit(events.USER_MESSAGE, msgPayload);
-      history.push({ role: "user", content: msgPayload.content });
-
-      const tools = ctx.runtime.tools.list();
-      const response = await ctx.runtime.executor.send(history, tools);
-
-      const respPayload: ResponseContext = { sessionId, content: response.content };
-      if (response.content) {
-        await ctx.emit(events.AGENT_RESPONSE, respPayload);
-      }
-
-      history.push({
-        role: "assistant",
-        content: respPayload.content,
-        ...(response.tool_calls.length > 0 ? { tool_calls: response.tool_calls } : {}),
-      });
-
-      for (const tc of response.tool_calls) {
-        await ctx.emit(events.TOOL_BEFORE, { sessionId, tool: tc.name, args: tc.args });
-        await channel.send({ type: "tool_call", name: tc.name, args: tc.args });
-
-        const result = await ctx.runtime.tools.execute(tc.name, tc.args);
-        const output = result.error ?? result.output ?? JSON.stringify(result.data) ?? "";
-        history.push({ role: "tool", content: output, tool_call_id: tc.id });
-
-        await ctx.emit(events.TOOL_AFTER, { sessionId, tool: tc.name, ok: result.ok, output });
-        await channel.send({ type: "tool_result", name: tc.name, ok: result.ok, output });
-      }
-
-      if (response.content) {
-        await channel.send({ type: "text", content: respPayload.content + "\n" });
-      }
-
-      await ctx.runtime.pluginManager.drainPendingReloads();
-    }
-  } finally {
-    await ctx.emit(events.SESSION_END, { sessionId });
-    await channel.close();
-  }
+async function broadcast(channels: Iterable<UiChannel>, msg: AgentMessage): Promise<void> {
+  await Promise.all([...channels].map((c) => c.send(msg).catch(() => {})));
 }
 
 const plugin: KaizenPlugin = {
@@ -99,15 +41,147 @@ const plugin: KaizenPlugin = {
 
   async start(ctx) {
     const { events } = ctx.getService(CoreEventsServiceToken);
-    const sessions: Promise<void>[] = [];
-    for await (const channel of ctx.runtime.ui.getFirst().accept()) {
-      sessions.push(
-        runSession(channel, ctx, events).catch((err: unknown) => {
-          ctx.log(`session ${channel.id} error: ${err instanceof Error ? err.message : String(err)}`);
-        }),
-      );
+    const providers = ctx.runtime.ui.list();
+
+    // Accumulate channels from all providers. A provider's accept() may yield
+    // lazily (terminal yields once; web could yield per-connection indefinitely).
+    const activeChannels = new Set<UiChannel>();
+    let stopAccepting = false;
+    let pumpsDone = false;
+
+    // Resolvers waiting for channel-added / pump-drained signals.
+    let channelAddedResolvers: Array<() => void> = [];
+    const notifyChannelAdded = () => {
+      const rs = channelAddedResolvers;
+      channelAddedResolvers = [];
+      for (const r of rs) r();
+    };
+
+    const pumps: Promise<void>[] = providers.map(async (provider) => {
+      try {
+        for await (const channel of provider.accept()) {
+          if (stopAccepting) {
+            await channel.close().catch(() => {});
+            break;
+          }
+          activeChannels.add(channel);
+          notifyChannelAdded();
+        }
+      } catch (err) {
+        ctx.log(`ui provider pump error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+    const pumpsSettled = Promise.allSettled(pumps).then(() => {
+      pumpsDone = true;
+      notifyChannelAdded(); // unblock any waiter
+    });
+
+    const waitForChannelOrDrain = async (): Promise<void> => {
+      if (activeChannels.size > 0 || pumpsDone) return;
+      await new Promise<void>((resolve) => channelAddedResolvers.push(resolve));
+    };
+
+    // Give sync-yielding providers a chance to populate before deciding headless.
+    await Promise.resolve();
+    await waitForChannelOrDrain();
+
+    // Headless: no channels, all providers done — exit cleanly without a session.
+    if (activeChannels.size === 0 && pumpsDone) {
+      await pumpsSettled;
+      return;
     }
-    await Promise.all(sessions);
+
+    // Shared session state — ONE session driven by races across all channels.
+    const sessionId = randomUUID();
+    const history: Message[] = [];
+    const systemPrompt = ctx.config["systemPrompt"];
+    if (typeof systemPrompt === "string") {
+      history.push({ role: "system", content: systemPrompt });
+    }
+    await ctx.emit(events.SESSION_START, { sessionId, config: ctx.config });
+
+    try {
+      while (true) {
+        if (activeChannels.size === 0) {
+          if (pumpsDone) break;
+          await waitForChannelOrDrain();
+          continue;
+        }
+
+        // Race receives across all active channels.
+        // TODO: losers remain as orphaned pending promises on their channels'
+        // next message or close. Acceptable for phase 1 per plan (simplicity
+        // over premature cancellation); real channels consume on receive() so
+        // no message is lost — just a transient memory/resource footprint.
+        const receives = [...activeChannels].map((c) =>
+          c.receive().then(
+            (msg) => ({ kind: "msg" as const, msg, channel: c }),
+            (err: unknown) => ({ kind: "err" as const, err, channel: c }),
+          ),
+        );
+        // A late-arriving channel should re-drive the race without waiting on
+        // existing receives.
+        const newChannelSignal = new Promise<{ kind: "new" }>((resolve) => {
+          channelAddedResolvers.push(() => resolve({ kind: "new" }));
+        });
+
+        const first = await Promise.race<
+          | { kind: "msg"; msg: import("../../src/types/plugin.js").UserMessage; channel: UiChannel }
+          | { kind: "err"; err: unknown; channel: UiChannel }
+          | { kind: "new" }
+        >([...receives, newChannelSignal]);
+
+        if (first.kind === "new") continue;
+        if (first.kind === "err") {
+          activeChannels.delete(first.channel);
+          continue;
+        }
+
+        const userMsg = first.msg;
+        const msgPayload: UserMessageContext = { sessionId, content: userMsg.content };
+        await ctx.emit(events.USER_MESSAGE, msgPayload);
+        history.push({ role: "user", content: msgPayload.content });
+
+        const tools = ctx.runtime.tools.list();
+        const response = await ctx.runtime.executor.send(history, tools);
+
+        const respPayload: ResponseContext = { sessionId, content: response.content };
+        if (response.content) {
+          await ctx.emit(events.AGENT_RESPONSE, respPayload);
+        }
+
+        history.push({
+          role: "assistant",
+          content: respPayload.content,
+          ...(response.tool_calls.length > 0 ? { tool_calls: response.tool_calls } : {}),
+        });
+
+        for (const tc of response.tool_calls) {
+          await ctx.emit(events.TOOL_BEFORE, { sessionId, tool: tc.name, args: tc.args });
+          await broadcast(activeChannels, { type: "tool_call", name: tc.name, args: tc.args });
+
+          const result = await ctx.runtime.tools.execute(tc.name, tc.args);
+          const output = result.error ?? result.output ?? JSON.stringify(result.data) ?? "";
+          history.push({ role: "tool", content: output, tool_call_id: tc.id });
+
+          await ctx.emit(events.TOOL_AFTER, { sessionId, tool: tc.name, ok: result.ok, output });
+          await broadcast(activeChannels, { type: "tool_result", name: tc.name, ok: result.ok, output });
+        }
+
+        if (response.content) {
+          await broadcast(activeChannels, { type: "text", content: respPayload.content + "\n" });
+        }
+
+        await ctx.runtime.pluginManager.drainPendingReloads();
+      }
+    } finally {
+      stopAccepting = true;
+      await ctx.emit(events.SESSION_END, { sessionId });
+      await Promise.all([...activeChannels].map((c) => c.close().catch(() => {})));
+      activeChannels.clear();
+      await pumpsSettled;
+    }
   },
 };
 

--- a/plugins/core-lifecycle/index.ts
+++ b/plugins/core-lifecycle/index.ts
@@ -66,12 +66,34 @@ async function runSession(channel: UiChannel, ctx: PluginContext, events: CoreEv
 
 const plugin: KaizenPlugin = {
   name: "core-lifecycle",
-  apiVersion: "1.0.0",
-  provides: ["lifecycle"],
-  depends: ["events", "executor", "ui"],
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["core-lifecycle:lifecycle.drive"],
+    consumes: [
+      "core-lifecycle:executor.send",
+      "core-lifecycle:ui.input",
+      "core-lifecycle:ui.output",
+    ],
+  },
 
   async setup(ctx) {
-    ctx.getService(CoreEventsServiceToken); // validates CoreEventsService is available
+    ctx.defineCapability("core-lifecycle:lifecycle.drive", {
+      cardinality: "one",
+      description: "Drives the session loop via start(ctx).",
+    });
+    ctx.defineCapability("core-lifecycle:ui.input", {
+      cardinality: "many",
+      description: "Provides user-input channels to the session loop.",
+    });
+    ctx.defineCapability("core-lifecycle:ui.output", {
+      cardinality: "many",
+      description: "Renders session output to a destination.",
+    });
+    ctx.defineCapability("core-lifecycle:executor.send", {
+      cardinality: "many",
+      description: "Sends messages/tools to an executor backend.",
+    });
+    ctx.getService(CoreEventsServiceToken);
   },
 
   async start(ctx) {

--- a/plugins/core-lifecycle/index.ts
+++ b/plugins/core-lifecycle/index.ts
@@ -101,6 +101,25 @@ const plugin: KaizenPlugin = {
     }
     await ctx.emit(events.SESSION_START, { sessionId, config: ctx.config });
 
+    // Per-channel pending receive — we reuse the same promise across race
+    // iterations so receive() is called at most once per channel per yielded
+    // message. Prevents the "orphan receive consumes a future message" problem.
+    type RaceResult =
+      | { kind: "msg"; msg: import("../../src/types/plugin.js").UserMessage; channel: UiChannel }
+      | { kind: "err"; err: unknown; channel: UiChannel };
+    const pending = new Map<UiChannel, Promise<RaceResult>>();
+    const ensurePending = (c: UiChannel): Promise<RaceResult> => {
+      let p = pending.get(c);
+      if (!p) {
+        p = c.receive().then(
+          (msg) => ({ kind: "msg" as const, msg, channel: c }),
+          (err: unknown) => ({ kind: "err" as const, err, channel: c }),
+        );
+        pending.set(c, p);
+      }
+      return p;
+    };
+
     try {
       while (true) {
         if (activeChannels.size === 0) {
@@ -109,30 +128,18 @@ const plugin: KaizenPlugin = {
           continue;
         }
 
-        // Race receives across all active channels.
-        // TODO: losers remain as orphaned pending promises on their channels'
-        // next message or close. Acceptable for phase 1 per plan (simplicity
-        // over premature cancellation); real channels consume on receive() so
-        // no message is lost — just a transient memory/resource footprint.
-        const receives = [...activeChannels].map((c) =>
-          c.receive().then(
-            (msg) => ({ kind: "msg" as const, msg, channel: c }),
-            (err: unknown) => ({ kind: "err" as const, err, channel: c }),
-          ),
-        );
+        const receives = [...activeChannels].map((c) => ensurePending(c));
         // A late-arriving channel should re-drive the race without waiting on
         // existing receives.
         const newChannelSignal = new Promise<{ kind: "new" }>((resolve) => {
           channelAddedResolvers.push(() => resolve({ kind: "new" }));
         });
 
-        const first = await Promise.race<
-          | { kind: "msg"; msg: import("../../src/types/plugin.js").UserMessage; channel: UiChannel }
-          | { kind: "err"; err: unknown; channel: UiChannel }
-          | { kind: "new" }
-        >([...receives, newChannelSignal]);
+        const first = await Promise.race<RaceResult | { kind: "new" }>([...receives, newChannelSignal]);
 
         if (first.kind === "new") continue;
+        // Clear the settled pending entry so the next iteration re-issues receive().
+        pending.delete(first.channel);
         if (first.kind === "err") {
           activeChannels.delete(first.channel);
           continue;

--- a/plugins/core-lifecycle/index.ts
+++ b/plugins/core-lifecycle/index.ts
@@ -73,6 +73,7 @@ const plugin: KaizenPlugin = {
       "core-lifecycle:executor.send",
       "core-lifecycle:ui.input",
       "core-lifecycle:ui.output",
+      "core-events:service",
     ],
   },
 

--- a/plugins/core-lifecycle/index.ts
+++ b/plugins/core-lifecycle/index.ts
@@ -77,7 +77,7 @@ const plugin: KaizenPlugin = {
   async start(ctx) {
     const { events } = ctx.getService(CoreEventsServiceToken);
     const sessions: Promise<void>[] = [];
-    for await (const channel of ctx.runtime.ui.accept()) {
+    for await (const channel of ctx.runtime.ui.getFirst().accept()) {
       sessions.push(
         runSession(channel, ctx, events).catch((err: unknown) => {
           ctx.log(`session ${channel.id} error: ${err instanceof Error ? err.message : String(err)}`);

--- a/plugins/core-lifecycle/multi-ui.test.ts
+++ b/plugins/core-lifecycle/multi-ui.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  makeMockChannel,
+  makeMockUiProvider,
+  makeTestHarness,
+} from "./test-helpers.js";
+
+describe("core-lifecycle multi-UI race + broadcast", () => {
+  test(
+    "single user message on one channel triggers broadcast to all channels",
+    async () => {
+      const a = makeMockChannel("ui-a");
+      const b = makeMockChannel("ui-b");
+
+      const harness = await makeTestHarness({
+        uiProviderPlugins: [
+          makeMockUiProvider([a.channel], "mock-ui-a"),
+          makeMockUiProvider([b.channel], "mock-ui-b"),
+        ],
+      });
+
+      const runPromise = harness.run();
+
+      // Send from A; both A and B should receive the echo.
+      a.sendUserMessage("hello");
+
+      const msgA = await a.waitForSend(
+        (m) => m.type === "text" && m.content.startsWith("echo:hello"),
+      );
+      const msgB = await b.waitForSend(
+        (m) => m.type === "text" && m.content.startsWith("echo:hello"),
+      );
+
+      expect(msgA.type).toBe("text");
+      expect(msgB.type).toBe("text");
+
+      // Close both channels to exit the session loop.
+      a.close();
+      b.close();
+      await runPromise;
+    },
+    10_000,
+  );
+
+  test(
+    "zero channels returns cleanly (headless)",
+    async () => {
+      const harness = await makeTestHarness({
+        uiProviderPlugins: [makeMockUiProvider([], "mock-ui-empty")],
+      });
+      await harness.run();
+    },
+    10_000,
+  );
+});

--- a/plugins/core-lifecycle/test-helpers.ts
+++ b/plugins/core-lifecycle/test-helpers.ts
@@ -1,0 +1,232 @@
+import type {
+  UiChannel,
+  UiProvider,
+  UserMessage,
+  AgentMessage,
+  Executor,
+  KaizenPlugin,
+  KaizenConfig,
+  Message,
+  ToolDefinition,
+  LLMResponse,
+} from "../../src/types/plugin.js";
+import { PluginManager } from "../../src/core/plugin-manager.js";
+import { EventBus } from "../../src/core/event-bus.js";
+import { ToolRegistry } from "../../src/core/tool-registry.js";
+import { ExecutorRegistry } from "../../src/core/executor-registry.js";
+import { UiRegistry } from "../../src/core/ui-registry.js";
+import { CapabilityRegistry } from "../../src/core/capability-registry.js";
+import { ServiceRegistry } from "../../src/core/service-registry.js";
+import coreEvents from "../core-events/index.js";
+import coreLifecycle from "./index.js";
+
+export interface MockChannel {
+  channel: UiChannel;
+  sendUserMessage: (content: string) => void;
+  sent: AgentMessage[];
+  close: () => void;
+  waitForSend: (predicate: (msg: AgentMessage) => boolean, timeoutMs?: number) => Promise<AgentMessage>;
+}
+
+export function makeMockChannel(id: string): MockChannel {
+  const sent: AgentMessage[] = [];
+  const sendWaiters: Array<(msg: AgentMessage) => void> = [];
+  let pendingUserResolve: ((msg: UserMessage) => void) | null = null;
+  let pendingReject: ((err: Error) => void) | null = null;
+  const queue: UserMessage[] = [];
+  let closed = false;
+
+  const channel: UiChannel = {
+    id,
+    async receive() {
+      if (closed) throw new Error("closed");
+      if (queue.length > 0) return queue.shift()!;
+      return new Promise<UserMessage>((resolve, reject) => {
+        pendingUserResolve = resolve;
+        pendingReject = reject;
+      });
+    },
+    async send(msg) {
+      sent.push(msg);
+      const waiters = sendWaiters.splice(0, sendWaiters.length);
+      for (const w of waiters) w(msg);
+    },
+    async close() {
+      closed = true;
+      const reject = pendingReject;
+      pendingUserResolve = null;
+      pendingReject = null;
+      if (reject) reject(new Error("closed"));
+    },
+  };
+
+  return {
+    channel,
+    sent,
+    sendUserMessage(content) {
+      if (pendingUserResolve) {
+        const resolve = pendingUserResolve;
+        pendingUserResolve = null;
+        pendingReject = null;
+        resolve({ type: "text", content });
+      } else {
+        queue.push({ type: "text", content });
+      }
+    },
+    close() {
+      closed = true;
+      const reject = pendingReject;
+      pendingUserResolve = null;
+      pendingReject = null;
+      if (reject) reject(new Error("closed"));
+    },
+    async waitForSend(predicate, timeoutMs = 2000) {
+      // Check already-received messages first.
+      for (const m of sent) if (predicate(m)) return m;
+      return new Promise<AgentMessage>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error("waitForSend timeout"));
+        }, timeoutMs);
+        const check = (msg: AgentMessage) => {
+          if (predicate(msg)) {
+            clearTimeout(timer);
+            resolve(msg);
+          } else {
+            sendWaiters.push(check);
+          }
+        };
+        sendWaiters.push(check);
+      });
+    },
+  };
+}
+
+export function makeMockUiProvider(channels: UiChannel[], pluginName: string): KaizenPlugin {
+  const provider: UiProvider = {
+    async *accept() {
+      for (const c of channels) yield c;
+    },
+  };
+  return {
+    name: pluginName,
+    apiVersion: "2.0.0",
+    capabilities: {
+      provides: ["core-lifecycle:ui.input", "core-lifecycle:ui.output"],
+      consumes: [],
+    },
+    async setup(ctx) {
+      ctx.registerUi(provider);
+    },
+  };
+}
+
+export function makeEchoExecutorPlugin(pluginName = "mock-executor"): KaizenPlugin {
+  const executor: Executor = {
+    async send(messages: Message[], _tools: ToolDefinition[]): Promise<LLMResponse> {
+      const last = [...messages].reverse().find((m) => m.role === "user");
+      return {
+        content: `echo:${last?.content ?? ""}`,
+        tool_calls: [],
+        stop_reason: "end_turn",
+      };
+    },
+    async *stream() {
+      yield { type: "done" };
+    },
+  };
+  return {
+    name: pluginName,
+    apiVersion: "2.0.0",
+    capabilities: {
+      provides: ["core-lifecycle:executor.send"],
+      consumes: [],
+    },
+    async setup(ctx) {
+      ctx.registerExecutor(executor);
+    },
+  };
+}
+
+export interface TestHarness {
+  manager: PluginManager;
+  lifecycleProvider: KaizenPlugin;
+  lifecycleCtx: Parameters<NonNullable<KaizenPlugin["start"]>>[0];
+  run: () => Promise<void>;
+}
+
+export async function makeTestHarness(opts: {
+  uiProviderPlugins: KaizenPlugin[];
+  executorPlugin?: KaizenPlugin;
+  extraPlugins?: KaizenPlugin[];
+  systemPrompt?: string;
+}): Promise<TestHarness> {
+  const executorPlugin = opts.executorPlugin ?? makeEchoExecutorPlugin();
+  const extras = opts.extraPlugins ?? [];
+  const builtins: Record<string, KaizenPlugin> = {
+    "core-events": coreEvents,
+    "core-lifecycle": coreLifecycle,
+    [executorPlugin.name]: executorPlugin,
+  };
+  const pluginNames = ["core-events", executorPlugin.name];
+  for (const ui of opts.uiProviderPlugins) {
+    builtins[ui.name] = ui;
+    pluginNames.push(ui.name);
+  }
+  for (const extra of extras) {
+    builtins[extra.name] = extra;
+    pluginNames.push(extra.name);
+  }
+  pluginNames.push("core-lifecycle");
+
+  const config: KaizenConfig = {
+    plugins: pluginNames,
+    ...(opts.systemPrompt ? { "core-lifecycle": { systemPrompt: opts.systemPrompt } } : {}),
+  };
+
+  const eventBus = new EventBus();
+  const toolRegistry = new ToolRegistry();
+  const executorRegistry = new ExecutorRegistry();
+  const uiRegistry = new UiRegistry();
+  const capabilityRegistry = new CapabilityRegistry();
+  const serviceRegistry = new ServiceRegistry();
+
+  const manager = new PluginManager(
+    config,
+    builtins,
+    eventBus,
+    toolRegistry,
+    executorRegistry,
+    uiRegistry,
+    capabilityRegistry,
+    serviceRegistry,
+  );
+  const { lifecycleProvider } = await manager.initialize();
+
+  // Build a context for start() — use the same createPluginContext path plugin-manager uses.
+  const { createPluginContext } = await import("../../src/core/context.js");
+  const pluginConfig = (config[lifecycleProvider.name] as Record<string, unknown> | undefined) ?? {};
+  const ctx = createPluginContext(
+    lifecycleProvider.name,
+    pluginConfig,
+    eventBus,
+    toolRegistry,
+    executorRegistry,
+    uiRegistry,
+    capabilityRegistry,
+    serviceRegistry,
+    () => "READY",
+    manager.getPublicApi(),
+    manager.getLifecycleApi(),
+  );
+
+  return {
+    manager,
+    lifecycleProvider,
+    lifecycleCtx: ctx,
+    run: async () => {
+      if (lifecycleProvider.start) {
+        await lifecycleProvider.start(ctx);
+      }
+    },
+  };
+}

--- a/plugins/core-lifecycle/test-helpers.ts
+++ b/plugins/core-lifecycle/test-helpers.ts
@@ -31,19 +31,23 @@ export interface MockChannel {
 export function makeMockChannel(id: string): MockChannel {
   const sent: AgentMessage[] = [];
   const sendWaiters: Array<(msg: AgentMessage) => void> = [];
-  let pendingUserResolve: ((msg: UserMessage) => void) | null = null;
-  let pendingReject: ((err: Error) => void) | null = null;
-  const queue: UserMessage[] = [];
+  // FIFO queues — models a real channel where pending receive() calls line up
+  // and each produced message resolves exactly one. Prevents orphan promises
+  // from silently consuming messages.
+  const receiveWaiters: Array<{
+    resolve: (msg: UserMessage) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  const msgQueue: UserMessage[] = [];
   let closed = false;
 
   const channel: UiChannel = {
     id,
     async receive() {
       if (closed) throw new Error("closed");
-      if (queue.length > 0) return queue.shift()!;
+      if (msgQueue.length > 0) return msgQueue.shift()!;
       return new Promise<UserMessage>((resolve, reject) => {
-        pendingUserResolve = resolve;
-        pendingReject = reject;
+        receiveWaiters.push({ resolve, reject });
       });
     },
     async send(msg) {
@@ -53,10 +57,8 @@ export function makeMockChannel(id: string): MockChannel {
     },
     async close() {
       closed = true;
-      const reject = pendingReject;
-      pendingUserResolve = null;
-      pendingReject = null;
-      if (reject) reject(new Error("closed"));
+      const waiters = receiveWaiters.splice(0, receiveWaiters.length);
+      for (const w of waiters) w.reject(new Error("closed"));
     },
   };
 
@@ -64,21 +66,18 @@ export function makeMockChannel(id: string): MockChannel {
     channel,
     sent,
     sendUserMessage(content) {
-      if (pendingUserResolve) {
-        const resolve = pendingUserResolve;
-        pendingUserResolve = null;
-        pendingReject = null;
-        resolve({ type: "text", content });
+      const msg: UserMessage = { type: "text", content };
+      if (receiveWaiters.length > 0) {
+        const waiter = receiveWaiters.shift()!;
+        waiter.resolve(msg);
       } else {
-        queue.push({ type: "text", content });
+        msgQueue.push(msg);
       }
     },
     close() {
       closed = true;
-      const reject = pendingReject;
-      pendingUserResolve = null;
-      pendingReject = null;
-      if (reject) reject(new Error("closed"));
+      const waiters = receiveWaiters.splice(0, receiveWaiters.length);
+      for (const w of waiters) w.reject(new Error("closed"));
     },
     async waitForSend(predicate, timeoutMs = 2000) {
       // Check already-received messages first.

--- a/plugins/core-lifecycle/two-ui-integration.test.ts
+++ b/plugins/core-lifecycle/two-ui-integration.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage } from "../../src/types/plugin.js";
+import {
+  makeMockChannel,
+  makeMockUiProvider,
+  makeTestHarness,
+} from "./test-helpers.js";
+
+describe("two UIs driving one shared session (integration)", () => {
+  test(
+    "messages from either UI drive the shared session; output broadcasts to both",
+    async () => {
+      const a = makeMockChannel("ui-a");
+      const b = makeMockChannel("ui-b");
+
+      const harness = await makeTestHarness({
+        uiProviderPlugins: [
+          makeMockUiProvider([a.channel], "mock-ui-a"),
+          makeMockUiProvider([b.channel], "mock-ui-b"),
+        ],
+      });
+
+      const runPromise = harness.run();
+
+      // Turn 1 — input on channel A; both receive echo.
+      a.sendUserMessage("from-a");
+      const a1 = await a.waitForSend(
+        (m: AgentMessage) => m.type === "text" && m.content.startsWith("echo:from-a"),
+      );
+      const b1 = await b.waitForSend(
+        (m: AgentMessage) => m.type === "text" && m.content.startsWith("echo:from-a"),
+      );
+      expect(a1.type).toBe("text");
+      expect(b1.type).toBe("text");
+
+      // Turn 2 — input on channel B; both receive echo.
+      b.sendUserMessage("from-b");
+      const a2 = await a.waitForSend(
+        (m: AgentMessage) => m.type === "text" && m.content.startsWith("echo:from-b"),
+      );
+      const b2 = await b.waitForSend(
+        (m: AgentMessage) => m.type === "text" && m.content.startsWith("echo:from-b"),
+      );
+      expect(a2.type).toBe("text");
+      expect(b2.type).toBe("text");
+
+      // Terminate — close both channels.
+      a.close();
+      b.close();
+      await runPromise;
+
+      // Sanity: each channel saw BOTH echoes.
+      const aEchoes = a.sent.filter(
+        (m) => m.type === "text" && (m.content.startsWith("echo:from-a") || m.content.startsWith("echo:from-b")),
+      );
+      const bEchoes = b.sent.filter(
+        (m) => m.type === "text" && (m.content.startsWith("echo:from-a") || m.content.startsWith("echo:from-b")),
+      );
+      expect(aEchoes.length).toBe(2);
+      expect(bEchoes.length).toBe(2);
+    },
+    10_000,
+  );
+
+  test(
+    "closing one channel mid-session keeps session alive on the remaining channel",
+    async () => {
+      const a = makeMockChannel("ui-a");
+      const b = makeMockChannel("ui-b");
+
+      const harness = await makeTestHarness({
+        uiProviderPlugins: [
+          makeMockUiProvider([a.channel], "mock-ui-a"),
+          makeMockUiProvider([b.channel], "mock-ui-b"),
+        ],
+      });
+
+      const runPromise = harness.run();
+
+      a.sendUserMessage("first");
+      await a.waitForSend(
+        (m: AgentMessage) => m.type === "text" && m.content.startsWith("echo:first"),
+      );
+      await b.waitForSend(
+        (m: AgentMessage) => m.type === "text" && m.content.startsWith("echo:first"),
+      );
+
+      // Close A; session should continue via B.
+      a.close();
+
+      b.sendUserMessage("second");
+      const echoB = await b.waitForSend(
+        (m: AgentMessage) => m.type === "text" && m.content.startsWith("echo:second"),
+      );
+      expect(echoB.type).toBe("text");
+
+      b.close();
+      await runPromise;
+    },
+    10_000,
+  );
+});

--- a/plugins/core-plugin-manager/index.ts
+++ b/plugins/core-plugin-manager/index.ts
@@ -2,9 +2,8 @@ import type { KaizenPlugin } from "../../src/types/plugin.js";
 
 const plugin: KaizenPlugin = {
   name: "core-plugin-manager",
-  apiVersion: "1.0.0",
-  provides: [],
-  depends: [],
+  apiVersion: "2.0.0",
+  capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] },
 
   async setup(ctx) {
     ctx.registerTool({

--- a/plugins/core-ui-terminal/index.ts
+++ b/plugins/core-ui-terminal/index.ts
@@ -50,9 +50,8 @@ function createTerminalChannel(opts: {
 
 const plugin: KaizenPlugin = {
   name: "core-ui-terminal",
-  apiVersion: "1.0.0",
-  provides: ["ui"],
-  depends: [],
+  apiVersion: "2.0.0",
+  capabilities: { provides: ["core-lifecycle:ui.input", "core-lifecycle:ui.output"] },
 
   async setup(ctx) {
     const prompt = (ctx.config["prompt"] as string | undefined) ?? "> ";

--- a/plugins/kaizen-plugin-timestamps/index.ts
+++ b/plugins/kaizen-plugin-timestamps/index.ts
@@ -4,9 +4,8 @@ import type { UserMessageContext, ResponseContext } from "../core-events/index.j
 
 const plugin: KaizenPlugin = {
   name: "kaizen-plugin-timestamps",
-  apiVersion: "1.0.0",
-  provides: [],
-  depends: ["events"],
+  apiVersion: "2.0.0",
+  capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] },
 
   async setup(ctx) {
     ctx.on(EVENTS.USER_MESSAGE, async (payload) => {

--- a/scripts/test-core.ts
+++ b/scripts/test-core.ts
@@ -44,9 +44,10 @@ const results: Record<string, unknown> = {};
 
 const mockExecutorPlugin: KaizenPlugin = {
   name: "mock-executor",
-  apiVersion: "1.0.0",
-  provides: ["executor"],
-  depends: [],
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["core-lifecycle:executor.send"],
+  },
   async setup(ctx) {
     ctx.registerExecutor({
       async send(): Promise<LLMResponse> {
@@ -64,9 +65,10 @@ const mockExecutorPlugin: KaizenPlugin = {
 
 const mockUiPlugin: KaizenPlugin = {
   name: "mock-ui",
-  apiVersion: "1.0.0",
-  provides: ["ui"],
-  depends: [],
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["core-lifecycle:ui.input", "core-lifecycle:ui.output"],
+  },
   async setup(ctx) {
     const sentMessages: unknown[] = [];
     let receiveCount = 0;
@@ -101,9 +103,10 @@ const mockUiPlugin: KaizenPlugin = {
 
 const observerPlugin: KaizenPlugin = {
   name: "observer",
-  apiVersion: "1.0.0",
-  provides: [],
-  depends: ["events", "executor", "ui"],
+  apiVersion: "2.0.0",
+  capabilities: {
+    consumes: ["core-events:service"],
+  },
   async setup(ctx: PluginContext) {
     ctx.on(EVENTS.SESSION_START, async () => { results["event_session_start"] = true; });
     ctx.on(EVENTS.USER_MESSAGE, async (p) => { results["event_user_message"] = p; });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -205,6 +205,32 @@ if (subcommand === "plugin") {
 }
 
 // ---------------------------------------------------------------------------
+// Subcommand: kaizen capability list|show <name>
+// ---------------------------------------------------------------------------
+
+if (subcommand === "capability") {
+  const sub = rawArgs[1];
+  const { capabilityList, capabilityShow } = await import("./commands/capability.js");
+  const { initializePluginSystem } = await import("./core/index.js");
+  const cfg = resolveConfig({});
+  const { capabilityRegistry } = await initializePluginSystem(cfg, builtins);
+  if (sub === "list") {
+    capabilityList(capabilityRegistry);
+  } else if (sub === "show") {
+    const name = rawArgs[2];
+    if (!name) {
+      console.error("Usage: kaizen capability show <name>");
+      process.exit(1);
+    }
+    capabilityShow(capabilityRegistry, name);
+  } else {
+    console.error("Usage: kaizen capability list|show <name>");
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
 // Subcommand: kaizen run [prompt]  (also: kaizen [flags])
 // ---------------------------------------------------------------------------
 

--- a/src/commands/capability.ts
+++ b/src/commands/capability.ts
@@ -1,0 +1,34 @@
+import type { CapabilityRegistry } from "../core/capability-registry.js";
+
+export function capabilityList(reg: CapabilityRegistry): void {
+  const entries = reg.list().sort((a, b) => a.name.localeCompare(b.name));
+  if (entries.length === 0) {
+    console.log("No capabilities defined.");
+    return;
+  }
+  for (const e of entries) {
+    console.log(`${e.name}  (${e.spec.cardinality})  — ${e.spec.description}`);
+    console.log(`    defined by: ${e.definedBy}`);
+    console.log(`    providers:  ${e.providers.join(", ") || "(none)"}`);
+    console.log(`    consumers:  ${e.consumers.join(", ") || "(none)"}`);
+  }
+}
+
+export function capabilityShow(reg: CapabilityRegistry, name: string): void {
+  const entry = reg.list().find((e) => e.name === name);
+  if (!entry) {
+    console.error(`Capability '${name}' not defined.`);
+    process.exit(1);
+  }
+  console.log(`Name:        ${entry.name}`);
+  console.log(`Cardinality: ${entry.spec.cardinality}`);
+  console.log(`Defined by:  ${entry.definedBy}`);
+  console.log(`Description: ${entry.spec.description}`);
+  if (entry.spec.version) console.log(`Version:     ${entry.spec.version}`);
+  console.log(`Providers:   ${entry.providers.join(", ") || "(none)"}`);
+  console.log(`Consumers:   ${entry.consumers.join(", ") || "(none)"}`);
+  if (entry.spec.schema) {
+    console.log("Schema:");
+    console.log(JSON.stringify(entry.spec.schema, null, 2));
+  }
+}

--- a/src/core/capability-registry.test.ts
+++ b/src/core/capability-registry.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from "bun:test";
+import { CapabilityRegistry } from "./capability-registry.js";
+
+describe("CapabilityRegistry", () => {
+  test("define + getSpec round-trips", () => {
+    const r = new CapabilityRegistry();
+    r.define("core-lifecycle:ui.input", "core-lifecycle", {
+      cardinality: "many", description: "User input source"
+    });
+    const spec = r.getSpec("core-lifecycle:ui.input");
+    expect(spec?.cardinality).toBe("many");
+    expect(spec?.description).toBe("User input source");
+  });
+
+  test("owner prefix must match defining plugin", () => {
+    const r = new CapabilityRegistry();
+    expect(() => r.define("foo:bar", "not-foo", {
+      cardinality: "one", description: ""
+    })).toThrow(/must be prefixed with plugin name 'not-foo'/);
+  });
+
+  test("duplicate define logs and ignores second", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "one", description: "first" });
+    r.define("p:x", "p", { cardinality: "many", description: "second" });
+    expect(r.getSpec("p:x")?.description).toBe("first");
+  });
+
+  test("provider + consumer tracking", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "many", description: "" });
+    r.addProvider("p:x", "a");
+    r.addProvider("p:x", "b");
+    r.addConsumer("p:x", "c");
+    expect(r.providersOf("p:x")).toEqual(["a", "b"]);
+    expect(r.consumersOf("p:x")).toEqual(["c"]);
+  });
+
+  test("validateCardinality one: exactly one ok", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "one", description: "" });
+    r.addProvider("p:x", "a");
+    r.addConsumer("p:x", "c");
+    expect(() => r.validateAll()).not.toThrow();
+  });
+
+  test("validateCardinality one: zero providers throws if consumed", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "one", description: "" });
+    r.addConsumer("p:x", "c");
+    expect(() => r.validateAll()).toThrow(/No plugin provides/);
+  });
+
+  test("validateCardinality one: two providers throws", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "one", description: "" });
+    r.addProvider("p:x", "a");
+    r.addProvider("p:x", "b");
+    r.addConsumer("p:x", "c");
+    expect(() => r.validateAll()).toThrow(/Multiple plugins provide/);
+  });
+
+  test("validateCardinality many: zero/one/two all ok", () => {
+    const r = new CapabilityRegistry();
+    r.define("p:x", "p", { cardinality: "many", description: "" });
+    r.addConsumer("p:x", "c");
+    expect(() => r.validateAll()).not.toThrow();
+    r.addProvider("p:x", "a");
+    expect(() => r.validateAll()).not.toThrow();
+    r.addProvider("p:x", "b");
+    expect(() => r.validateAll()).not.toThrow();
+  });
+
+  test("validateAll: undefined capability in consumer throws", () => {
+    const r = new CapabilityRegistry();
+    r.addConsumer("p:undefined", "c");
+    expect(() => r.validateAll()).toThrow(/undefined capability 'p:undefined'/);
+  });
+
+  test("validateAll: undefined capability in provider throws", () => {
+    const r = new CapabilityRegistry();
+    r.addProvider("p:undefined", "a");
+    expect(() => r.validateAll()).toThrow(/undefined capability 'p:undefined'/);
+  });
+
+  test("resolveName: canonical passes through", () => {
+    const r = new CapabilityRegistry();
+    expect(r.resolveName("core-lifecycle:ui.input", {})).toBe("core-lifecycle:ui.input");
+  });
+
+  test("resolveName: alias resolves", () => {
+    const r = new CapabilityRegistry();
+    const aliases = { "ui.input": "core-lifecycle:ui.input" };
+    expect(r.resolveName("ui.input", aliases)).toBe("core-lifecycle:ui.input");
+  });
+
+  test("list: returns all defined capabilities", () => {
+    const r = new CapabilityRegistry();
+    r.define("a:x", "a", { cardinality: "one", description: "X" });
+    r.define("b:y", "b", { cardinality: "many", description: "Y" });
+    const names = r.list().map((c) => c.name).sort();
+    expect(names).toEqual(["a:x", "b:y"]);
+  });
+
+  test("deregisterByPlugin removes defines/providers/consumers", () => {
+    const r = new CapabilityRegistry();
+    r.define("a:x", "a", { cardinality: "many", description: "" });
+    r.addProvider("a:x", "a");
+    r.addConsumer("a:x", "b");
+    r.deregisterByPlugin("a");
+    expect(r.getSpec("a:x")).toBeUndefined();
+    expect(r.providersOf("a:x")).toEqual([]);
+    r.deregisterByPlugin("b");
+    expect(r.consumersOf("a:x")).toEqual([]);
+  });
+});

--- a/src/core/capability-registry.ts
+++ b/src/core/capability-registry.ts
@@ -1,0 +1,119 @@
+import type { CapabilitySpec } from "../types/plugin.js";
+import { warn } from "./errors.js";
+
+export interface CapabilityEntry {
+  name: string;
+  spec: CapabilitySpec;
+  definedBy: string;
+  providers: string[];
+  consumers: string[];
+}
+
+export class CapabilityRegistry {
+  private readonly entries = new Map<string, CapabilityEntry>();
+  private readonly providers = new Map<string, Set<string>>();
+  private readonly consumers = new Map<string, Set<string>>();
+
+  define(name: string, pluginName: string, spec: CapabilitySpec): void {
+    const colon = name.indexOf(":");
+    if (colon < 0 || name.slice(0, colon) !== pluginName) {
+      throw new Error(
+        `Capability '${name}' must be prefixed with plugin name '${pluginName}' ` +
+        `(e.g. '${pluginName}:...').`,
+      );
+    }
+    if (this.entries.has(name)) {
+      warn(`Capability '${name}' already defined. Ignoring duplicate from '${pluginName}'.`);
+      return;
+    }
+    this.entries.set(name, {
+      name, spec, definedBy: pluginName,
+      providers: [], consumers: [],
+    });
+  }
+
+  addProvider(name: string, pluginName: string): void {
+    const set = this.providers.get(name) ?? new Set<string>();
+    set.add(pluginName);
+    this.providers.set(name, set);
+  }
+
+  addConsumer(name: string, pluginName: string): void {
+    const set = this.consumers.get(name) ?? new Set<string>();
+    set.add(pluginName);
+    this.consumers.set(name, set);
+  }
+
+  providersOf(name: string): string[] {
+    return Array.from(this.providers.get(name) ?? []);
+  }
+
+  consumersOf(name: string): string[] {
+    return Array.from(this.consumers.get(name) ?? []);
+  }
+
+  getSpec(name: string): CapabilitySpec | undefined {
+    return this.entries.get(name)?.spec;
+  }
+
+  resolveName(name: string, aliases: Record<string, string>): string {
+    return aliases[name] ?? name;
+  }
+
+  list(): CapabilityEntry[] {
+    return Array.from(this.entries.values()).map((e) => ({
+      ...e,
+      providers: this.providersOf(e.name),
+      consumers: this.consumersOf(e.name),
+    }));
+  }
+
+  validateAll(): void {
+    const referenced = new Set<string>([
+      ...this.providers.keys(),
+      ...this.consumers.keys(),
+    ]);
+    for (const name of referenced) {
+      if (!this.entries.has(name)) {
+        const where = this.providers.has(name) ? "provides" : "consumes";
+        const plugins = where === "provides"
+          ? this.providersOf(name) : this.consumersOf(name);
+        throw new Error(
+          `Plugin(s) [${plugins.join(", ")}] ${where} undefined capability '${name}'. ` +
+          `Typo, missing plugin dependency, or missing alias?`,
+        );
+      }
+    }
+
+    for (const entry of this.entries.values()) {
+      if (entry.spec.cardinality !== "one") continue;
+      const consumers = this.consumersOf(entry.name);
+      if (consumers.length === 0) continue;
+      const providers = this.providersOf(entry.name);
+      if (providers.length === 0) {
+        throw new Error(
+          `No plugin provides capability '${entry.name}' (consumed by: ${consumers.join(", ")}).`,
+        );
+      }
+      if (providers.length > 1) {
+        throw new Error(
+          `Multiple plugins provide capability '${entry.name}': ${providers.join(", ")}. Remove one.`,
+        );
+      }
+    }
+  }
+
+  deregisterByPlugin(pluginName: string): void {
+    for (const [name, entry] of this.entries) {
+      if (entry.definedBy === pluginName) this.entries.delete(name);
+    }
+    for (const [name, set] of this.providers) {
+      set.delete(pluginName);
+      if (set.size === 0) this.providers.delete(name);
+    }
+    for (const [name, set] of this.consumers) {
+      set.delete(pluginName);
+      if (set.size === 0) this.consumers.delete(name);
+    }
+  }
+}

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -5,6 +5,7 @@ import type { ToolRegistry } from "./tool-registry.js";
 import type { ExecutorRegistry } from "./executor-registry.js";
 import type { UiRegistry } from "./ui-registry.js";
 import type { ServiceRegistry } from "./service-registry.js";
+import type { CapabilityRegistry } from "./capability-registry.js";
 
 export type CoreState = "INITIALIZING" | "READY" | "RUNNING" | "CLOSED";
 
@@ -21,6 +22,7 @@ export function createPluginContext(
   toolRegistry: ToolRegistry,
   executorRegistry: ExecutorRegistry,
   uiRegistry: UiRegistry,
+  capabilityRegistry: CapabilityRegistry,
   serviceRegistry: ServiceRegistry,
   getState: () => CoreState,
   pluginManagerPublicApi: PluginManagerPublicApi,
@@ -57,6 +59,11 @@ export function createPluginContext(
     registerUi(impl) {
       assertInitializing(getState(), "register UI provider");
       uiRegistry.register(impl, pluginName);
+    },
+
+    defineCapability(name, spec) {
+      assertInitializing(getState(), "define capabilities");
+      capabilityRegistry.define(name, pluginName, spec);
     },
 
     defineEvent(name: string): void {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -82,7 +82,11 @@ export function createPluginContext(
 
     runtime: {
       get executor() {
-        return executorRegistry.get();
+        return executorRegistry.getFirst();
+      },
+      executors: {
+        list: () => executorRegistry.list(),
+        getFirst: () => executorRegistry.getFirst(),
       },
       ui: {
         list: () => uiRegistry.list(),

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -84,8 +84,9 @@ export function createPluginContext(
       get executor() {
         return executorRegistry.get();
       },
-      get ui() {
-        return uiRegistry.get();
+      ui: {
+        list: () => uiRegistry.list(),
+        getFirst: () => uiRegistry.getFirst(),
       },
       tools: {
         list() {

--- a/src/core/executor-registry.test.ts
+++ b/src/core/executor-registry.test.ts
@@ -2,30 +2,59 @@ import { describe, expect, test } from "bun:test";
 import { ExecutorRegistry } from "./executor-registry.js";
 import type { Executor } from "../types/plugin.js";
 
-const stubExecutor: Executor = {
-  send: async () => ({ content: "", tool_calls: [], stop_reason: "end_turn" }),
-  stream: async function* () { yield { type: "done" }; },
-};
+function stub(): Executor {
+  return {
+    send: async () => ({ content: "", tool_calls: [], stop_reason: "end_turn" }),
+    stream: async function* () { yield { type: "done" }; },
+  };
+}
 
-describe("ExecutorRegistry.deregisterByPlugin", () => {
-  test("removes executor registered by named plugin", () => {
-    const registry = new ExecutorRegistry();
-    registry.register(stubExecutor, "plugin-exec");
-    registry.deregisterByPlugin("plugin-exec");
-    expect(registry.isRegistered()).toBe(false);
+describe("ExecutorRegistry multi-provider", () => {
+  test("two registrations: both stored in registration order", () => {
+    const r = new ExecutorRegistry();
+    const a = stub(), b = stub();
+    r.register(a, "a"); r.register(b, "b");
+    expect(r.list()).toEqual([a, b]);
   });
 
-  test("no-op when plugin name does not match", () => {
-    const registry = new ExecutorRegistry();
-    registry.register(stubExecutor, "plugin-exec");
-    registry.deregisterByPlugin("plugin-other");
-    expect(registry.isRegistered()).toBe(true);
+  test("getFirst returns first registered", () => {
+    const r = new ExecutorRegistry();
+    const a = stub(), b = stub();
+    r.register(a, "a"); r.register(b, "b");
+    expect(r.getFirst()).toBe(a);
   });
 
-  test("deregistered executor slot can be re-registered", () => {
-    const registry = new ExecutorRegistry();
-    registry.register(stubExecutor, "plugin-exec");
-    registry.deregisterByPlugin("plugin-exec");
-    expect(() => registry.register(stubExecutor, "plugin-exec")).not.toThrow();
+  test("getFirst fatal when none registered", () => {
+    const r = new ExecutorRegistry();
+    expect(() => r.getFirst()).toThrow();
+  });
+
+  test("isRegistered true when at least one", () => {
+    const r = new ExecutorRegistry();
+    expect(r.isRegistered()).toBe(false);
+    r.register(stub(), "a");
+    expect(r.isRegistered()).toBe(true);
+  });
+
+  test("deregisterByPlugin removes only the targeted plugin's executor", () => {
+    const r = new ExecutorRegistry();
+    const a = stub(), b = stub();
+    r.register(a, "a"); r.register(b, "b");
+    r.deregisterByPlugin("a");
+    expect(r.list()).toEqual([b]);
+  });
+
+  test("deregisterByPlugin no-op when name does not match", () => {
+    const r = new ExecutorRegistry();
+    r.register(stub(), "a");
+    r.deregisterByPlugin("other");
+    expect(r.isRegistered()).toBe(true);
+  });
+
+  test("deregistered slot can be re-registered", () => {
+    const r = new ExecutorRegistry();
+    r.register(stub(), "a");
+    r.deregisterByPlugin("a");
+    expect(() => r.register(stub(), "a")).not.toThrow();
   });
 });

--- a/src/core/executor-registry.ts
+++ b/src/core/executor-registry.ts
@@ -1,29 +1,29 @@
 import type { Executor } from "../types/plugin.js";
 import { fatal } from "./errors.js";
 
+interface Entry { impl: Executor; pluginName: string; }
+
 export class ExecutorRegistry {
-  private impl: Executor | null = null;
-  private registeredBy: string | null = null;
+  private readonly entries: Entry[] = [];
 
   register(impl: Executor, pluginName: string): void {
-    if (this.impl !== null) {
-      fatal(`Two plugins registered an executor: '${this.registeredBy}' and '${pluginName}'. Remove one.`);
-    }
-    this.impl = impl;
-    this.registeredBy = pluginName;
+    this.entries.push({ impl, pluginName });
   }
 
-  get(): Executor {
-    if (!this.impl) fatal("No executor registered. Add an executor plugin to kaizen.json.");
-    return this.impl;
+  list(): Executor[] {
+    return this.entries.map((e) => e.impl);
   }
 
-  isRegistered(): boolean { return this.impl !== null; }
+  getFirst(): Executor {
+    if (this.entries.length === 0) fatal("No executor registered.");
+    return this.entries[0]!.impl;
+  }
+
+  isRegistered(): boolean { return this.entries.length > 0; }
 
   deregisterByPlugin(pluginName: string): void {
-    if (this.registeredBy === pluginName) {
-      this.impl = null;
-      this.registeredBy = null;
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      if (this.entries[i]!.pluginName === pluginName) this.entries.splice(i, 1);
     }
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,15 +9,27 @@ import { PluginManager, type Builtins } from "./plugin-manager.js";
 import { createPluginContext } from "./context.js";
 
 export { CapabilityRegistry } from "./capability-registry.js";
+export { PluginManager } from "./plugin-manager.js";
 
 export { PLUGIN_API_VERSION } from "../types/plugin.js";
 export type { KaizenPlugin, PluginContext } from "../types/plugin.js";
 export type { Builtins } from "./plugin-manager.js";
 
-export async function bootstrap(
+interface InitializedSystem {
+  capabilityRegistry: CapabilityRegistry;
+  manager: PluginManager;
+  eventBus: EventBus;
+  toolRegistry: ToolRegistry;
+  executorRegistry: ExecutorRegistry;
+  uiRegistry: UiRegistry;
+  serviceRegistry: ServiceRegistry;
+  lifecycleProvider: Awaited<ReturnType<PluginManager["initialize"]>>["lifecycleProvider"];
+}
+
+export async function initializePluginSystem(
   kaizenConfig: KaizenConfig,
   builtins: Builtins = {},
-): Promise<void> {
+): Promise<InitializedSystem> {
   const eventBus = new EventBus();
   const toolRegistry = new ToolRegistry();
   const executorRegistry = new ExecutorRegistry();
@@ -29,8 +41,21 @@ export async function bootstrap(
     kaizenConfig, builtins,
     eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
   );
-
   const { lifecycleProvider } = await manager.initialize();
+  return {
+    capabilityRegistry, manager, eventBus, toolRegistry,
+    executorRegistry, uiRegistry, serviceRegistry, lifecycleProvider,
+  };
+}
+
+export async function bootstrap(
+  kaizenConfig: KaizenConfig,
+  builtins: Builtins = {},
+): Promise<void> {
+  const {
+    manager, eventBus, toolRegistry, executorRegistry, uiRegistry,
+    capabilityRegistry, serviceRegistry, lifecycleProvider,
+  } = await initializePluginSystem(kaizenConfig, builtins);
 
   const lifecycleConfig =
     (kaizenConfig[lifecycleProvider.name] as Record<string, unknown> | undefined) ?? {};

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,8 +4,11 @@ import { ToolRegistry } from "./tool-registry.js";
 import { ExecutorRegistry } from "./executor-registry.js";
 import { UiRegistry } from "./ui-registry.js";
 import { ServiceRegistry } from "./service-registry.js";
+import { CapabilityRegistry } from "./capability-registry.js";
 import { PluginManager, type Builtins } from "./plugin-manager.js";
 import { createPluginContext } from "./context.js";
+
+export { CapabilityRegistry } from "./capability-registry.js";
 
 export { PLUGIN_API_VERSION } from "../types/plugin.js";
 export type { KaizenPlugin, PluginContext } from "../types/plugin.js";
@@ -19,11 +22,12 @@ export async function bootstrap(
   const toolRegistry = new ToolRegistry();
   const executorRegistry = new ExecutorRegistry();
   const uiRegistry = new UiRegistry();
+  const capabilityRegistry = new CapabilityRegistry();
   const serviceRegistry = new ServiceRegistry();
 
   const manager = new PluginManager(
     kaizenConfig, builtins,
-    eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry,
+    eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
   );
 
   const { lifecycleProvider } = await manager.initialize();
@@ -37,6 +41,7 @@ export async function bootstrap(
     toolRegistry,
     executorRegistry,
     uiRegistry,
+    capabilityRegistry,
     serviceRegistry,
     () => "RUNNING",
     manager.getPublicApi(),

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -5,6 +5,7 @@ import { ToolRegistry } from "./tool-registry.js";
 import { ExecutorRegistry } from "./executor-registry.js";
 import { UiRegistry } from "./ui-registry.js";
 import { ServiceRegistry } from "./service-registry.js";
+import { CapabilityRegistry } from "./capability-registry.js";
 import type { KaizenPlugin, KaizenConfig, Executor, UiProvider } from "../types/plugin.js";
 
 const stubExecutor: Executor = {
@@ -19,16 +20,20 @@ function makeRegistries() {
     toolRegistry: new ToolRegistry(),
     executorRegistry: new ExecutorRegistry(),
     uiRegistry: new UiRegistry(),
+    capabilityRegistry: new CapabilityRegistry(),
     serviceRegistry: new ServiceRegistry(),
   };
 }
 
-function makePlugin(name: string, setupFn?: (ctx: Parameters<KaizenPlugin["setup"]>[0]) => Promise<void>): KaizenPlugin {
+function makePlugin(
+  name: string,
+  setupFn?: (ctx: Parameters<KaizenPlugin["setup"]>[0]) => Promise<void>,
+  capabilities?: KaizenPlugin["capabilities"],
+): KaizenPlugin {
   return {
     name,
-    apiVersion: "1",
-    provides: [],
-    depends: [],
+    apiVersion: "2",
+    ...(capabilities ? { capabilities } : {}),
     async setup(ctx) {
       await setupFn?.(ctx);
     },
@@ -38,31 +43,33 @@ function makePlugin(name: string, setupFn?: (ctx: Parameters<KaizenPlugin["setup
 describe("PluginManager.initialize", () => {
   test("calls setup on all plugins and returns lifecycle provider", async () => {
     const setupCalls: string[] = [];
-    const { eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry } = makeRegistries();
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
     executorRegistry.register(stubExecutor, "test-exec");
     uiRegistry.register(stubUi, "test-ui");
 
-    const config: KaizenConfig = { plugins: ["lifecycle-plugin"] };
+    const config: KaizenConfig = { plugins: ["core-lifecycle"] };
     const lifecyclePlugin: KaizenPlugin = {
-      name: "lifecycle-plugin",
-      apiVersion: "1",
-      provides: ["lifecycle"],
-      depends: [],
-      async setup() { setupCalls.push("lifecycle-plugin"); },
+      name: "core-lifecycle",
+      apiVersion: "2",
+      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
+      async setup(ctx) {
+        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "lifecycle" });
+        setupCalls.push("core-lifecycle");
+      },
       async start() {},
     };
 
     const manager = new PluginManager(
-      config, { "lifecycle-plugin": lifecyclePlugin },
-      eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry,
+      config, { "core-lifecycle": lifecyclePlugin },
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
     );
     const { lifecycleProvider } = await manager.initialize();
-    expect(setupCalls).toEqual(["lifecycle-plugin"]);
-    expect(lifecycleProvider.name).toBe("lifecycle-plugin");
+    expect(setupCalls).toEqual(["core-lifecycle"]);
+    expect(lifecycleProvider.name).toBe("core-lifecycle");
   });
 
   test("plugins can register tools during setup", async () => {
-    const { eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry } = makeRegistries();
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
     executorRegistry.register(stubExecutor, "test-exec");
     uiRegistry.register(stubUi, "test-ui");
 
@@ -75,14 +82,18 @@ describe("PluginManager.initialize", () => {
       });
     });
     const lifecyclePlugin: KaizenPlugin = {
-      name: "lc", apiVersion: "1", provides: ["lifecycle"], depends: [],
-      async setup() {}, async start() {},
+      name: "core-lifecycle", apiVersion: "2",
+      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
+      async setup(ctx) {
+        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "lifecycle" });
+      },
+      async start() {},
     };
 
     const manager = new PluginManager(
-      { plugins: ["tool-plugin", "lc"] },
-      { "tool-plugin": toolPlugin, "lc": lifecyclePlugin },
-      eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry,
+      { plugins: ["tool-plugin", "core-lifecycle"] },
+      { "tool-plugin": toolPlugin, "core-lifecycle": lifecyclePlugin },
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
     );
     await manager.initialize();
     expect(toolRegistry.list().map((t) => t.name)).toContain("my-tool");
@@ -91,28 +102,28 @@ describe("PluginManager.initialize", () => {
 
 describe("PluginManager.load + unload + reload", () => {
   test("load registers a plugin's tools", async () => {
-    const { eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry } = makeRegistries();
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
     const config: KaizenConfig = { plugins: [] };
     const newPlugin = makePlugin("dyn-plugin", async (ctx) => {
       ctx.registerTool({ name: "dyn-tool", description: "", parameters: {}, execute: async () => ({ ok: true }) });
     });
     const manager = new PluginManager(
       config, { "dyn-plugin": newPlugin },
-      eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry,
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
     );
     await manager.load("dyn-plugin");
     expect(toolRegistry.list().map((t) => t.name)).toContain("dyn-tool");
   });
 
   test("unload deregisters a plugin's tools", async () => {
-    const { eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry } = makeRegistries();
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
     const config: KaizenConfig = { plugins: [] };
     const plugin = makePlugin("rm-plugin", async (ctx) => {
       ctx.registerTool({ name: "rm-tool", description: "", parameters: {}, execute: async () => ({ ok: true }) });
     });
     const manager = new PluginManager(
       config, { "rm-plugin": plugin },
-      eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry,
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
     );
     await manager.load("rm-plugin");
     await manager.unload("rm-plugin");
@@ -120,7 +131,7 @@ describe("PluginManager.load + unload + reload", () => {
   });
 
   test("reload replaces plugin tools", async () => {
-    const { eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry } = makeRegistries();
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
     let callCount = 0;
     const plugin = makePlugin("swap-plugin", async (ctx) => {
       callCount++;
@@ -133,7 +144,7 @@ describe("PluginManager.load + unload + reload", () => {
     });
     const manager = new PluginManager(
       { plugins: [] }, { "swap-plugin": plugin },
-      eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry,
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
     );
     await manager.load("swap-plugin");
     await manager.reload("swap-plugin");
@@ -148,19 +159,19 @@ describe("PluginManager.drainPendingReloads", () => {
     const manager = new PluginManager(
       { plugins: [] }, {},
       registries.eventBus, registries.toolRegistry, registries.executorRegistry,
-      registries.uiRegistry, registries.serviceRegistry,
+      registries.uiRegistry, registries.capabilityRegistry, registries.serviceRegistry,
     );
     await expect(manager.drainPendingReloads()).resolves.toBeUndefined();
   });
 
   test("drains queued reloads in order", async () => {
-    const { eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry } = makeRegistries();
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
     const drained: string[] = [];
     const pluginA = makePlugin("a", async () => { drained.push("a"); });
     const pluginB = makePlugin("b", async () => { drained.push("b"); });
     const manager = new PluginManager(
       { plugins: [] }, { a: pluginA, b: pluginB },
-      eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry,
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
     );
     await manager.load("a");
     await manager.load("b");
@@ -174,16 +185,180 @@ describe("PluginManager.drainPendingReloads", () => {
 
 describe("PluginManager.list", () => {
   test("returns loaded plugin entries", async () => {
-    const { eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry } = makeRegistries();
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
     const plugin = makePlugin("listed-plugin");
     const manager = new PluginManager(
       { plugins: [] }, { "listed-plugin": plugin },
-      eventBus, toolRegistry, executorRegistry, uiRegistry, serviceRegistry,
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
     );
     await manager.load("listed-plugin");
     const entries = manager.list();
     expect(entries).toHaveLength(1);
     expect(entries[0]?.name).toBe("listed-plugin");
     expect(entries[0]?.status).toBe("loaded");
+  });
+});
+
+describe("PluginManager capability validation", () => {
+  function baseRegistries() {
+    return {
+      eventBus: new EventBus(),
+      toolRegistry: new ToolRegistry(),
+      executorRegistry: new ExecutorRegistry(),
+      uiRegistry: new UiRegistry(),
+      capabilityRegistry: new CapabilityRegistry(),
+      serviceRegistry: new ServiceRegistry(),
+    };
+  }
+
+  test("zero providers for a consumed 'one' capability is fatal", async () => {
+    const regs = baseRegistries();
+    const owner: KaizenPlugin = {
+      name: "owner", apiVersion: "2",
+      capabilities: { provides: [] },
+      async setup(ctx) {
+        ctx.defineCapability("owner:thing", { cardinality: "one", description: "t" });
+      },
+    };
+    const consumer: KaizenPlugin = {
+      name: "consumer", apiVersion: "2",
+      capabilities: { consumes: ["owner:thing"] },
+      async setup() {},
+    };
+    const manager = new PluginManager(
+      { plugins: ["owner", "consumer"] }, { owner, consumer },
+      regs.eventBus, regs.toolRegistry, regs.executorRegistry, regs.uiRegistry, regs.capabilityRegistry, regs.serviceRegistry,
+    );
+    await expect(manager.initialize()).rejects.toThrow();
+  });
+
+  test("two providers for a consumed 'one' capability is fatal", async () => {
+    const regs = baseRegistries();
+    const owner: KaizenPlugin = {
+      name: "owner", apiVersion: "2",
+      capabilities: { provides: ["owner:thing"] },
+      async setup(ctx) {
+        ctx.defineCapability("owner:thing", { cardinality: "one", description: "" });
+      },
+    };
+    const a: KaizenPlugin = {
+      name: "a", apiVersion: "2", capabilities: { provides: ["owner:thing"] },
+      async setup() {},
+    };
+    const b: KaizenPlugin = {
+      name: "b", apiVersion: "2", capabilities: { provides: ["owner:thing"] },
+      async setup() {},
+    };
+    const consumer: KaizenPlugin = {
+      name: "consumer", apiVersion: "2", capabilities: { consumes: ["owner:thing"] },
+      async setup() {},
+    };
+    const manager = new PluginManager(
+      { plugins: ["owner", "a", "b", "consumer"] }, { owner, a, b, consumer },
+      regs.eventBus, regs.toolRegistry, regs.executorRegistry, regs.uiRegistry, regs.capabilityRegistry, regs.serviceRegistry,
+    );
+    await expect(manager.initialize()).rejects.toThrow(/Multiple plugins provide/);
+  });
+
+  test("zero providers for a consumed 'many' capability is ok", async () => {
+    const regs = baseRegistries();
+    const owner: KaizenPlugin = {
+      name: "owner", apiVersion: "2",
+      capabilities: { provides: [] },
+      async setup(ctx) {
+        ctx.defineCapability("owner:bag", { cardinality: "many", description: "" });
+      },
+    };
+    const consumer: KaizenPlugin = {
+      name: "consumer", apiVersion: "2",
+      capabilities: { consumes: ["owner:bag"] },
+      async setup() {},
+    };
+    const life: KaizenPlugin = {
+      name: "core-lifecycle", apiVersion: "2",
+      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
+      async setup(ctx) {
+        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "" });
+      },
+      async start() {},
+    };
+    const manager = new PluginManager(
+      { plugins: ["owner", "consumer", "core-lifecycle"] },
+      { owner, consumer, "core-lifecycle": life },
+      regs.eventBus, regs.toolRegistry, regs.executorRegistry, regs.uiRegistry, regs.capabilityRegistry, regs.serviceRegistry,
+    );
+    await expect(manager.initialize()).resolves.toBeDefined();
+  });
+
+  test("cycle in consumes graph is fatal", async () => {
+    const regs = baseRegistries();
+    const a: KaizenPlugin = {
+      name: "a", apiVersion: "2",
+      capabilities: { provides: ["a:x"], consumes: ["b:y"] },
+      async setup(ctx) { ctx.defineCapability("a:x", { cardinality: "many", description: "" }); },
+    };
+    const b: KaizenPlugin = {
+      name: "b", apiVersion: "2",
+      capabilities: { provides: ["b:y"], consumes: ["a:x"] },
+      async setup(ctx) { ctx.defineCapability("b:y", { cardinality: "many", description: "" }); },
+    };
+    const manager = new PluginManager(
+      { plugins: ["a", "b"] }, { a, b },
+      regs.eventBus, regs.toolRegistry, regs.executorRegistry, regs.uiRegistry, regs.capabilityRegistry, regs.serviceRegistry,
+    );
+    await expect(manager.initialize()).rejects.toThrow(/Cycle/i);
+  });
+
+  test("alias resolution in consumes", async () => {
+    const regs = baseRegistries();
+    const life: KaizenPlugin = {
+      name: "core-lifecycle", apiVersion: "2",
+      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
+      async setup(ctx) {
+        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "" });
+      },
+      async start() {},
+    };
+    let consumerRan = false;
+    const consumer: KaizenPlugin = {
+      name: "consumer", apiVersion: "2",
+      aliases: { "lifecycle": "core-lifecycle:lifecycle.drive" },
+      capabilities: { consumes: ["lifecycle"] },
+      async setup() { consumerRan = true; },
+    };
+    const manager = new PluginManager(
+      { plugins: ["consumer", "core-lifecycle"] },
+      { consumer, "core-lifecycle": life },
+      regs.eventBus, regs.toolRegistry, regs.executorRegistry, regs.uiRegistry, regs.capabilityRegistry, regs.serviceRegistry,
+    );
+    await manager.initialize();
+    expect(consumerRan).toBe(true);
+  });
+
+  test("owner-prefix mismatch throws during setup (plugin flagged as failed when not critical)", async () => {
+    const regs = baseRegistries();
+    const life: KaizenPlugin = {
+      name: "core-lifecycle", apiVersion: "2",
+      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
+      async setup(ctx) {
+        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "" });
+      },
+      async start() {},
+    };
+    const bad: KaizenPlugin = {
+      name: "bad", apiVersion: "2",
+      capabilities: { provides: [] },
+      async setup(ctx) {
+        ctx.defineCapability("someoneElse:thing", { cardinality: "one", description: "" });
+      },
+    };
+    const manager = new PluginManager(
+      { plugins: ["bad", "core-lifecycle"] },
+      { bad, "core-lifecycle": life },
+      regs.eventBus, regs.toolRegistry, regs.executorRegistry, regs.uiRegistry, regs.capabilityRegistry, regs.serviceRegistry,
+    );
+    await manager.initialize();
+    const entries = manager.list();
+    expect(entries.find((e) => e.name === "bad")?.status).toBe("failed");
   });
 });

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -11,6 +11,7 @@ import type { ToolRegistry } from "./tool-registry.js";
 import type { ExecutorRegistry } from "./executor-registry.js";
 import type { UiRegistry } from "./ui-registry.js";
 import type { ServiceRegistry } from "./service-registry.js";
+import type { CapabilityRegistry } from "./capability-registry.js";
 import { createPluginContext } from "./context.js";
 import type { CoreState } from "./context.js";
 
@@ -171,6 +172,7 @@ export class PluginManager {
     private readonly toolRegistry: ToolRegistry,
     private readonly executorRegistry: ExecutorRegistry,
     private readonly uiRegistry: UiRegistry,
+    private readonly capabilityRegistry: CapabilityRegistry,
     private readonly serviceRegistry: ServiceRegistry,
   ) {}
 
@@ -306,6 +308,7 @@ export class PluginManager {
     this.serviceRegistry.deregisterByPlugin(name);
     this.executorRegistry.deregisterByPlugin(name);
     this.uiRegistry.deregisterByPlugin(name);
+    this.capabilityRegistry.deregisterByPlugin(name);
     record.entry.status = "unloaded";
     this.plugins.delete(name);
     debug(`Plugin '${name}' unloaded.`);
@@ -371,6 +374,7 @@ export class PluginManager {
       this.toolRegistry,
       this.executorRegistry,
       this.uiRegistry,
+      this.capabilityRegistry,
       this.serviceRegistry,
       () => pluginState,
       this.getPublicApi(),

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -107,29 +107,58 @@ function bustRequireCache(name: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Topological sort (Kahn's algorithm)
+// Topological sort (Kahn's algorithm) — driven by capability provides/consumes
 // ---------------------------------------------------------------------------
+
+function resolveCapName(name: string, aliases: Record<string, string>): string {
+  return aliases[name] ?? name;
+}
+
+function isCritical(plugin: KaizenPlugin, reg: CapabilityRegistry): boolean {
+  const aliases = plugin.aliases ?? {};
+  for (const raw of plugin.capabilities?.provides ?? []) {
+    const cap = resolveCapName(raw, aliases);
+    const spec = reg.getSpec(cap);
+    if (spec?.cardinality === "one" && reg.consumersOf(cap).length > 0) return true;
+  }
+  return false;
+}
 
 function topoSort(plugins: KaizenPlugin[]): KaizenPlugin[] {
   const nameToPlugin = new Map(plugins.map((p) => [p.name, p]));
-  const roleToPlugin = new Map<string, KaizenPlugin>();
+
+  // Map canonical capability name → list of plugins that provide it.
+  const capToProviders = new Map<string, string[]>();
   for (const p of plugins) {
-    for (const role of p.provides ?? []) roleToPlugin.set(role, p);
-  }
-  const inDegree = new Map(plugins.map((p) => [p.name, 0]));
-  const edges = new Map<string, string[]>();
-  for (const p of plugins) {
-    for (const dep of p.depends ?? []) {
-      const depPlugin = roleToPlugin.get(dep) ?? nameToPlugin.get(dep);
-      if (!depPlugin) continue;
-      const depName = depPlugin.name;
-      if (depName === p.name) continue;
-      const existing = edges.get(depName) ?? [];
+    const aliases = p.aliases ?? {};
+    for (const raw of p.capabilities?.provides ?? []) {
+      const cap = resolveCapName(raw, aliases);
+      const existing = capToProviders.get(cap) ?? [];
       existing.push(p.name);
-      edges.set(depName, existing);
-      inDegree.set(p.name, (inDegree.get(p.name) ?? 0) + 1);
+      capToProviders.set(cap, existing);
     }
   }
+
+  const inDegree = new Map(plugins.map((p) => [p.name, 0]));
+  const edges = new Map<string, string[]>();
+
+  for (const p of plugins) {
+    const aliases = p.aliases ?? {};
+    const seen = new Set<string>();
+    for (const raw of p.capabilities?.consumes ?? []) {
+      const cap = resolveCapName(raw, aliases);
+      for (const providerName of capToProviders.get(cap) ?? []) {
+        if (providerName === p.name) continue;
+        if (seen.has(providerName)) continue;
+        seen.add(providerName);
+        const existing = edges.get(providerName) ?? [];
+        existing.push(p.name);
+        edges.set(providerName, existing);
+        inDegree.set(p.name, (inDegree.get(p.name) ?? 0) + 1);
+      }
+    }
+  }
+
   const queue = plugins.filter((p) => (inDegree.get(p.name) ?? 0) === 0);
   const sorted: KaizenPlugin[] = [];
   while (queue.length > 0) {
@@ -193,70 +222,73 @@ export class PluginManager {
 
     const sorted = topoSort(resolved);
 
-    const requiredRoles = new Set<string>();
-    for (const p of sorted) {
-      for (const dep of p.depends ?? []) {
-        const isPluginName = sorted.some((q) => q.name === dep);
-        if (!isPluginName) requiredRoles.add(dep);
+    // PASS 1: register provide/consume metadata so criticality + validateAll see full graph
+    for (const plugin of sorted) {
+      const aliases = plugin.aliases ?? {};
+      for (const raw of plugin.capabilities?.provides ?? []) {
+        this.capabilityRegistry.addProvider(resolveCapName(raw, aliases), plugin.name);
+      }
+      for (const raw of plugin.capabilities?.consumes ?? []) {
+        this.capabilityRegistry.addConsumer(resolveCapName(raw, aliases), plugin.name);
       }
     }
 
+    // PASS 2: call setup() in topo order.
     const loadedNames = new Set<string>();
     for (const plugin of sorted) {
       const pluginMajor = plugin.apiVersion.split(".")[0];
       if (pluginMajor !== PLUGIN_API_VERSION) {
         warn(`Plugin '${plugin.name}' apiVersion ${plugin.apiVersion}, core expects ${PLUGIN_API_VERSION}.x. Loading anyway.`);
       }
-      const providesRequiredRole = (plugin.provides ?? []).some((r) => requiredRoles.has(r));
+      const critical = isCritical(plugin, this.capabilityRegistry);
       try {
         await this.setupPlugin(plugin);
         loadedNames.add(plugin.name);
         this.plugins.set(plugin.name, {
           plugin,
-          entry: { name: plugin.name, apiVersion: plugin.apiVersion, provides: plugin.provides ?? [], status: "loaded" },
+          entry: {
+            name: plugin.name,
+            apiVersion: plugin.apiVersion,
+            capabilities: plugin.capabilities ?? {},
+            status: "loaded",
+          },
         });
         debug(`Plugin '${plugin.name}' initialized.`);
       } catch (err) {
-        if (providesRequiredRole) {
-          const role = (plugin.provides ?? []).find((r) => requiredRoles.has(r))!;
-          fatal(`${plugin.name} (provides: ${role}) failed to initialize: ${err instanceof Error ? err.message : String(err)}`);
-        } else {
-          if (err instanceof Error && err.stack) debug(err.stack);
-          console.error(`[kaizen] error: plugin '${plugin.name}' failed to initialize:`, err instanceof Error ? err.message : err);
-          this.plugins.set(plugin.name, {
-            plugin,
-            entry: { name: plugin.name, apiVersion: plugin.apiVersion, provides: plugin.provides ?? [], status: "failed" },
-          });
+        if (critical) {
+          fatal(`${plugin.name} (provides critical capability) failed to initialize: ${err instanceof Error ? err.message : String(err)}`);
         }
+        if (err instanceof Error && err.stack) debug(err.stack);
+        console.error(`[kaizen] error: plugin '${plugin.name}' failed to initialize:`, err instanceof Error ? err.message : err);
+        this.plugins.set(plugin.name, {
+          plugin,
+          entry: {
+            name: plugin.name,
+            apiVersion: plugin.apiVersion,
+            capabilities: plugin.capabilities ?? {},
+            status: "failed",
+          },
+        });
       }
     }
 
-    // Role validation
-    const roleProviders = new Map<string, string[]>();
-    for (const [name, record] of this.plugins) {
-      if (record.entry.status !== "loaded") continue;
-      for (const role of record.plugin.provides ?? []) {
-        const existing = roleProviders.get(role) ?? [];
-        existing.push(name);
-        roleProviders.set(role, existing);
-      }
-    }
-    for (const role of requiredRoles) {
-      const providers = roleProviders.get(role) ?? [];
-      if (providers.length === 0) fatal(`No plugin provides role '${role}'. Add one to kaizen.json.`);
-      if (providers.length > 1) fatal(`Multiple plugins provide role '${role}': ${providers.join(", ")}. Remove one.`);
+    // PASS 3: validate capability cardinalities + referenced-but-undefined
+    try {
+      this.capabilityRegistry.validateAll();
+    } catch (err) {
+      fatal(err instanceof Error ? err.message : String(err));
     }
 
     // Warn on unclaimed config keys
-    const claimedKeys = new Set(["plugins", ...loadedNames]);
+    const claimedKeys = new Set(["plugins", "extends", ...loadedNames]);
     for (const key of Object.keys(this.config)) {
       if (!claimedKeys.has(key)) warn(`Unknown config key '${key}'. No plugin claimed it.`);
     }
 
-    // Find lifecycle provider
-    const lifecycleProviderName = roleProviders.get("lifecycle")?.[0];
-    if (!lifecycleProviderName) fatal("No lifecycle plugin found. Add one to kaizen.json.");
-    const lifecycleProvider = this.plugins.get(lifecycleProviderName!)?.plugin;
+    // Resolve lifecycle provider — sole provider of core-lifecycle:lifecycle.drive
+    const lifeProviders = this.capabilityRegistry.providersOf("core-lifecycle:lifecycle.drive");
+    if (lifeProviders.length === 0) fatal("No lifecycle plugin found. Add one to kaizen.json.");
+    const lifecycleProvider = this.plugins.get(lifeProviders[0]!)?.plugin;
     if (!lifecycleProvider || typeof lifecycleProvider.start !== "function") {
       fatal("No lifecycle plugin found. Add one to kaizen.json.");
     }
@@ -278,22 +310,44 @@ export class PluginManager {
     if (pluginMajor !== PLUGIN_API_VERSION) {
       warn(`Plugin '${plugin.name}' apiVersion ${plugin.apiVersion}, core expects ${PLUGIN_API_VERSION}.x. Loading anyway.`);
     }
+    const aliases = plugin.aliases ?? {};
+    for (const raw of plugin.capabilities?.provides ?? []) {
+      this.capabilityRegistry.addProvider(resolveCapName(raw, aliases), plugin.name);
+    }
+    for (const raw of plugin.capabilities?.consumes ?? []) {
+      this.capabilityRegistry.addConsumer(resolveCapName(raw, aliases), plugin.name);
+    }
     try {
       await this.setupPlugin(plugin);
       this.plugins.set(name, {
         plugin,
-        entry: { name: plugin.name, apiVersion: plugin.apiVersion, provides: plugin.provides ?? [], status: "loaded" },
+        entry: {
+          name: plugin.name,
+          apiVersion: plugin.apiVersion,
+          capabilities: plugin.capabilities ?? {},
+          status: "loaded",
+        },
       });
+      try {
+        this.capabilityRegistry.validateAll();
+      } catch (err) {
+        warn(`Capability validation after loading '${name}': ${err instanceof Error ? err.message : String(err)}`);
+      }
       debug(`Plugin '${name}' loaded.`);
     } catch (err) {
       this.plugins.set(name, {
         plugin,
-        entry: { name: plugin.name, apiVersion: plugin.apiVersion, provides: plugin.provides ?? [], status: "failed" },
+        entry: {
+          name: plugin.name,
+          apiVersion: plugin.apiVersion,
+          capabilities: plugin.capabilities ?? {},
+          status: "failed",
+        },
       });
       const msg = err instanceof Error ? err.message : String(err);
       warn(`Plugin '${name}' failed to load: ${msg}`);
-      const providesList = (plugin.provides ?? []).join(", ");
-      if (providesList) warn(`Plugin '${name}' provides [${providesList}] but failed — role may be unavailable.`);
+      const provList = (plugin.capabilities?.provides ?? []).join(", ");
+      if (provList) warn(`Plugin '${name}' provides [${provList}] but failed — capability may be unavailable.`);
     }
   }
 

--- a/src/core/ui-registry.test.ts
+++ b/src/core/ui-registry.test.ts
@@ -6,25 +6,59 @@ const stubUi: UiProvider = {
   accept: async function* () {},
 };
 
-describe("UiRegistry.deregisterByPlugin", () => {
-  test("removes UI provider registered by named plugin", () => {
-    const registry = new UiRegistry();
-    registry.register(stubUi, "plugin-ui");
-    registry.deregisterByPlugin("plugin-ui");
-    expect(registry.isRegistered()).toBe(false);
+describe("UiRegistry multi-provider", () => {
+  test("two registrations: both stored, list() returns them in registration order", () => {
+    const r = new UiRegistry();
+    const a: UiProvider = { accept: async function* () {} };
+    const b: UiProvider = { accept: async function* () {} };
+    r.register(a, "plugin-a");
+    r.register(b, "plugin-b");
+    expect(r.list()).toEqual([a, b]);
   });
 
-  test("no-op when plugin name does not match", () => {
-    const registry = new UiRegistry();
-    registry.register(stubUi, "plugin-ui");
-    registry.deregisterByPlugin("plugin-other");
-    expect(registry.isRegistered()).toBe(true);
+  test("getFirst returns the first registered provider", () => {
+    const r = new UiRegistry();
+    const a: UiProvider = { accept: async function* () {} };
+    const b: UiProvider = { accept: async function* () {} };
+    r.register(a, "plugin-a");
+    r.register(b, "plugin-b");
+    expect(r.getFirst()).toBe(a);
+  });
+
+  test("getFirst fatal when none registered", () => {
+    const r = new UiRegistry();
+    expect(() => r.getFirst()).toThrow();
+  });
+
+  test("isRegistered true when at least one registered", () => {
+    const r = new UiRegistry();
+    expect(r.isRegistered()).toBe(false);
+    r.register(stubUi, "a");
+    expect(r.isRegistered()).toBe(true);
+  });
+
+  test("deregisterByPlugin removes only the targeted plugin's provider", () => {
+    const r = new UiRegistry();
+    const a: UiProvider = { accept: async function* () {} };
+    const b: UiProvider = { accept: async function* () {} };
+    r.register(a, "plugin-a");
+    r.register(b, "plugin-b");
+    r.deregisterByPlugin("plugin-a");
+    expect(r.list()).toEqual([b]);
+    expect(r.isRegistered()).toBe(true);
+  });
+
+  test("deregisterByPlugin no-op when name does not match", () => {
+    const r = new UiRegistry();
+    r.register(stubUi, "plugin-ui");
+    r.deregisterByPlugin("plugin-other");
+    expect(r.isRegistered()).toBe(true);
   });
 
   test("deregistered UI slot can be re-registered", () => {
-    const registry = new UiRegistry();
-    registry.register(stubUi, "plugin-ui");
-    registry.deregisterByPlugin("plugin-ui");
-    expect(() => registry.register(stubUi, "plugin-ui")).not.toThrow();
+    const r = new UiRegistry();
+    r.register(stubUi, "plugin-ui");
+    r.deregisterByPlugin("plugin-ui");
+    expect(() => r.register(stubUi, "plugin-ui")).not.toThrow();
   });
 });

--- a/src/core/ui-registry.ts
+++ b/src/core/ui-registry.ts
@@ -1,29 +1,31 @@
 import type { UiProvider } from "../types/plugin.js";
 import { fatal } from "./errors.js";
 
+interface Entry { impl: UiProvider; pluginName: string; }
+
 export class UiRegistry {
-  private impl: UiProvider | null = null;
-  private registeredBy: string | null = null;
+  private readonly entries: Entry[] = [];
 
   register(impl: UiProvider, pluginName: string): void {
-    if (this.impl !== null) {
-      fatal(`Two plugins registered a UI provider: '${this.registeredBy}' and '${pluginName}'. Remove one.`);
-    }
-    this.impl = impl;
-    this.registeredBy = pluginName;
+    this.entries.push({ impl, pluginName });
   }
 
-  get(): UiProvider {
-    if (!this.impl) fatal("No UI provider registered. Add a UI plugin to kaizen.json.");
-    return this.impl;
+  /** All registered providers, in registration order. */
+  list(): UiProvider[] {
+    return this.entries.map((e) => e.impl);
   }
 
-  isRegistered(): boolean { return this.impl !== null; }
+  /** First-registered provider, for back-compat with single-provider code paths. */
+  getFirst(): UiProvider {
+    if (this.entries.length === 0) fatal("No UI provider registered.");
+    return this.entries[0]!.impl;
+  }
+
+  isRegistered(): boolean { return this.entries.length > 0; }
 
   deregisterByPlugin(pluginName: string): void {
-    if (this.registeredBy === pluginName) {
-      this.impl = null;
-      this.registeredBy = null;
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      if (this.entries[i]!.pluginName === pluginName) this.entries.splice(i, 1);
     }
   }
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -217,6 +217,12 @@ export interface PluginContext {
   // --- Runtime primitives --------------------------------------------------
 
   runtime: {
+    /** All registered executors; routing mechanism deferred. */
+    executors: {
+      list(): Executor[];
+      getFirst(): Executor;
+    };
+    /** First-registered executor — preserved for back-compat. Deprecated once routing lands. */
     executor: Executor;
     /** All registered UI providers, in registration order. */
     ui: {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -218,7 +218,11 @@ export interface PluginContext {
 
   runtime: {
     executor: Executor;
-    ui: UiProvider;
+    /** All registered UI providers, in registration order. */
+    ui: {
+      list(): UiProvider[];
+      getFirst(): UiProvider;
+    };
     tools: {
       /** Returns all registered tools at the time of the call. */
       list(): ToolDefinition[];

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -9,7 +9,7 @@
  * live in the `core-events` plugin, not here. Import them from `core-events`.
  */
 
-export const PLUGIN_API_VERSION = "1";
+export const PLUGIN_API_VERSION = "2";
 
 import { ServiceToken } from "../core/service-registry.js";
 export { ServiceToken };
@@ -138,6 +138,28 @@ export interface UiProvider {
 export type EventHandler = (payload?: unknown) => Promise<unknown | void>;
 
 // ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+export type Cardinality = "one" | "many";
+
+export interface CapabilitySpec {
+  /** "one": exactly one provider required when consumed. "many": any count, including zero. */
+  cardinality: Cardinality;
+  /** Optional JSON schema validated against provider registrations. */
+  schema?: JsonSchema;
+  /** Optional semver string — future-proofing; currently informational only. */
+  version?: string;
+  /** Human-readable; shown by `kaizen capability show`. */
+  description: string;
+}
+
+export interface PluginCapabilities {
+  provides?: string[];
+  consumes?: string[];
+}
+
+// ---------------------------------------------------------------------------
 // Plugin context — passed to setup() and start()
 // ---------------------------------------------------------------------------
 
@@ -219,27 +241,17 @@ export interface KaizenPlugin {
   /** semver. Core warns if major != PLUGIN_API_VERSION. */
   apiVersion: string;
 
-  /** Capability roles this plugin fulfills (e.g. 'lifecycle', 'ui'). */
-  provides?: string[];
+  /** What this plugin provides and consumes in the capability registry. */
+  capabilities?: PluginCapabilities;
 
   /**
-   * Capability roles or plugin names that must be initialized before this plugin.
-   * Core enforces: exactly one loaded plugin must provide each required role.
+   * Map short or alternative capability names to canonical owner-qualified names.
+   * Resolved when reading the `capabilities` lists above.
+   * e.g. { "ui.input": "core-lifecycle:ui.input" }
    */
-  depends?: string[];
+  aliases?: Record<string, string>;
 
-  /**
-   * Called once during INITIALIZING. Register tools, define events, subscribe to events.
-   * Calling registerTool, defineEvent, on, or registerExecutor/registerUi after
-   * setup() returns throws.
-   */
   setup(ctx: PluginContext): Promise<void>;
-
-  /**
-   * Called by core on the lifecycle role provider after all plugins have initialized.
-   * Only the plugin providing role 'lifecycle' should implement this.
-   * If the lifecycle provider does not export start(): fatal error.
-   */
   start?(ctx: PluginContext): Promise<void>;
 }
 
@@ -267,7 +279,7 @@ export interface KaizenConfig {
 export interface PluginEntry {
   name: string;
   apiVersion: string;
-  provides: string[];
+  capabilities: PluginCapabilities;
   status: "loaded" | "unloaded" | "failed";
 }
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -183,6 +183,10 @@ export interface PluginContext {
   /** Register the UI provider. Exactly one plugin must call this. */
   registerUi(impl: UiProvider): void;
 
+  // --- Capability registry (INITIALIZING state only) -----------------------
+  /** Declare a capability. Name must be prefixed with the calling plugin's name. */
+  defineCapability(name: string, spec: CapabilitySpec): void;
+
   // --- Event bus -----------------------------------------------------------
 
   /** Declare a new event type. Advisory only — suppresses "unknown event" warnings. */


### PR DESCRIPTION
## Summary
- Replaces `provides`/`depends` role system with owner-qualified capability registry (`CapabilityRegistry` + `KaizenPlugin.capabilities`).
- Multi-provider `UiRegistry`/`ExecutorRegistry`; lifecycle races input and broadcasts output across all UI providers (one shared session).
- Adds `kaizen capability list/show`; plugin API bumped to v2; all built-in plugins migrated.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun test` — 64/64 pass
- [x] `bun run test:core` — 8/8 pass
- [x] `kaizen capability list` — shows the 5 foundational capabilities with correct providers/consumers
- [ ] End-to-end with real `--harness core-anthropic` session (requires ANTHROPIC_API_KEY)

## Notes
- Plan: `docs/superpowers/plans/2026-04-17-capability-registry.md`
- Migration guide for plugin authors: `docs/plugin-migration-capability-registry.md`
- Executed via subagent-driven development (17 tasks, 19 commits)