### PR TITLE
docs: plugin tooling brainstorm — 4 specs + 4 implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-04-18-builtin-plugins-repo-decoupling.md
+++ b/docs/superpowers/plans/2026-04-18-builtin-plugins-repo-decoupling.md
@@ -1,0 +1,303 @@
+# Built-in Plugins Repo Decoupling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decouple the built-in plugins from the main kaizen monorepo into a
+dedicated `kaizen-sh/kaizen-plugins` repository. Establish the official kaizen
+marketplace. After this plan, plugins have their own release cadence, authors have
+a canonical reference repo, and `kaizen marketplace add` works with the official
+catalog.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md`
+
+**Prerequisites:**
+- Spec 1 (marketplace) must be shipped — the new repo emits a `marketplace.json`
+  in the format Spec 1 defines, and the `kaizen marketplace add` command must exist.
+- Spec 3 (scaffolder + standards) is recommended before starting — scaffolded
+  plugins in the new repo should pass `kaizen plugin validate`.
+
+---
+
+## Phase 1 — Set Up New Repository
+
+### Task 1: Create `kaizen-sh/kaizen-plugins` repo
+
+- [ ] **Step 1: Create the repository**
+
+Create `kaizen-sh/kaizen-plugins` (or equivalent under the project's GitHub org).
+Initialize with MIT license and a README stub.
+
+- [ ] **Step 2: Set up directory structure**
+
+```
+kaizen-plugins/
+├── .kaizen/
+│   └── marketplace.json
+├── plugins/
+├── harnesses/
+├── README.md
+└── package.json    # optional workspace root
+```
+
+- [ ] **Step 3: Write initial `README.md`**
+
+Explain:
+- What this repo is (official kaizen plugins + marketplace catalog).
+- How to add the official marketplace: `kaizen marketplace add <url>`.
+- How to contribute a plugin.
+- How to contribute a harness.
+- Link to `docs/plugin-standards.md` in the main kaizen repo.
+
+---
+
+## Phase 2 — Migrate Plugins
+
+### Task 2: Copy and update each built-in plugin
+
+For each of the following plugins, complete all steps. Work through them one at a
+time to avoid merge conflicts.
+
+**Plugins to migrate:**
+- `core-events`
+- `core-executor-anthropic`
+- `core-executor-openai`
+- `core-executor-debug`
+- `core-executor-shell`
+- `core-ui-terminal`
+- `core-cli`
+- `core-lifecycle`
+- `core-plugin-manager`
+- `kaizen-plugin-timestamps`
+
+For each plugin:
+
+- [ ] **Step A: Copy source to `plugins/<name>/`**
+
+Copy `plugins/<name>/` from the main kaizen repo to `plugins/<name>/` in the new
+repo.
+
+- [ ] **Step B: Fix imports**
+
+Replace relative imports:
+```typescript
+// Before
+import type { KaizenPlugin } from "../../src/types/plugin.js";
+import { EVENTS } from "../core-events/index.js";
+
+// After
+import type { KaizenPlugin } from "kaizen/types";
+import { EVENTS } from "core-events";
+```
+
+- [ ] **Step C: Update `package.json`**
+
+```json
+{
+  "name": "<plugin-name>",
+  "version": "0.1.0",
+  "description": "<description>",
+  "type": "module",
+  "exports": { ".": "./index.ts" },
+  "keywords": ["kaizen-plugin"],
+  "peerDependencies": { "kaizen": "*" },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.4.0"
+  }
+}
+```
+
+- [ ] **Step D: Add/update tests**
+
+Ensure `index.test.ts` exists. Add minimal test (metadata + setup runs) if absent.
+Use `makeCtx()` pattern from the scaffold template.
+
+- [ ] **Step E: Add `README.md`**
+
+At minimum: plugin name, description, installation, configuration table (if any),
+permissions, capabilities.
+
+- [ ] **Step F: Run `kaizen plugin validate plugins/<name>`**
+
+Fix any validation errors before moving to the next plugin.
+
+---
+
+## Phase 3 — Migrate Harnesses
+
+### Task 3: Copy harness files
+
+- [ ] **Step 1: Copy `harnesses/core-anthropic/kaizen.json` → `harnesses/core-anthropic.json`**
+
+Flatten from `harnesses/<name>/kaizen.json` to `harnesses/<name>.json` in the new
+repo (a harness is a single file, not a directory).
+
+- [ ] **Step 2: Copy `harnesses/core-debug.json` and `harnesses/core-shell.json`**
+
+Same pattern.
+
+- [ ] **Step 3: Update plugin refs in harnesses**
+
+Harness files should use canonical refs. For built-in plugins that remain compiled
+into the binary, bare names (`"core-events"`) are fine. Once Spec 1 is shipped,
+harnesses in the marketplace repo can optionally use fully-qualified refs
+(`"official/core-events@2.0.0"`).
+
+---
+
+## Phase 4 — Write Official Marketplace Catalog
+
+### Task 4: Write `.kaizen/marketplace.json`
+
+- [ ] **Step 1: Add all migrated plugins to the catalog**
+
+For each plugin in Phase 2, add an entry:
+
+```json
+{
+  "name": "core-events",
+  "description": "Default event vocabulary for kaizen sessions.",
+  "categories": ["core"],
+  "versions": [
+    {
+      "version": "0.1.0",
+      "source": { "type": "file", "path": "plugins/core-events" }
+    }
+  ]
+}
+```
+
+Initially use `file` sources (the plugins live in this repo). Once plugins are
+published to npm separately, switch entries to `npm` sources.
+
+- [ ] **Step 2: Add harness entries**
+
+```json
+{
+  "name": "core-anthropic",
+  "description": "Default Anthropic LLM harness.",
+  "categories": ["harness"],
+  "versions": [
+    { "version": "1.0.0", "path": "harnesses/core-anthropic.json" }
+  ]
+}
+```
+
+- [ ] **Step 3: Run `kaizen marketplace validate .`**
+
+Fix any validation errors.
+
+---
+
+## Phase 5 — Update Build in Main Repo
+
+### Task 5: Update kaizen build to use new repo
+
+- [ ] **Step 1: Add `kaizen-plugins` as a dependency or workspace**
+
+In the main kaizen repo's `package.json`:
+```json
+{
+  "workspaces": ["plugins/*"]
+}
+```
+
+Point workspace entries at the new repo via git dependency or by checking it out
+as a sibling directory in CI:
+```json
+{
+  "dependencies": {
+    "core-events": "github:kaizen-sh/kaizen-plugins#HEAD:plugins/core-events"
+  }
+}
+```
+
+Or (simpler for development): keep `plugins/*` as local workspace entries that
+are symlinked to the checked-out `kaizen-plugins` repo during development.
+
+- [ ] **Step 2: Verify `bun build --compile` still works**
+
+Run the full binary build. Confirm all static imports in `src/cli.ts` resolve.
+
+- [ ] **Step 3: Update `src/cli.ts` static imports if needed**
+
+If import paths change (e.g., from workspace-relative to package name), update.
+
+---
+
+## Phase 6 — Official Marketplace Bootstrap in `kaizen init`
+
+### Task 6: Pre-add official marketplace in new installs
+
+- [ ] **Step 1: Update `kaizen init --global`**
+
+When creating `~/.kaizen/kaizen.json`, pre-populate the `marketplaces` array:
+
+```json
+{
+  "marketplaces": [
+    {
+      "id": "official",
+      "url": "https://github.com/kaizen-sh/kaizen-plugins.git"
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Run `kaizen marketplace update official` in `kaizen init --global`**
+
+Fetches the catalog on first install so `kaizen marketplace browse` works immediately.
+
+---
+
+## Phase 7 — Remove Old `plugins/` from Main Repo
+
+### Task 7: Cleanup (do last, after build verified)
+
+- [ ] **Step 1: Verify build and all tests pass with new repo**
+
+Run full test suite from a clean checkout. No references to old `plugins/` paths.
+
+- [ ] **Step 2: Delete `plugins/` directory from main kaizen repo**
+
+```bash
+git rm -r plugins/
+```
+
+- [ ] **Step 3: Delete `harnesses/` directory from main kaizen repo** (if harnesses
+  migrated fully to new repo and no longer needed here).
+
+- [ ] **Step 4: Update `docs/architecture.md`**
+
+Change "Directory structure" section:
+- Remove `plugins/` entry.
+- Add reference to `kaizen-sh/kaizen-plugins` repo.
+- Update plugin resolution order to mention official marketplace.
+
+- [ ] **Step 5: Update `docs/plugin-loading.md`**
+
+Update "Development workflow for plugin authors" to reference the new repo as the
+reference implementation.
+
+- [ ] **Step 6: Update `docs/plugin-api.md`**
+
+Change import examples from relative paths to `kaizen/types`.
+
+---
+
+## Phase 8 — Documentation
+
+### Task 8: Docs
+
+- [ ] **Step 1: Write `docs/contributing-plugins.md`**
+
+Guide for contributing to `kaizen-sh/kaizen-plugins`:
+- How to add a new plugin (copy scaffold, add to catalog, open PR).
+- Standards requirements (link to `docs/plugin-standards.md`).
+- How to publish a plugin to npm (future — note it's not required; `file` sources work).
+- How to add a harness.
+
+- [ ] **Step 2: Update `README.md`**
+
+Add official marketplace to the "Installation and discovery" section.
+Update the built-in plugin list to reflect they're now in `kaizen-sh/kaizen-plugins`.

--- a/docs/superpowers/plans/2026-04-18-builtin-plugins-repo-decoupling.md
+++ b/docs/superpowers/plans/2026-04-18-builtin-plugins-repo-decoupling.md
@@ -1,90 +1,142 @@
-# Built-in Plugins Repo Decoupling — Implementation Plan
+# Extract Plugins from Kaizen Binary — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Decouple the built-in plugins from the main kaizen monorepo into a
-dedicated `kaizen-sh/kaizen-plugins` repository. Establish the official kaizen
-marketplace. After this plan, plugins have their own release cadence, authors have
-a canonical reference repo, and `kaizen marketplace add` works with the official
-catalog.
+**Goal:** Extract every first-party plugin from the `kaizen-code` binary into
+a dedicated `kaizen-sh/kaizen-plugins` repository. Publish the official
+marketplace catalog. Remove the embedding path from `kaizen-code` entirely
+— after this plan, the binary ships with zero plugins and every plugin
+reaches a user through the Spec 1 marketplace install path.
 
 **Spec:** `docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md`
 
 **Prerequisites:**
-- Spec 1 (marketplace) must be shipped — the new repo emits a `marketplace.json`
-  in the format Spec 1 defines, and the `kaizen marketplace add` command must exist.
-- Spec 3 (scaffolder + standards) is recommended before starting — scaffolded
-  plugins in the new repo should pass `kaizen plugin validate`.
+- **Spec 1 (marketplace) fully shipped.** Specifically its plan tasks that
+  deliver marketplace add/update/install CLI, the install layout under
+  `~/.kaizen/marketplaces/<id>/`, `src/core/kaizen-config.ts`, and the
+  dynamic plugin loader wired in `src/cli.ts`. Without the loader live,
+  removing static imports breaks the binary.
+- **Spec 3 (scaffolder + standards) recommended.** Migrated plugins should
+  pass `kaizen plugin validate`.
+- **Spec 2 (unified config + core-secrets) optional.** If Spec 2 is merged
+  first, `core-secrets` joins the initial migration. Otherwise Spec 2's
+  plan adds it to `kaizen-plugins` later.
 
 ---
 
-## Phase 1 — Set Up New Repository
+## Phase 1 — Set Up `kaizen-sh/kaizen-plugins`
 
-### Task 1: Create `kaizen-sh/kaizen-plugins` repo
+### Task 1: Create the repo
 
 - [ ] **Step 1: Create the repository**
 
-Create `kaizen-sh/kaizen-plugins` (or equivalent under the project's GitHub org).
-Initialize with MIT license and a README stub.
+Create `kaizen-sh/kaizen-plugins` under the project's GitHub org. MIT license.
 
-- [ ] **Step 2: Set up directory structure**
+- [ ] **Step 2: Initial directory layout**
 
 ```
 kaizen-plugins/
 ├── .kaizen/
-│   └── marketplace.json
+│   └── marketplace.json      # empty entries[] initially
 ├── plugins/
 ├── harnesses/
-├── README.md
-└── package.json    # optional workspace root
+├── package.json              # workspace root
+└── README.md
 ```
 
-- [ ] **Step 3: Write initial `README.md`**
+Workspace root `package.json`:
+```json
+{
+  "name": "kaizen-plugins-workspace",
+  "private": true,
+  "workspaces": ["plugins/*"]
+}
+```
 
-Explain:
-- What this repo is (official kaizen plugins + marketplace catalog).
-- How to add the official marketplace: `kaizen marketplace add <url>`.
-- How to contribute a plugin.
-- How to contribute a harness.
-- Link to `docs/plugin-standards.md` in the main kaizen repo.
+Empty initial catalog:
+```json
+{
+  "version": "1.0.0",
+  "name": "kaizen-official",
+  "description": "Official kaizen plugins and harnesses.",
+  "url": "https://github.com/kaizen-sh/kaizen-plugins.git",
+  "entries": []
+}
+```
+
+- [ ] **Step 3: README**
+
+Cover: what the repo is, how to add the official marketplace
+(`kaizen marketplace add official https://github.com/kaizen-sh/kaizen-plugins.git`),
+how to contribute a plugin/harness, link to `docs/plugin-standards.md` in
+`kaizen-code`.
 
 ---
 
-## Phase 2 — Migrate Plugins
+## Phase 2 — Add `kaizen/types` Export in kaizen-code
 
-### Task 2: Copy and update each built-in plugin
+### Task 2: Publish public plugin types from the kaizen package
 
-For each of the following plugins, complete all steps. Work through them one at a
-time to avoid merge conflicts.
+- [ ] **Step 1: Declare `./types` in `package.json#exports`**
 
-**Plugins to migrate:**
-- `core-events`
-- `core-executor-anthropic`
-- `core-executor-openai`
-- `core-executor-debug`
-- `core-executor-shell`
-- `core-ui-terminal`
-- `core-cli`
-- `core-lifecycle`
-- `core-plugin-manager`
-- `kaizen-plugin-timestamps`
+In `kaizen-code/package.json`:
+```json
+{
+  "exports": {
+    ".": "./src/index.ts",
+    "./types": "./src/types/plugin.ts"
+  }
+}
+```
+
+- [ ] **Step 2: Verify the export surface**
+
+`src/types/plugin.ts` should re-export everything plugins need
+(`KaizenPlugin`, context types, event types, capability types). If
+anything plugin-facing currently lives under other internal paths, move or
+re-export.
+
+- [ ] **Step 3: Smoke-test from outside**
+
+In a scratch directory, `bun add ../kaizen-code` and
+`import type { KaizenPlugin } from "kaizen/types"`. Confirm resolution.
+
+---
+
+## Phase 3 — Migrate Plugins
+
+### Task 3: Copy and update each plugin
+
+Plugins to migrate (copy in this order to minimize cross-plugin breakage):
+1. `core-events`
+2. `core-lifecycle`
+3. `core-ui-terminal`
+4. `core-cli`
+5. `core-plugin-manager`
+6. `core-executor-debug`
+7. `core-executor-shell`
+8. `core-executor-anthropic`
+9. `core-executor-openai`
+10. `timestamps` (renamed from `kaizen-plugin-timestamps`)
+11. `core-secrets` — only if Spec 2 is merged before this task; otherwise
+    skip and let Spec 2's plan add it.
 
 For each plugin:
 
 - [ ] **Step A: Copy source to `plugins/<name>/`**
 
-Copy `plugins/<name>/` from the main kaizen repo to `plugins/<name>/` in the new
-repo.
+Copy `kaizen-code/plugins/<name>/` → `kaizen-plugins/plugins/<name>/`.
+Rename `kaizen-plugin-timestamps/` → `timestamps/`.
 
 - [ ] **Step B: Fix imports**
 
-Replace relative imports:
+Replace:
 ```typescript
-// Before
 import type { KaizenPlugin } from "../../src/types/plugin.js";
 import { EVENTS } from "../core-events/index.js";
-
-// After
+```
+with:
+```typescript
 import type { KaizenPlugin } from "kaizen/types";
 import { EVENTS } from "core-events";
 ```
@@ -99,205 +151,303 @@ import { EVENTS } from "core-events";
   "type": "module",
   "exports": { ".": "./index.ts" },
   "keywords": ["kaizen-plugin"],
-  "peerDependencies": { "kaizen": "*" },
-  "devDependencies": {
-    "@types/bun": "latest",
-    "typescript": "^5.4.0"
+  "peerDependencies": {
+    "kaizen": "*"
   }
 }
 ```
 
-- [ ] **Step D: Add/update tests**
+List cross-plugin peer deps (e.g. `core-lifecycle` peers
+`"core-events": "*"`).
 
-Ensure `index.test.ts` exists. Add minimal test (metadata + setup runs) if absent.
-Use `makeCtx()` pattern from the scaffold template.
+Executors (`core-executor-anthropic`, `core-executor-openai`, etc.) are
+copied **as-is**. Spec 2's plan Phase 9 reshapes them to `config.schema`
++ `config.secrets` later.
 
-- [ ] **Step E: Add `README.md`**
+- [ ] **Step D: Tests**
 
-At minimum: plugin name, description, installation, configuration table (if any),
-permissions, capabilities.
+Ensure `index.test.ts` exists. Use `makeCtx()` from the Spec 3 scaffold
+template. At minimum: metadata + setup smoke test.
 
-- [ ] **Step F: Run `kaizen plugin validate plugins/<name>`**
+- [ ] **Step E: README**
 
-Fix any validation errors before moving to the next plugin.
+Plugin name, description, config table (if any), permissions,
+capabilities (provides/consumes).
 
----
+- [ ] **Step F: Validate**
 
-## Phase 3 — Migrate Harnesses
-
-### Task 3: Copy harness files
-
-- [ ] **Step 1: Copy `harnesses/core-anthropic/kaizen.json` → `harnesses/core-anthropic.json`**
-
-Flatten from `harnesses/<name>/kaizen.json` to `harnesses/<name>.json` in the new
-repo (a harness is a single file, not a directory).
-
-- [ ] **Step 2: Copy `harnesses/core-debug.json` and `harnesses/core-shell.json`**
-
-Same pattern.
-
-- [ ] **Step 3: Update plugin refs in harnesses**
-
-Harness files should use canonical refs. For built-in plugins that remain compiled
-into the binary, bare names (`"core-events"`) are fine. Once Spec 1 is shipped,
-harnesses in the marketplace repo can optionally use fully-qualified refs
-(`"official/core-events@2.0.0"`).
+```bash
+kaizen plugin validate plugins/<name>
+```
+Fix errors before moving to the next plugin.
 
 ---
 
-## Phase 4 — Write Official Marketplace Catalog
+## Phase 4 — Migrate Harnesses
 
-### Task 4: Write `.kaizen/marketplace.json`
+### Task 4: Copy and rewrite harness files
 
-- [ ] **Step 1: Add all migrated plugins to the catalog**
+- [ ] **Step 1: Copy harness files to `harnesses/*.json`**
 
-For each plugin in Phase 2, add an entry:
+Flatten `harnesses/<name>/kaizen.json` → `harnesses/<name>.json` if the
+source uses the directory form.
 
+- [ ] **Step 2: Rewrite plugin refs to canonical form**
+
+In each harness file, every plugin ref becomes
+`official/<name>@<version>`:
 ```json
 {
+  "plugins": [
+    "official/core-events@0.1.0",
+    "official/core-lifecycle@0.1.0",
+    "official/core-ui-terminal@0.1.0",
+    "official/core-executor-anthropic@0.1.0"
+  ]
+}
+```
+
+No bare names in shipped harnesses.
+
+- [ ] **Step 3: Validate**
+
+Harness JSON schema check; refs resolve against the catalog written in
+Phase 5.
+
+---
+
+## Phase 5 — Write Official Catalog
+
+### Task 5: Populate `.kaizen/marketplace.json`
+
+- [ ] **Step 1: Plugin entries**
+
+For each migrated plugin:
+```json
+{
+  "kind": "plugin",
   "name": "core-events",
   "description": "Default event vocabulary for kaizen sessions.",
   "categories": ["core"],
   "versions": [
     {
       "version": "0.1.0",
-      "source": { "type": "file", "path": "plugins/core-events" }
+      "source": { "type": "file", "path": "plugins/core-events" },
+      "minKaizenVersion": "<current-kaizen-version>"
     }
   ]
 }
 ```
 
-Initially use `file` sources (the plugins live in this repo). Once plugins are
-published to npm separately, switch entries to `npm` sources.
+Pick `<current-kaizen-version>` as the kaizen version that first ships
+with the loader live (i.e. the release that merges Spec 1's plan). Bare
+semver; no range operators.
 
-- [ ] **Step 2: Add harness entries**
+- [ ] **Step 2: Harness entries**
 
 ```json
 {
+  "kind": "harness",
   "name": "core-anthropic",
   "description": "Default Anthropic LLM harness.",
   "categories": ["harness"],
   "versions": [
-    { "version": "1.0.0", "path": "harnesses/core-anthropic.json" }
-  ]
-}
-```
-
-- [ ] **Step 3: Run `kaizen marketplace validate .`**
-
-Fix any validation errors.
-
----
-
-## Phase 5 — Update Build in Main Repo
-
-### Task 5: Update kaizen build to use new repo
-
-- [ ] **Step 1: Add `kaizen-plugins` as a dependency or workspace**
-
-In the main kaizen repo's `package.json`:
-```json
-{
-  "workspaces": ["plugins/*"]
-}
-```
-
-Point workspace entries at the new repo via git dependency or by checking it out
-as a sibling directory in CI:
-```json
-{
-  "dependencies": {
-    "core-events": "github:kaizen-sh/kaizen-plugins#HEAD:plugins/core-events"
-  }
-}
-```
-
-Or (simpler for development): keep `plugins/*` as local workspace entries that
-are symlinked to the checked-out `kaizen-plugins` repo during development.
-
-- [ ] **Step 2: Verify `bun build --compile` still works**
-
-Run the full binary build. Confirm all static imports in `src/cli.ts` resolve.
-
-- [ ] **Step 3: Update `src/cli.ts` static imports if needed**
-
-If import paths change (e.g., from workspace-relative to package name), update.
-
----
-
-## Phase 6 — Official Marketplace Bootstrap in `kaizen init`
-
-### Task 6: Pre-add official marketplace in new installs
-
-- [ ] **Step 1: Update `kaizen init --global`**
-
-When creating `~/.kaizen/kaizen.json`, pre-populate the `marketplaces` array:
-
-```json
-{
-  "marketplaces": [
     {
-      "id": "official",
-      "url": "https://github.com/kaizen-sh/kaizen-plugins.git"
+      "version": "1.0.0",
+      "path": "harnesses/core-anthropic.json",
+      "minKaizenVersion": "<current-kaizen-version>"
     }
   ]
 }
 ```
 
-- [ ] **Step 2: Run `kaizen marketplace update official` in `kaizen init --global`**
+- [ ] **Step 3: Validate**
 
-Fetches the catalog on first install so `kaizen marketplace browse` works immediately.
+```bash
+kaizen marketplace validate .
+```
+
+Check: names unique across kinds, every version has `minKaizenVersion`,
+harness paths resolve.
 
 ---
 
-## Phase 7 — Remove Old `plugins/` from Main Repo
+## Phase 6 — Remove Embedding from kaizen-code
 
-### Task 7: Cleanup (do last, after build verified)
+**Prerequisite check:** Spec 1's plan tasks delivering the dynamic loader
+(`src/core/plugin-loader.ts`) and the `src/cli.ts` wiring must be merged.
+Confirm by inspecting `src/cli.ts` — it should already be loading plugins
+from installed marketplaces; static imports should be redundant.
 
-- [ ] **Step 1: Verify build and all tests pass with new repo**
+### Task 6: Delete static plugin imports
 
-Run full test suite from a clean checkout. No references to old `plugins/` paths.
+- [ ] **Step 1: Remove `import <plugin> from "<plugin>"` lines in `src/cli.ts`**
 
-- [ ] **Step 2: Delete `plugins/` directory from main kaizen repo**
+Delete every static plugin import. Delete any hard-coded
+`builtinPlugins = [...]` array or equivalent.
+
+- [ ] **Step 2: Remove the embedded-vs-installed branch in the resolver**
+
+Any code that distinguished "embedded" (workspace/static) from
+"installed" (marketplace) plugins collapses into the installed-only
+path.
+
+- [ ] **Step 3: Delete `plugins/` directory**
 
 ```bash
 git rm -r plugins/
 ```
 
-- [ ] **Step 3: Delete `harnesses/` directory from main kaizen repo** (if harnesses
-  migrated fully to new repo and no longer needed here).
+- [ ] **Step 4: Delete `harnesses/` directory**
 
-- [ ] **Step 4: Update `docs/architecture.md`**
+```bash
+git rm -r harnesses/
+```
 
-Change "Directory structure" section:
-- Remove `plugins/` entry.
-- Add reference to `kaizen-sh/kaizen-plugins` repo.
-- Update plugin resolution order to mention official marketplace.
+- [ ] **Step 5: Remove `plugins/*` workspace entries from root `package.json`**
 
-- [ ] **Step 5: Update `docs/plugin-loading.md`**
+- [ ] **Step 6: Build and smoke test**
 
-Update "Development workflow for plugin authors" to reference the new repo as the
-reference implementation.
+```bash
+bun install
+bun build --compile
+```
 
-- [ ] **Step 6: Update `docs/plugin-api.md`**
+Against an empty `~/.kaizen/`, the binary must produce the documented
+first-run error (no marketplaces / no harness), not a silent boot.
 
-Change import examples from relative paths to `kaizen/types`.
+### Task 7: Inline test fixtures
+
+- [ ] **Step 1: Create `test/fixtures/plugins/*`**
+
+Minimal plugins exercising: event emit/consume, capability provides/consumes,
+setup/teardown, session wiring. Each fixture is a single file with
+metadata + trivial logic.
+
+- [ ] **Step 2: Test-only fixture marketplace**
+
+Unit tests set up a temporary `~/.kaizen/` (or a test-scoped config dir),
+add a file-URL marketplace pointing at `test/fixtures/plugins`, and
+install the fixtures through the standard path.
+
+- [ ] **Step 3: Rewrite existing unit tests that imported plugin modules
+  directly**
+
+Any test that did `import coreEvents from "core-events"` or
+`import { X } from "../../plugins/core-events"` switches to the fixture
+approach.
+
+### Task 8: Integration tests against real `kaizen-plugins`
+
+- [ ] **Step 1: Pinning strategy**
+
+CI checks out `kaizen-sh/kaizen-plugins` at a pinned SHA (tracked in a
+file under `test/integration/pinned-plugins-sha`). Bump the SHA
+deliberately.
+
+- [ ] **Step 2: Integration harness setup**
+
+Before running integration tests, CI seeds a test `~/.kaizen/` with a
+`file://` marketplace at the checkout and installs the needed plugins +
+harness.
+
+- [ ] **Step 3: E2E smoke test**
+
+Boot kaizen with the full official harness; run a short session; assert
+no errors, expected events fire.
+
+### Task 9: Dev-setup helper script
+
+- [ ] **Step 1: `scripts/dev-setup.sh`**
+
+Idempotent script that:
+1. Checks for a sibling `../kaizen-plugins` checkout; prints clone
+   instructions if missing.
+2. Adds a `dev` marketplace pointing at the checkout (if absent).
+3. Installs the default set of plugins + a harness.
+
+The script uses only the public `kaizen marketplace` and `kaizen install`
+commands. No dev-only code path in the binary.
+
+- [ ] **Step 2: Document in CONTRIBUTING.md**
+
+Short section: "Running kaizen from source." Cover clone, dev-setup,
+`kaizen run`.
 
 ---
 
-## Phase 8 — Documentation
+## Phase 7 — Documentation
 
-### Task 8: Docs
+### Task 10: Update kaizen-code docs
 
-- [ ] **Step 1: Write `docs/contributing-plugins.md`**
+- [ ] **Step 1: `docs/architecture.md`**
+
+Remove "Directory structure: plugins/" section. Add: "Plugins live in
+`kaizen-sh/kaizen-plugins` and are installed via the marketplace." Update
+plugin resolution order — there is now one path: marketplace install.
+
+- [ ] **Step 2: `docs/plugin-loading.md`**
+
+Rewrite around marketplace-only loading. Remove any "embedded plugins"
+sections. Describe the loader flow: harness → ref → install-dir →
+dynamic import.
+
+- [ ] **Step 3: `docs/plugin-api.md`**
+
+Import examples use `kaizen/types`. Remove references to relative
+imports into `../../src/`.
+
+- [ ] **Step 4: New `docs/contributing-plugins.md`**
 
 Guide for contributing to `kaizen-sh/kaizen-plugins`:
-- How to add a new plugin (copy scaffold, add to catalog, open PR).
-- Standards requirements (link to `docs/plugin-standards.md`).
-- How to publish a plugin to npm (future — note it's not required; `file` sources work).
-- How to add a harness.
+- Scaffold a plugin (link Spec 3).
+- Add the plugin to `.kaizen/marketplace.json`.
+- Open a PR.
+- Standards link.
+- Adding a harness (same shape).
 
-- [ ] **Step 2: Update `README.md`**
+- [ ] **Step 5: Update `README.md` in kaizen-code**
 
-Add official marketplace to the "Installation and discovery" section.
-Update the built-in plugin list to reflect they're now in `kaizen-sh/kaizen-plugins`.
+Note: binary ships with no plugins; installer seeds the official
+marketplace; from-source contributors use `scripts/dev-setup.sh`.
+
+---
+
+## Phase 8 — Release Coordination
+
+### Task 11: Coordinate cut with installer work
+
+- [ ] **Step 1: Notify installer owners**
+
+Signal to the installer/packaging layer that a kaizen release without
+embedded plugins is coming. They are responsible for the first-run
+experience: pre-seed `official` marketplace, pre-install a default
+plugin set, install a default harness. Out of scope here, but the cut
+must not land in a user-facing release before installers are ready.
+
+- [ ] **Step 2: Pre-release check**
+
+Before tagging the kaizen-code release that drops embedding, verify:
+- `kaizen-plugins` repo has a tagged release whose catalog `minKaizenVersion`
+  ≤ the upcoming kaizen version.
+- An installer path exists that a user can follow to a working first run.
+
+- [ ] **Step 3: Release**
+
+Tag, release, communicate. Installer teams flip their seeding to the
+new catalog on their own cadence.
+
+---
+
+## Rollback
+
+If the release-without-embedding surfaces a blocking issue:
+
+1. Revert Task 6 commits in `kaizen-code` (restores static imports and
+   `plugins/` directory).
+2. Re-tag the prior-behavior release.
+3. `kaizen-plugins` repo is unaffected — it remains the source of truth
+   for plugin source; the next attempt re-applies Task 6 after the fix.
+
+No database or on-disk state migration is involved; rollback is
+source-level only.

--- a/docs/superpowers/plans/2026-04-18-plugin-marketplace.md
+++ b/docs/superpowers/plans/2026-04-18-plugin-marketplace.md
@@ -1,0 +1,386 @@
+# Plugin Marketplace, Kaizen-Level Config & Install Rework — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement federated marketplaces, polymorphic plugin refs, portable
+harness bootstrap, and a unified install CLI. After this plan, `kaizen marketplace
+add <url>` adds a catalog, `kaizen install official/timestamps@1.0.0` installs from
+it, and `kaizen --harness <url>` bootstraps missing plugins automatically.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md`
+
+**Tech Stack:** TypeScript, Bun, existing `src/core/` infrastructure,
+`src/commands/` pattern.
+
+**Prerequisites:** None (this is the first-domino spec).
+
+---
+
+## File Structure
+
+**New files:**
+- `src/core/marketplace.ts` — kaizen-level config I/O + catalog fetch/cache
+- `src/core/marketplace.test.ts`
+- `src/core/ref-resolver.ts` — plugin ref parser + resolver
+- `src/core/ref-resolver.test.ts`
+- `src/commands/marketplace.ts` — add/list/remove/update/browse subcommands
+- `src/commands/uninstall.ts` — unified uninstall
+- `src/commands/update.ts` — unified update
+
+**Modified files:**
+- `src/types/plugin.ts` — add `MarketplaceRef`, `MarketplaceCatalog`, `PluginSource` types; extend harness `KaizenConfig` with `marketplaces` field
+- `src/commands/install.ts` — rework to use ref resolver; deprecate old path
+- `src/commands/manage.ts` — deprecation notices on `cmdPluginInstall`/`cmdPluginRemove`
+- `src/cli.ts` — wire new subcommands; extend `--harness` bootstrap
+
+---
+
+## Phase 1 — Types & Catalog Schema
+
+### Task 1: Define marketplace types
+
+**Files:** `src/types/plugin.ts`
+
+- [ ] **Step 1: Add `PluginSource` union type**
+
+```typescript
+export type PluginSource =
+  | { type: "npm";     name: string;  version: string }
+  | { type: "git";     url: string;   ref: string }
+  | { type: "tarball"; url: string;   sha256?: string }
+  | { type: "file";    path: string };
+```
+
+- [ ] **Step 2: Add `MarketplacePluginEntry`, `MarketplaceHarnessEntry`, `MarketplaceCatalog`**
+
+```typescript
+export interface PluginVersionEntry {
+  version: string;
+  source: PluginSource;
+  changelog?: string;
+  minKaizenVersion?: string;
+}
+
+export interface HarnessVersionEntry {
+  version: string;
+  path: string;
+  changelog?: string;
+}
+
+export interface MarketplacePluginEntry {
+  name: string;
+  description: string;
+  categories?: string[];
+  versions: PluginVersionEntry[];
+}
+
+export interface MarketplaceHarnessEntry {
+  name: string;
+  description: string;
+  categories?: string[];
+  versions: HarnessVersionEntry[];
+}
+
+export interface MarketplaceCatalog {
+  version: "1.0.0";
+  name: string;
+  description?: string;
+  url: string;
+  signature?: string;
+  plugins: MarketplacePluginEntry[];
+  harnesses: MarketplaceHarnessEntry[];
+}
+```
+
+- [ ] **Step 3: Add `MarketplaceRef` and extend global config**
+
+```typescript
+export interface MarketplaceRef {
+  id: string;
+  url: string;
+  updatedAt?: string;
+}
+
+export interface KaizenGlobalConfig {
+  marketplaces?: MarketplaceRef[];
+  defaultHarness?: string;
+  defaults?: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 4: Extend the harness config type to allow `marketplaces` field**
+
+In `src/core/config.ts`, extend the harness config shape to allow an optional
+`marketplaces: MarketplaceRef[]` field.
+
+---
+
+## Phase 2 — Ref Parser
+
+### Task 2: Implement `src/core/ref-resolver.ts`
+
+- [ ] **Step 1: Define `ParsedRef` discriminated union**
+
+```typescript
+export type ParsedRef =
+  | { kind: "marketplace"; id: string;  name: string; version?: string }
+  | { kind: "shorthand";               name: string; version?: string }
+  | { kind: "local";       path: string }
+  | { kind: "url";         url: string }
+  | { kind: "npm";         name: string; version?: string };
+```
+
+- [ ] **Step 2: Implement `parseRef(ref: string): ParsedRef`**
+
+Detection rules (in order):
+1. Starts with `./` or `/` → `local`
+2. Starts with `https://` or `http://` → `url`
+3. Contains `/` and does not look like a scoped npm package (`@scope/name`) →
+   split on first `/`, left is `id`, right is `name@version` → `marketplace`
+4. No `/` → check for `@version` suffix → `shorthand` (may be npm name without `/`)
+
+- [ ] **Step 3: Implement `resolveRef(parsed, marketplaces, catalogs): ResolvedSource`**
+
+```typescript
+export interface ResolvedSource {
+  source: PluginSource;
+  marketplaceId?: string;
+  pluginName: string;
+  version: string;
+}
+```
+
+Resolution logic:
+- `marketplace`: look up `id` in `catalogs`, find entry by `name`, resolve version
+  (latest if not specified, exact if specified). Throw `MarketplaceNotFoundError` or
+  `PluginNotFoundError` as appropriate.
+- `shorthand`: search all catalogs. If zero matches: try as npm package. If one match:
+  return it. If multiple matches: throw `RefConflictError` listing the marketplaces.
+- `local`: return `{ type: "file", path: ... }`.
+- `url`: return `{ type: "tarball", url: ... }`.
+- `npm`: return `{ type: "npm", name, version: version ?? "latest" }`.
+
+- [ ] **Step 4: Write `src/core/ref-resolver.test.ts`**
+
+Tests:
+- `parseRef` for each form including edge cases (`@scope/pkg`, `market/name@1.0`,
+  bare name, `./path`, absolute path, HTTPS URL).
+- `resolveRef` marketplace found, not found, ambiguous shorthand, local, URL, npm.
+
+---
+
+## Phase 3 — Marketplace Config & Catalog I/O
+
+### Task 3: Implement `src/core/marketplace.ts`
+
+- [ ] **Step 1: `loadGlobalConfig()` and `saveGlobalConfig()`**
+
+Read/write `~/.kaizen/kaizen.json`. Handle file-not-found (return empty config).
+
+- [ ] **Step 2: `fetchCatalog(url: string): Promise<MarketplaceCatalog>`**
+
+Detection:
+- Local path (starts with `./`, `/`, or `file://`): read `.kaizen/marketplace.json`
+  from the directory.
+- Git URL (ends in `.git` or matches GitHub URL pattern): use GitHub raw content API
+  (`https://raw.githubusercontent.com/<user>/<repo>/HEAD/.kaizen/marketplace.json`)
+  for HTTPS GitHub URLs. For other git URLs, fall back to `git archive` subprocess
+  call: `git archive --remote=<url> HEAD .kaizen/marketplace.json`.
+- Validate result against `MarketplaceCatalog` schema (Zod or manual).
+- Throw descriptive errors for network failures, missing file, schema errors.
+
+- [ ] **Step 3: `getCachedCatalog(id)` and `writeCachedCatalog(id, catalog)`**
+
+Cache path: `~/.kaizen/marketplaces/<id>/marketplace.json`. Create dirs as needed.
+
+- [ ] **Step 4: Write `src/core/marketplace.test.ts`**
+
+Mock filesystem + HTTP. Test: fetch from local path, fetch from GitHub URL, cache
+read/write, invalid schema, file not found.
+
+---
+
+## Phase 4 — `kaizen marketplace` Commands
+
+### Task 4: Implement `src/commands/marketplace.ts`
+
+- [ ] **Step 1: `cmdMarketplaceAdd(url, idOverride?)`**
+
+1. Derive `id` from URL basename if no override.
+2. Check `id` not already in global config (warn if updating).
+3. Call `fetchCatalog(url)`.
+4. Call `writeCachedCatalog(id, catalog)`.
+5. Update `loadGlobalConfig()`, push `{ id, url, updatedAt }`, `saveGlobalConfig()`.
+6. Print: `Added marketplace 'official' (42 plugins, 3 harnesses).`
+
+- [ ] **Step 2: `cmdMarketplaceList()`**
+
+Load global config, read each cached catalog, print table:
+```
+  ID        PLUGINS  HARNESSES  UPDATED
+  official       42          3  2026-04-18
+  my-internal    12          1  2026-04-17
+```
+
+- [ ] **Step 3: `cmdMarketplaceRemove(id)`**
+
+Remove from global config, delete `~/.kaizen/marketplaces/<id>/`. Confirm if
+`--force` not set.
+
+- [ ] **Step 4: `cmdMarketplaceUpdate(id?)`**
+
+Re-fetch for one or all marketplaces. Print diff of plugin/harness count.
+
+- [ ] **Step 5: `cmdMarketplaceBrowse(id?)`**
+
+Print all plugin entries (from cached catalog) in a table. Filter by `id` if given.
+v1: stdout only.
+
+---
+
+## Phase 5 — Unified Install
+
+### Task 5: Rework `src/commands/install.ts`
+
+- [ ] **Step 1: Replace `runInstall` with `runUnifiedInstall(ref, opts)`**
+
+```typescript
+interface InstallOpts {
+  lockfilePath: string;
+  allowUnscoped: boolean;
+  nonInteractive: boolean;
+  ephemeral?: boolean;   // install to cache instead of node_modules
+}
+```
+
+Flow:
+1. Load global config + all cached catalogs.
+2. `parseRef(ref)` → `resolveRef(parsed, marketplaces, catalogs)` → `ResolvedSource`.
+3. Fetch plugin source to a temp dir (npm install, git clone, HTTP fetch, or local
+   path as-is).
+4. Read `KaizenPlugin` default export from the fetched source.
+5. Run existing consent flow (`runInstall` internals — reuse or inline).
+6. Install: if `ephemeral`, copy to `~/.kaizen/cache/<hash>/`; else npm install to
+   `~/.kaizen/node_modules/`.
+7. Write lockfile entry.
+8. If project config exists and not ephemeral: add canonical ref to `plugins` array
+   in `.kaizen/kaizen.json`.
+
+- [ ] **Step 2: Deprecation shims in `src/commands/manage.ts`**
+
+`cmdPluginInstall` prints:
+```
+Note: 'kaizen plugin install' is deprecated. Use 'kaizen install <ref>' instead.
+```
+Then delegates to `runUnifiedInstall`.
+
+---
+
+## Phase 6 — Uninstall & Update
+
+### Task 6: `src/commands/uninstall.ts`
+
+- [ ] **Step 1: `runUninstall(name, opts: { purge: boolean })`**
+
+1. Remove from `.kaizen/kaizen.json` plugins array (if present).
+2. If `--purge`: npm uninstall from `~/.kaizen/node_modules/`; delete lockfile entry.
+3. Print result.
+
+### Task 7: `src/commands/update.ts`
+
+- [ ] **Step 1: `runUpdate(ref?, opts)`**
+
+1. If no ref: update all plugins in `.kaizen/kaizen.json`.
+2. Resolve current version from lockfile.
+3. Resolve latest available from catalog or npm.
+4. If version changed: re-run consent flow, install, update lockfile.
+5. If tier/grants unchanged and only version changed: silent update.
+
+---
+
+## Phase 7 — Harness Bootstrap
+
+### Task 8: Bootstrap-on-startup in `src/cli.ts`
+
+- [ ] **Step 1: Extend `--harness` arg to accept marketplace ref and URL**
+
+Current: only file path. New: detect form, fetch if URL/marketplace ref.
+
+- [ ] **Step 2: Implement `bootstrapMissingPlugins(harnessConfig, opts)`**
+
+```
+For each plugin ref in harnessConfig.plugins:
+  1. Check if already installed (existing isInstalled() check).
+  2. If not installed:
+     a. Resolve ref.
+     b. Run consent flow (skip if --trust-lockfile covers it).
+     c. Install (to node_modules if interactive, cache if ephemeral URL harness).
+  3. Continue to next plugin.
+```
+
+If any consent is denied: fatal with a summary of what was denied.
+If `--non-interactive --trust-lockfile`: fail fast if any plugin missing from lockfile.
+
+- [ ] **Step 3: Temporary marketplace registration from harness `marketplaces` section**
+
+If harness has a `marketplaces` array, register each entry temporarily (in-memory)
+for this run. Do not write to `~/.kaizen/kaizen.json`.
+
+---
+
+## Phase 8 — Wire CLI
+
+### Task 9: Update `src/cli.ts`
+
+- [ ] **Step 1: Add `kaizen marketplace` subcommand routing**
+
+```typescript
+if (subcommand === "marketplace") {
+  const sub = rawArgs[1];
+  // route to cmdMarketplaceAdd / List / Remove / Update / Browse
+}
+```
+
+- [ ] **Step 2: Add `kaizen uninstall <ref>` routing**
+
+- [ ] **Step 3: Add `kaizen update [<ref>]` routing**
+
+- [ ] **Step 4: Update `kaizen install` routing** to use `runUnifiedInstall`.
+
+- [ ] **Step 5: Update `kaizen --harness` path** to call `bootstrapMissingPlugins`
+before `bootstrap(kaizenConfig, builtins)`.
+
+---
+
+## Phase 9 — Tests & Integration
+
+### Task 10: Integration tests
+
+- [ ] **Step 1: End-to-end: local marketplace**
+
+Create a temp local marketplace dir with a `file`-source plugin. Run:
+1. `kaizen marketplace add <dir>` — catalog loaded.
+2. `kaizen install local-market/test-plugin` — plugin installed, lockfile written.
+3. `kaizen marketplace list` — shows the marketplace.
+4. `kaizen uninstall test-plugin --purge` — plugin removed.
+
+- [ ] **Step 2: Backward compatibility**
+
+Existing harness file with `"plugins": ["core-events", "core-executor-anthropic"]`
+(bare npm names) loads without modification. Verify no errors or deprecation noise.
+
+- [ ] **Step 3: Bootstrap test**
+
+Write a harness JSON referencing a local marketplace plugin. Run `kaizen --harness
+<file>` with missing plugin — bootstrap triggers consent + install, then kaizen starts.
+
+---
+
+## Phase 10 — Docs
+
+### Task 11: Documentation updates
+
+- [ ] Update `docs/architecture.md` — kaizen-level config, marketplace resolution in
+  plugin resolution order.
+- [ ] Update `README.md` — add `kaizen marketplace` to commands reference.
+- [ ] Add marketplace section to `docs/plugin-api.md` — "Installing from a marketplace".

--- a/docs/superpowers/plans/2026-04-18-plugin-marketplace.md
+++ b/docs/superpowers/plans/2026-04-18-plugin-marketplace.md
@@ -2,58 +2,177 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Implement federated marketplaces, polymorphic plugin refs, portable
-harness bootstrap, and a unified install CLI. After this plan, `kaizen marketplace
-add <url>` adds a catalog, `kaizen install official/timestamps@1.0.0` installs from
-it, and `kaizen --harness <url>` bootstraps missing plugins automatically.
+**Goal:** Implement federated git-backed marketplaces, marketplace-scoped plugin refs,
+a unified install tree under `~/.kaizen/marketplaces/<id>/`, portable harness
+bootstrap, and a unified `kaizen install|uninstall|update|marketplace` CLI surface.
+After this plan, `kaizen marketplace add <git-url>` registers a catalog,
+`kaizen install official/timestamps@1.2.3` installs from it by absolute path (no
+`node_modules` for third-party plugins), and `kaizen --harness <file|ref>`
+auto-bootstraps missing marketplaces + plugins.
 
 **Spec:** `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md`
 
-**Tech Stack:** TypeScript, Bun, existing `src/core/` infrastructure,
-`src/commands/` pattern.
+**Architecture:** New `src/core/kaizen-config.ts` owns the whole `~/.kaizen/` tree
+(paths + global config I/O). `src/core/marketplace.ts` owns git clone/pull +
+catalog read/validate. `src/core/ref-resolver.ts` parses/resolves refs.
+`src/core/plugin-installer.ts` materializes plugin bits into
+`marketplaces/<id>/plugins/<name>@<ver>/`. `src/core/plugin-loader.ts` imports
+marketplace plugins by absolute path. `src/core/bootstrap.ts` closes the loop
+for `--harness`.
 
-**Prerequisites:** None (this is the first-domino spec).
+**Tech Stack:** TypeScript, Bun, Node `child_process` (`git`), Bun `$` shell,
+existing `src/core/` infrastructure (lockfile, consent-flow, plugin-hash).
+
+**Prerequisites:** None — this is the first-domino spec; Specs 2–4 depend on it.
 
 ---
 
 ## File Structure
 
 **New files:**
-- `src/core/marketplace.ts` — kaizen-level config I/O + catalog fetch/cache
+
+- `src/core/kaizen-config.ts` — path helpers, `ensureKaizenHome()`,
+  load/save of `~/.kaizen/kaizen.json`
+- `src/core/kaizen-config.test.ts`
+- `src/core/marketplace.ts` — `addMarketplace`, `pullMarketplace`,
+  `readCatalog`, `validateCatalog`, background refresh helpers
 - `src/core/marketplace.test.ts`
-- `src/core/ref-resolver.ts` — plugin ref parser + resolver
+- `src/core/ref-resolver.ts` — `parseRef`, `resolveRef`
 - `src/core/ref-resolver.test.ts`
-- `src/commands/marketplace.ts` — add/list/remove/update/browse subcommands
-- `src/commands/uninstall.ts` — unified uninstall
-- `src/commands/update.ts` — unified update
+- `src/core/plugin-installer.ts` — materializes plugin bits; dispatches by
+  source type (`npm` / `tarball` / `file`); also installs harnesses
+- `src/core/plugin-installer.test.ts`
+- `src/core/plugin-loader.ts` — `loadPluginFromInstallDir` (absolute-path import)
+- `src/core/plugin-loader.test.ts`
+- `src/core/bootstrap.ts` — `bootstrapMissingPlugins`
+- `src/core/bootstrap.test.ts`
+- `src/commands/marketplace.ts` — `add|list|remove|update|browse`
+- `src/commands/uninstall.ts`
+- `src/commands/update.ts`
+- `tests/integration/marketplace.integration.test.ts` — end-to-end with a
+  real local git repo fixture
 
 **Modified files:**
-- `src/types/plugin.ts` — add `MarketplaceRef`, `MarketplaceCatalog`, `PluginSource` types; extend harness `KaizenConfig` with `marketplaces` field
-- `src/commands/install.ts` — rework to use ref resolver; deprecate old path
-- `src/commands/manage.ts` — deprecation notices on `cmdPluginInstall`/`cmdPluginRemove`
-- `src/cli.ts` — wire new subcommands; extend `--harness` bootstrap
+
+- `src/types/plugin.ts` — add marketplace/catalog/ref/global-config types;
+  extend `KaizenConfig` harness schema with optional `marketplaces`
+- `src/core/config.ts` — retire direct `KAIZEN_HOME*` use where superseded by
+  `kaizen-config.ts`; keep `loadHarnessConfig` but route home-harness lookup
+  through new path helper `harnessInstallDir`
+- `src/core/plugin-hash.ts` — add `canonicalTierGrantHash(permissions, tier)`
+- `src/core/plugin-manager.ts` — add `isInstalled(marketplaceId, name, version)`;
+  include marketplace install dirs in the plugin import resolution path
+- `src/commands/install.ts` — rework to unified `runUnifiedInstall(ref, opts)`
+- `src/commands/manage.ts` — deprecation shims on `cmdPluginInstall` /
+  `cmdPluginRemove`; legacy `kaizen-plugin-*` auto-resolves against `official`
+- `src/cli.ts` — wire `marketplace`, `uninstall`, `update`; extend `--harness`
+  to accept file-path or marketplace-ref (reject raw URLs); add
+  `--trust-lockfile` and `--non-interactive`; background refresh on first invocation
 
 ---
 
-## Phase 1 — Types & Catalog Schema
+## Conventions used throughout this plan
 
-### Task 1: Define marketplace types
+- **Commit cadence:** each task ends with a single commit. Commit message format:
+  `feat(marketplace): <what>` or `test(marketplace): <what>` — no Co-Authored-By.
+- **TDD:** write the failing test first, run it, write minimal code to pass,
+  run again, commit. Plan steps below enforce this explicitly.
+- **Imports:** all path math goes through `kaizen-config.ts` after Task 2 —
+  never hardcode `~/.kaizen/...` or concatenate `"/plugins/"` manually.
+- **Git subprocess:** use `Bun.spawn` (or the existing pattern used in
+  `src/core/plugin-manager.ts` for `bun pm ls --global`) with a 60s timeout.
+- **Fixtures:** tests that need a real marketplace create a temp-dir git repo
+  with `git init -q && git add . && git commit -qm init`. Use `Bun.$`:
+  ```ts
+  import { $ } from "bun";
+  await $`git init -q`.cwd(dir);
+  await $`git add .`.cwd(dir);
+  await $`git -c user.email=t@t -c user.name=t commit -qm init`.cwd(dir);
+  ```
 
-**Files:** `src/types/plugin.ts`
+---
 
-- [ ] **Step 1: Add `PluginSource` union type**
+## Phase 1 — Types, Global Config, Hash Helper
 
-```typescript
-export type PluginSource =
-  | { type: "npm";     name: string;  version: string }
-  | { type: "git";     url: string;   ref: string }
-  | { type: "tarball"; url: string;   sha256?: string }
-  | { type: "file";    path: string };
+### Task 1: Marketplace / catalog / ref / global-config types
+
+**Files:**
+- Modify: `src/types/plugin.ts`
+
+- [ ] **Step 1: Write failing test `src/types/plugin.test.ts`**
+
+Create the file (new) that just type-checks usage of the new types. Kaizen
+has no existing `plugin.test.ts`; this acts as a compile-time fixture.
+
+```ts
+import { describe, it, expect } from "bun:test";
+import type {
+  PluginSource, MarketplaceEntry, MarketplaceCatalog,
+  MarketplaceRef, KaizenGlobalConfig, KaizenConfig,
+} from "./plugin.js";
+
+describe("marketplace types", () => {
+  it("accepts a catalog with plugin + harness entries", () => {
+    const cat: MarketplaceCatalog = {
+      version: "1.0.0",
+      name: "Official",
+      url: "https://github.com/kaizen-sh/kaizen-plugins.git",
+      entries: [
+        {
+          kind: "plugin",
+          name: "timestamps",
+          description: "time tools",
+          versions: [{ version: "1.2.3", source: { type: "file", path: "plugins/timestamps" } }],
+        },
+        {
+          kind: "harness",
+          name: "anthropic-default",
+          description: "default harness",
+          versions: [{ version: "1.0.0", path: "harnesses/anthropic.json" }],
+        },
+      ],
+    };
+    expect(cat.entries.length).toBe(2);
+  });
+
+  it("accepts a global config with marketplaces", () => {
+    const g: KaizenGlobalConfig = {
+      marketplaces: [{ id: "official", url: "https://…", updatedAt: "2026-04-18T00:00:00Z" }],
+      marketplaceUpdateTTL: 900,
+    };
+    expect(g.marketplaces?.[0]?.id).toBe("official");
+  });
+
+  it("accepts a harness config with marketplaces slice", () => {
+    const h: KaizenConfig = {
+      plugins: ["official/timestamps@1.2.3"],
+      marketplaces: [{ id: "official", url: "https://…" }],
+    };
+    expect(h.plugins.length).toBe(1);
+  });
+});
 ```
 
-- [ ] **Step 2: Add `MarketplacePluginEntry`, `MarketplaceHarnessEntry`, `MarketplaceCatalog`**
+- [ ] **Step 2: Run the test — expect compile failures**
 
-```typescript
+Run: `bun test src/types/plugin.test.ts`
+Expected: type errors for `PluginSource`, `MarketplaceEntry`, `MarketplaceCatalog`,
+`MarketplaceRef`, `KaizenGlobalConfig`, and `KaizenConfig.marketplaces`.
+
+- [ ] **Step 3: Add types to `src/types/plugin.ts`**
+
+Append at the bottom of the file (after `PluginManagerLifecycleApi`):
+
+```ts
+// ---------------------------------------------------------------------------
+// Marketplace types (Spec 1)
+// ---------------------------------------------------------------------------
+
+export type PluginSource =
+  | { type: "npm";     name: string;  version: string }
+  | { type: "tarball"; url: string;   sha256?: string }
+  | { type: "file";    path: string };  // relative to marketplace repo root
+
 export interface PluginVersionEntry {
   version: string;
   source: PluginSource;
@@ -63,11 +182,13 @@ export interface PluginVersionEntry {
 
 export interface HarnessVersionEntry {
   version: string;
+  /** Path to harness JSON, relative to marketplace repo root. */
   path: string;
   changelog?: string;
 }
 
 export interface MarketplacePluginEntry {
+  kind: "plugin";
   name: string;
   description: string;
   categories?: string[];
@@ -75,312 +196,2394 @@ export interface MarketplacePluginEntry {
 }
 
 export interface MarketplaceHarnessEntry {
+  kind: "harness";
   name: string;
   description: string;
   categories?: string[];
   versions: HarnessVersionEntry[];
 }
 
+export type MarketplaceEntry = MarketplacePluginEntry | MarketplaceHarnessEntry;
+
 export interface MarketplaceCatalog {
   version: "1.0.0";
   name: string;
   description?: string;
   url: string;
-  signature?: string;
-  plugins: MarketplacePluginEntry[];
-  harnesses: MarketplaceHarnessEntry[];
+  signature?: string;              // reserved; unused in v1
+  entries: MarketplaceEntry[];
 }
-```
 
-- [ ] **Step 3: Add `MarketplaceRef` and extend global config**
-
-```typescript
 export interface MarketplaceRef {
   id: string;
-  url: string;
-  updatedAt?: string;
+  url: string;                     // git URL or absolute local dir
+  updatedAt?: string;              // ISO-8601
 }
 
 export interface KaizenGlobalConfig {
   marketplaces?: MarketplaceRef[];
   defaultHarness?: string;
-  defaults?: Record<string, unknown>;
+  defaults?: Record<string, unknown>;   // Spec 2 uses this
+  /** Seconds between background marketplace refreshes; 0 disables. Default 900. */
+  marketplaceUpdateTTL?: number;
 }
 ```
 
-- [ ] **Step 4: Extend the harness config type to allow `marketplaces` field**
+- [ ] **Step 4: Extend `KaizenConfig` (harness file type)**
 
-In `src/core/config.ts`, extend the harness config shape to allow an optional
-`marketplaces: MarketplaceRef[]` field.
+Edit `src/types/plugin.ts` `KaizenConfig`:
+
+```ts
+export interface KaizenConfig {
+  /** Canonical refs (`<marketplace>/<name>@<version>`) or legacy bare npm names. */
+  plugins: string[];
+  extends?: string;
+  /** Informational marketplaces a harness expects; consumed by --harness bootstrap. */
+  marketplaces?: MarketplaceRef[];
+  [pluginName: string]: unknown;
+}
+```
+
+- [ ] **Step 5: Run the test — verify pass**
+
+Run: `bun test src/types/plugin.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Run project typecheck**
+
+Run: `bun x tsc --noEmit`
+Expected: PASS (no regressions). If new type usage in existing code breaks,
+**do not fix cascading code yet** — note the file and address in the task that
+owns it (paths in config.ts, plugin-manager, etc.).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types/plugin.ts src/types/plugin.test.ts
+git commit -m "feat(marketplace): add catalog, ref, global-config, source types"
+```
 
 ---
 
-## Phase 2 — Ref Parser
+### Task 2: `src/core/kaizen-config.ts` — owns `~/.kaizen/` tree
 
-### Task 2: Implement `src/core/ref-resolver.ts`
+**Files:**
+- Create: `src/core/kaizen-config.ts`
+- Create: `src/core/kaizen-config.test.ts`
 
-- [ ] **Step 1: Define `ParsedRef` discriminated union**
+- [ ] **Step 1: Write failing tests**
 
-```typescript
+```ts
+// src/core/kaizen-config.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  kaizenHome, marketplacesDir, marketplaceDir, marketplaceRepoDir,
+  pluginInstallDir, harnessInstallDir,
+  ensureKaizenHome, loadKaizenGlobalConfig, saveKaizenGlobalConfig,
+} from "./kaizen-config.js";
+
+let home: string;
+let origHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kz-home-"));
+  origHome = process.env.KAIZEN_HOME_OVERRIDE;
+  process.env.KAIZEN_HOME_OVERRIDE = home;
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (origHome === undefined) delete process.env.KAIZEN_HOME_OVERRIDE;
+  else process.env.KAIZEN_HOME_OVERRIDE = origHome;
+});
+
+describe("kaizen-config path helpers", () => {
+  it("returns KAIZEN_HOME_OVERRIDE when set", () => {
+    expect(kaizenHome()).toBe(home);
+    expect(marketplacesDir()).toBe(join(home, "marketplaces"));
+    expect(marketplaceDir("official")).toBe(join(home, "marketplaces", "official"));
+    expect(marketplaceRepoDir("official")).toBe(join(home, "marketplaces", "official", "repo"));
+    expect(pluginInstallDir("official", "timestamps", "1.2.3"))
+      .toBe(join(home, "marketplaces", "official", "plugins", "timestamps@1.2.3"));
+    expect(harnessInstallDir("official", "anthropic-default"))
+      .toBe(join(home, "marketplaces", "official", "harnesses", "anthropic-default"));
+  });
+});
+
+describe("ensureKaizenHome", () => {
+  it("creates kaizen home and marketplaces dir, idempotent", async () => {
+    await ensureKaizenHome();
+    await ensureKaizenHome();
+    expect(existsSync(join(home, "marketplaces"))).toBe(true);
+  });
+});
+
+describe("load/saveKaizenGlobalConfig", () => {
+  it("returns {} when file absent", async () => {
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg).toEqual({});
+  });
+
+  it("round-trips a config atomically", async () => {
+    await saveKaizenGlobalConfig({
+      marketplaces: [{ id: "official", url: "https://x/y.git" }],
+      marketplaceUpdateTTL: 900,
+    });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.marketplaces?.[0]?.id).toBe("official");
+    expect(cfg.marketplaceUpdateTTL).toBe(900);
+  });
+
+  it("atomic write: no partial file if writer crashes mid-write", async () => {
+    await saveKaizenGlobalConfig({ marketplaces: [] });
+    const txt = readFileSync(join(home, "kaizen.json"), "utf8");
+    expect(() => JSON.parse(txt)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, expect failure**
+
+Run: `bun test src/core/kaizen-config.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `src/core/kaizen-config.ts`**
+
+```ts
+import { existsSync, readFileSync, mkdirSync, renameSync, writeFileSync, unlinkSync } from "fs";
+import { homedir } from "os";
+import { join, dirname } from "path";
+import type { KaizenGlobalConfig } from "../types/plugin.js";
+
+/** Test hook: KAIZEN_HOME_OVERRIDE redirects `~/.kaizen` for a single process. */
+export function kaizenHome(): string {
+  return process.env.KAIZEN_HOME_OVERRIDE ?? join(homedir(), ".kaizen");
+}
+
+export function kaizenHomeConfigPath(): string {
+  return join(kaizenHome(), "kaizen.json");
+}
+
+export function marketplacesDir(): string {
+  return join(kaizenHome(), "marketplaces");
+}
+
+export function marketplaceDir(id: string): string {
+  return join(marketplacesDir(), id);
+}
+
+export function marketplaceRepoDir(id: string): string {
+  return join(marketplaceDir(id), "repo");
+}
+
+export function pluginInstallDir(id: string, name: string, version: string): string {
+  return join(marketplaceDir(id), "plugins", `${name}@${version}`);
+}
+
+export function harnessInstallDir(id: string, name: string): string {
+  return join(marketplaceDir(id), "harnesses", name);
+}
+
+export async function ensureKaizenHome(): Promise<void> {
+  mkdirSync(marketplacesDir(), { recursive: true });
+}
+
+export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
+  const path = kaizenHomeConfigPath();
+  if (!existsSync(path)) return {};
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${path}: expected a JSON object.`);
+  }
+  return parsed as KaizenGlobalConfig;
+}
+
+/** Atomic: write to `kaizen.json.tmp` then rename. */
+export async function saveKaizenGlobalConfig(cfg: KaizenGlobalConfig): Promise<void> {
+  await ensureKaizenHome();
+  const path = kaizenHomeConfigPath();
+  const tmp = path + ".tmp";
+  writeFileSync(tmp, JSON.stringify(cfg, null, 2) + "\n", "utf8");
+  try {
+    renameSync(tmp, path);
+  } catch (e) {
+    try { unlinkSync(tmp); } catch {}
+    throw e;
+  }
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `bun test src/core/kaizen-config.test.ts`
+Expected: PASS all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/kaizen-config.ts src/core/kaizen-config.test.ts
+git commit -m "feat(core): add kaizen-config module owning ~/.kaizen tree"
+```
+
+---
+
+### Task 3: `canonicalTierGrantHash` in `plugin-hash.ts`
+
+**Files:**
+- Modify: `src/core/plugin-hash.ts`
+- Modify: `src/core/plugin-hash.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to existing `src/core/plugin-hash.test.ts`:
+
+```ts
+import { canonicalTierGrantHash } from "./plugin-hash.js";
+import type { PluginPermissions } from "../types/plugin.js";
+
+describe("canonicalTierGrantHash", () => {
+  const base: PluginPermissions = {
+    tier: "scoped",
+    fs: { read: ["a", "b"], write: ["c"] },
+    net: { connect: ["x:1", "y:2"] },
+    env: ["HOME"],
+    exec: { binaries: ["git"] },
+    events: { subscribe: ["core-lifecycle:tool:before"] },
+  };
+
+  it("is stable under key reorder", () => {
+    const reordered: PluginPermissions = {
+      exec: { binaries: ["git"] },
+      events: { subscribe: ["core-lifecycle:tool:before"] },
+      env: ["HOME"],
+      net: { connect: ["x:1", "y:2"] },
+      fs: { write: ["c"], read: ["a", "b"] },
+      tier: "scoped",
+    };
+    expect(canonicalTierGrantHash(reordered)).toBe(canonicalTierGrantHash(base));
+  });
+
+  it("is stable under array reorder", () => {
+    const shuffled: PluginPermissions = {
+      ...base,
+      fs: { read: ["b", "a"], write: ["c"] },
+      net: { connect: ["y:2", "x:1"] },
+    };
+    expect(canonicalTierGrantHash(shuffled)).toBe(canonicalTierGrantHash(base));
+  });
+
+  it("changes when tier changes", () => {
+    expect(canonicalTierGrantHash({ ...base, tier: "trusted" }))
+      .not.toBe(canonicalTierGrantHash(base));
+  });
+
+  it("changes when a grant value changes", () => {
+    expect(canonicalTierGrantHash({ ...base, env: ["HOME", "USER"] }))
+      .not.toBe(canonicalTierGrantHash(base));
+  });
+
+  it("returns sha256:<64-hex>", () => {
+    expect(canonicalTierGrantHash(base)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `bun test src/core/plugin-hash.test.ts`
+Expected: FAIL — `canonicalTierGrantHash` undefined.
+
+- [ ] **Step 3: Implement `canonicalTierGrantHash`**
+
+Append to `src/core/plugin-hash.ts`:
+
+```ts
+import type { PluginPermissions } from "../types/plugin.js";
+
+/**
+ * SHA-256 of a canonical serialization of `{ tier, permissions-minus-tier }`:
+ * object keys sorted; arrays sorted. Any change (value, presence, tier) flips
+ * the hash. Silent updates only apply when hash is byte-equal.
+ */
+export function canonicalTierGrantHash(perms: PluginPermissions): string {
+  const canon = canonicalize({
+    tier: perms.tier ?? "trusted",
+    permissions: stripTier(perms),
+  });
+  return "sha256:" + createHash("sha256").update(canon).digest("hex");
+}
+
+function stripTier(p: PluginPermissions): Omit<PluginPermissions, "tier"> {
+  const { tier: _tier, ...rest } = p;
+  return rest;
+}
+
+function canonicalize(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v);
+  if (Array.isArray(v)) {
+    const sorted = [...v].map(canonicalize).sort();
+    return "[" + sorted.join(",") + "]";
+  }
+  const obj = v as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalize(obj[k])).join(",") + "}";
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `bun test src/core/plugin-hash.test.ts`
+Expected: PASS — existing + new cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-hash.ts src/core/plugin-hash.test.ts
+git commit -m "feat(core): add canonicalTierGrantHash for silent-update eligibility"
+```
+
+---
+
+## Phase 2 — Ref Parser & Resolver
+
+### Task 4: `src/core/ref-resolver.ts`
+
+**Files:**
+- Create: `src/core/ref-resolver.ts`
+- Create: `src/core/ref-resolver.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/core/ref-resolver.test.ts
+import { describe, it, expect } from "bun:test";
+import { parseRef, resolveRef, RefConflictError,
+         MarketplaceNotFoundError, PluginNotFoundError, RefParseError } from "./ref-resolver.js";
+import type { MarketplaceCatalog } from "../types/plugin.js";
+
+describe("parseRef", () => {
+  it("parses marketplace-qualified with version", () => {
+    expect(parseRef("official/timestamps@1.2.3"))
+      .toEqual({ kind: "marketplace", marketplaceId: "official", name: "timestamps", version: "1.2.3" });
+  });
+  it("parses marketplace-qualified without version", () => {
+    expect(parseRef("official/timestamps"))
+      .toEqual({ kind: "marketplace", marketplaceId: "official", name: "timestamps" });
+  });
+  it("parses shorthand with version", () => {
+    expect(parseRef("timestamps@1.2.3"))
+      .toEqual({ kind: "shorthand", name: "timestamps", version: "1.2.3" });
+  });
+  it("parses shorthand bare", () => {
+    expect(parseRef("timestamps"))
+      .toEqual({ kind: "shorthand", name: "timestamps" });
+  });
+  it("parses legacy kaizen-plugin-* shim", () => {
+    expect(parseRef("kaizen-plugin-timestamps"))
+      .toEqual({ kind: "legacy-npm", name: "kaizen-plugin-timestamps" });
+  });
+
+  it.each([
+    ["https://x/y.git"],
+    ["http://x/y"],
+    ["file:///x"],
+    ["./local"],
+    ["/abs/path"],
+    ["../up"],
+    ["@scope/pkg"],
+    [""],
+  ])("rejects %s", (r) => {
+    expect(() => parseRef(r)).toThrow(RefParseError);
+  });
+});
+
+describe("resolveRef", () => {
+  const catTs: MarketplaceCatalog = {
+    version: "1.0.0", name: "Official", url: "https://x.git",
+    entries: [{
+      kind: "plugin", name: "timestamps", description: "",
+      versions: [
+        { version: "1.0.0", source: { type: "file", path: "a" } },
+        { version: "1.2.3", source: { type: "file", path: "a" } },
+      ],
+    }],
+  };
+  const catOther: MarketplaceCatalog = {
+    version: "1.0.0", name: "Other", url: "https://o.git",
+    entries: [{
+      kind: "plugin", name: "timestamps", description: "",
+      versions: [{ version: "1.0.0", source: { type: "file", path: "a" } }],
+    }],
+  };
+
+  it("resolves marketplace-qualified to exact version", () => {
+    const r = resolveRef(parseRef("official/timestamps@1.2.3"), { official: catTs });
+    expect(r.marketplaceId).toBe("official");
+    expect(r.version).toBe("1.2.3");
+  });
+  it("resolves marketplace-qualified to latest when no version", () => {
+    const r = resolveRef(parseRef("official/timestamps"), { official: catTs });
+    expect(r.version).toBe("1.2.3");
+  });
+  it("throws MarketplaceNotFoundError for unknown marketplace", () => {
+    expect(() => resolveRef(parseRef("nope/x"), { official: catTs }))
+      .toThrow(MarketplaceNotFoundError);
+  });
+  it("throws PluginNotFoundError for unknown name in marketplace", () => {
+    expect(() => resolveRef(parseRef("official/missing"), { official: catTs }))
+      .toThrow(PluginNotFoundError);
+  });
+  it("shorthand with single match auto-resolves", () => {
+    const r = resolveRef(parseRef("timestamps@1.2.3"), { official: catTs });
+    expect(r.marketplaceId).toBe("official");
+  });
+  it("shorthand ambiguous throws RefConflictError listing candidates", () => {
+    expect(() => resolveRef(parseRef("timestamps"), { official: catTs, other: catOther }))
+      .toThrow(RefConflictError);
+  });
+  it("legacy-npm resolves against 'official'", () => {
+    const cat: MarketplaceCatalog = {
+      version: "1.0.0", name: "Official", url: "https://x.git",
+      entries: [{
+        kind: "plugin", name: "timestamps", description: "",
+        versions: [{ version: "1.0.0", source: { type: "npm", name: "kaizen-plugin-timestamps", version: "1.0.0" } }],
+      }],
+    };
+    const r = resolveRef(parseRef("kaizen-plugin-timestamps"), { official: cat });
+    expect(r.marketplaceId).toBe("official");
+    expect(r.entry.name).toBe("timestamps");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `bun test src/core/ref-resolver.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `src/core/ref-resolver.ts`**
+
+```ts
+import type {
+  MarketplaceCatalog, MarketplaceEntry, MarketplacePluginEntry,
+  PluginVersionEntry,
+} from "../types/plugin.js";
+
 export type ParsedRef =
-  | { kind: "marketplace"; id: string;  name: string; version?: string }
-  | { kind: "shorthand";               name: string; version?: string }
-  | { kind: "local";       path: string }
-  | { kind: "url";         url: string }
-  | { kind: "npm";         name: string; version?: string };
-```
+  | { kind: "marketplace"; marketplaceId: string; name: string; version?: string }
+  | { kind: "shorthand";   name: string;          version?: string }
+  | { kind: "legacy-npm";  name: string };           // kaizen-plugin-*
 
-- [ ] **Step 2: Implement `parseRef(ref: string): ParsedRef`**
-
-Detection rules (in order):
-1. Starts with `./` or `/` → `local`
-2. Starts with `https://` or `http://` → `url`
-3. Contains `/` and does not look like a scoped npm package (`@scope/name`) →
-   split on first `/`, left is `id`, right is `name@version` → `marketplace`
-4. No `/` → check for `@version` suffix → `shorthand` (may be npm name without `/`)
-
-- [ ] **Step 3: Implement `resolveRef(parsed, marketplaces, catalogs): ResolvedSource`**
-
-```typescript
-export interface ResolvedSource {
-  source: PluginSource;
-  marketplaceId?: string;
-  pluginName: string;
+export interface ResolvedEntry {
+  marketplaceId: string;
+  entry: MarketplaceEntry;
   version: string;
+  /** Present when entry.kind === "plugin". */
+  pluginVersion?: PluginVersionEntry;
+}
+
+export class RefParseError extends Error { constructor(msg: string) { super(msg); this.name = "RefParseError"; } }
+export class RefConflictError extends Error {
+  constructor(public name: string, public candidates: string[]) {
+    super(`ref '${name}' is ambiguous across marketplaces: ${candidates.join(", ")}. ` +
+          `Use the marketplace-qualified form, e.g. ${candidates[0]}/${name}.`);
+    this.name = "RefConflictError";
+  }
+}
+export class MarketplaceNotFoundError extends Error {
+  constructor(public marketplaceId: string) {
+    super(`marketplace '${marketplaceId}' is not added. Run \`kaizen marketplace list\`.`);
+    this.name = "MarketplaceNotFoundError";
+  }
+}
+export class PluginNotFoundError extends Error {
+  constructor(public name: string, marketplaceId?: string) {
+    super(marketplaceId
+      ? `plugin '${name}' not found in marketplace '${marketplaceId}'.`
+      : `plugin '${name}' not found in any added marketplace.`);
+    this.name = "PluginNotFoundError";
+  }
+}
+
+const LEGACY_PREFIX = "kaizen-plugin-";
+
+export function parseRef(ref: string): ParsedRef {
+  if (!ref) throw new RefParseError("empty ref");
+
+  // Rejections first — URL / local / scoped-npm.
+  if (/^https?:\/\//i.test(ref) || ref.startsWith("file://")) {
+    throw new RefParseError(rejectMsg(ref, "raw URL"));
+  }
+  if (ref.startsWith("./") || ref.startsWith("../") || ref.startsWith("/")) {
+    throw new RefParseError(rejectMsg(ref, "local path"));
+  }
+  if (ref.startsWith("@")) {
+    throw new RefParseError(rejectMsg(ref, "scoped npm package"));
+  }
+
+  // Legacy kaizen-plugin-* shim — no '/' or '@' allowed except the name itself.
+  if (ref.startsWith(LEGACY_PREFIX) && !ref.includes("/")) {
+    return { kind: "legacy-npm", name: splitAt(ref).name };
+  }
+
+  const slash = ref.indexOf("/");
+  if (slash >= 0) {
+    const id = ref.slice(0, slash);
+    const tail = ref.slice(slash + 1);
+    if (!id || !tail) throw new RefParseError(`invalid ref '${ref}'`);
+    const { name, version } = splitAt(tail);
+    return { kind: "marketplace", marketplaceId: id, name, ...(version !== undefined ? { version } : {}) };
+  }
+
+  const { name, version } = splitAt(ref);
+  return { kind: "shorthand", name, ...(version !== undefined ? { version } : {}) };
+}
+
+function splitAt(s: string): { name: string; version?: string } {
+  const at = s.indexOf("@");
+  if (at < 0) return { name: s };
+  return { name: s.slice(0, at), version: s.slice(at + 1) };
+}
+
+function rejectMsg(ref: string, what: string): string {
+  return `ref '${ref}' rejected: ${what} is not a supported ref form. ` +
+         `Refs must be marketplace-qualified (<id>/<name>[@<version>]) or shorthand (<name>[@<version>]). ` +
+         `To ship a plugin, publish it in a marketplace (\`kaizen marketplace add <url>\`).`;
+}
+
+export function resolveRef(
+  parsed: ParsedRef,
+  catalogs: Record<string, MarketplaceCatalog>,
+): ResolvedEntry {
+  if (parsed.kind === "marketplace") {
+    const cat = catalogs[parsed.marketplaceId];
+    if (!cat) throw new MarketplaceNotFoundError(parsed.marketplaceId);
+    return pickEntry(parsed.marketplaceId, cat, parsed.name, parsed.version);
+  }
+
+  if (parsed.kind === "legacy-npm") {
+    const cat = catalogs["official"];
+    if (!cat) throw new MarketplaceNotFoundError("official");
+    // Strip the `kaizen-plugin-` prefix; match against the catalog name.
+    const short = parsed.name.slice(LEGACY_PREFIX.length);
+    return pickEntry("official", cat, short, undefined);
+  }
+
+  // shorthand — search every catalog.
+  const hits: Array<{ id: string; resolved: ResolvedEntry }> = [];
+  for (const [id, cat] of Object.entries(catalogs)) {
+    try {
+      hits.push({ id, resolved: pickEntry(id, cat, parsed.name, parsed.version) });
+    } catch (e) {
+      if (e instanceof PluginNotFoundError) continue;
+      throw e;
+    }
+  }
+  if (hits.length === 0) throw new PluginNotFoundError(parsed.name);
+  if (hits.length > 1) throw new RefConflictError(parsed.name, hits.map((h) => h.id));
+  return hits[0]!.resolved;
+}
+
+function pickEntry(
+  id: string, cat: MarketplaceCatalog, name: string, version: string | undefined,
+): ResolvedEntry {
+  const entry = cat.entries.find((e) => e.name === name);
+  if (!entry) throw new PluginNotFoundError(name, id);
+
+  const versions = entry.kind === "plugin"
+    ? (entry as MarketplacePluginEntry).versions.map((v) => v.version)
+    : entry.versions.map((v) => v.version);
+
+  const chosen = version ?? pickLatestSemver(versions);
+  if (!versions.includes(chosen)) {
+    throw new PluginNotFoundError(`${name}@${chosen}`, id);
+  }
+
+  const result: ResolvedEntry = { marketplaceId: id, entry, version: chosen };
+  if (entry.kind === "plugin") {
+    result.pluginVersion = entry.versions.find((v) => v.version === chosen)!;
+  }
+  return result;
+}
+
+/** Naive semver: split by '.', numeric compare. Good enough for v1. */
+function pickLatestSemver(versions: string[]): string {
+  return [...versions].sort((a, b) => cmpSemver(b, a))[0]!;
+}
+function cmpSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
 }
 ```
 
-Resolution logic:
-- `marketplace`: look up `id` in `catalogs`, find entry by `name`, resolve version
-  (latest if not specified, exact if specified). Throw `MarketplaceNotFoundError` or
-  `PluginNotFoundError` as appropriate.
-- `shorthand`: search all catalogs. If zero matches: try as npm package. If one match:
-  return it. If multiple matches: throw `RefConflictError` listing the marketplaces.
-- `local`: return `{ type: "file", path: ... }`.
-- `url`: return `{ type: "tarball", url: ... }`.
-- `npm`: return `{ type: "npm", name, version: version ?? "latest" }`.
+- [ ] **Step 4: Run test, verify pass**
 
-- [ ] **Step 4: Write `src/core/ref-resolver.test.ts`**
+Run: `bun test src/core/ref-resolver.test.ts`
+Expected: PASS.
 
-Tests:
-- `parseRef` for each form including edge cases (`@scope/pkg`, `market/name@1.0`,
-  bare name, `./path`, absolute path, HTTPS URL).
-- `resolveRef` marketplace found, not found, ambiguous shorthand, local, URL, npm.
+- [ ] **Step 5: Commit**
 
----
-
-## Phase 3 — Marketplace Config & Catalog I/O
-
-### Task 3: Implement `src/core/marketplace.ts`
-
-- [ ] **Step 1: `loadGlobalConfig()` and `saveGlobalConfig()`**
-
-Read/write `~/.kaizen/kaizen.json`. Handle file-not-found (return empty config).
-
-- [ ] **Step 2: `fetchCatalog(url: string): Promise<MarketplaceCatalog>`**
-
-Detection:
-- Local path (starts with `./`, `/`, or `file://`): read `.kaizen/marketplace.json`
-  from the directory.
-- Git URL (ends in `.git` or matches GitHub URL pattern): use GitHub raw content API
-  (`https://raw.githubusercontent.com/<user>/<repo>/HEAD/.kaizen/marketplace.json`)
-  for HTTPS GitHub URLs. For other git URLs, fall back to `git archive` subprocess
-  call: `git archive --remote=<url> HEAD .kaizen/marketplace.json`.
-- Validate result against `MarketplaceCatalog` schema (Zod or manual).
-- Throw descriptive errors for network failures, missing file, schema errors.
-
-- [ ] **Step 3: `getCachedCatalog(id)` and `writeCachedCatalog(id, catalog)`**
-
-Cache path: `~/.kaizen/marketplaces/<id>/marketplace.json`. Create dirs as needed.
-
-- [ ] **Step 4: Write `src/core/marketplace.test.ts`**
-
-Mock filesystem + HTTP. Test: fetch from local path, fetch from GitHub URL, cache
-read/write, invalid schema, file not found.
-
----
-
-## Phase 4 — `kaizen marketplace` Commands
-
-### Task 4: Implement `src/commands/marketplace.ts`
-
-- [ ] **Step 1: `cmdMarketplaceAdd(url, idOverride?)`**
-
-1. Derive `id` from URL basename if no override.
-2. Check `id` not already in global config (warn if updating).
-3. Call `fetchCatalog(url)`.
-4. Call `writeCachedCatalog(id, catalog)`.
-5. Update `loadGlobalConfig()`, push `{ id, url, updatedAt }`, `saveGlobalConfig()`.
-6. Print: `Added marketplace 'official' (42 plugins, 3 harnesses).`
-
-- [ ] **Step 2: `cmdMarketplaceList()`**
-
-Load global config, read each cached catalog, print table:
-```
-  ID        PLUGINS  HARNESSES  UPDATED
-  official       42          3  2026-04-18
-  my-internal    12          1  2026-04-17
+```bash
+git add src/core/ref-resolver.ts src/core/ref-resolver.test.ts
+git commit -m "feat(core): add ref parser + resolver (marketplace + shorthand + legacy shim)"
 ```
 
-- [ ] **Step 3: `cmdMarketplaceRemove(id)`**
+---
 
-Remove from global config, delete `~/.kaizen/marketplaces/<id>/`. Confirm if
-`--force` not set.
+## Phase 3 — Marketplace Module (git + catalog)
 
-- [ ] **Step 4: `cmdMarketplaceUpdate(id?)`**
+### Task 5: `src/core/marketplace.ts`
 
-Re-fetch for one or all marketplaces. Print diff of plugin/harness count.
+**Files:**
+- Create: `src/core/marketplace.ts`
+- Create: `src/core/marketplace.test.ts`
 
-- [ ] **Step 5: `cmdMarketplaceBrowse(id?)`**
+This module is the **single entry point** used by `kaizen marketplace add`
+and `--harness` bootstrap. It never hardcodes `~/.kaizen` paths — all disk
+paths go through `kaizen-config.ts`.
 
-Print all plugin entries (from cached catalog) in a table. Filter by `id` if given.
-v1: stdout only.
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/core/marketplace.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { $ } from "bun";
+import {
+  addMarketplace, pullMarketplace, readCatalog, validateCatalog,
+  shouldRefresh, MarketplaceCatalogInvalidError,
+} from "./marketplace.js";
+import { loadKaizenGlobalConfig, marketplaceRepoDir } from "./kaizen-config.js";
+import type { MarketplaceCatalog } from "../types/plugin.js";
+
+let home: string;
+let upstream: string;
+
+async function makeUpstream(catalog: MarketplaceCatalog): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "kz-up-"));
+  mkdirSync(join(dir, ".kaizen"), { recursive: true });
+  writeFileSync(join(dir, ".kaizen", "marketplace.json"), JSON.stringify(catalog, null, 2));
+  await $`git init -q`.cwd(dir);
+  await $`git -c user.email=t@t -c user.name=t add .`.cwd(dir);
+  await $`git -c user.email=t@t -c user.name=t commit -qm init`.cwd(dir);
+  return dir;
+}
+
+const sampleCatalog: MarketplaceCatalog = {
+  version: "1.0.0", name: "Official", url: "local://upstream",
+  entries: [{
+    kind: "plugin", name: "timestamps", description: "ts",
+    versions: [{ version: "1.0.0", source: { type: "file", path: "plugins/timestamps" } }],
+  }],
+};
+
+beforeEach(async () => {
+  home = mkdtempSync(join(tmpdir(), "kz-home-"));
+  process.env.KAIZEN_HOME_OVERRIDE = home;
+  upstream = await makeUpstream(sampleCatalog);
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  rmSync(upstream, { recursive: true, force: true });
+  delete process.env.KAIZEN_HOME_OVERRIDE;
+});
+
+describe("validateCatalog", () => {
+  it("passes a valid catalog", () => {
+    expect(() => validateCatalog(sampleCatalog)).not.toThrow();
+  });
+  it("rejects unknown kind", () => {
+    const bad = { ...sampleCatalog, entries: [{ ...sampleCatalog.entries[0], kind: "bogus" }] } as unknown;
+    expect(() => validateCatalog(bad as MarketplaceCatalog)).toThrow(MarketplaceCatalogInvalidError);
+  });
+  it("rejects duplicate names across kinds", () => {
+    const dup: MarketplaceCatalog = {
+      ...sampleCatalog,
+      entries: [
+        sampleCatalog.entries[0]!,
+        { kind: "harness", name: "timestamps", description: "clash",
+          versions: [{ version: "1.0.0", path: "h.json" }] },
+      ],
+    };
+    expect(() => validateCatalog(dup)).toThrow(MarketplaceCatalogInvalidError);
+  });
+});
+
+describe("addMarketplace — git clone", () => {
+  it("clones upstream into <home>/marketplaces/<id>/repo, writes global config", async () => {
+    await addMarketplace(upstream, { id: "official" });
+    expect(existsSync(marketplaceRepoDir("official"))).toBe(true);
+    const cat = await readCatalog("official");
+    expect(cat.name).toBe("Official");
+    const g = await loadKaizenGlobalConfig();
+    expect(g.marketplaces?.[0]?.id).toBe("official");
+    expect(g.marketplaces?.[0]?.url).toBe(upstream);
+  });
+
+  it("is idempotent — re-adding same id is a no-op", async () => {
+    await addMarketplace(upstream, { id: "official" });
+    await addMarketplace(upstream, { id: "official" });
+    const g = await loadKaizenGlobalConfig();
+    expect(g.marketplaces?.length).toBe(1);
+  });
+
+  it("derives id from URL basename when not supplied", async () => {
+    await addMarketplace(upstream);
+    const g = await loadKaizenGlobalConfig();
+    expect(g.marketplaces?.[0]?.id).toBeDefined();
+  });
+});
+
+describe("addMarketplace — local path (symlinked)", () => {
+  it("symlinks repo dir when url is an absolute local path", async () => {
+    await addMarketplace(upstream, { id: "local-dev", local: true });
+    const repoPath = marketplaceRepoDir("local-dev");
+    expect(existsSync(repoPath)).toBe(true);
+    // Confirm it's a symlink by checking that editing upstream shows up.
+    writeFileSync(join(upstream, "NEW"), "x");
+    expect(existsSync(join(repoPath, "NEW"))).toBe(true);
+  });
+});
+
+describe("pullMarketplace", () => {
+  it("pulls a cloned marketplace (ff-only)", async () => {
+    await addMarketplace(upstream, { id: "official" });
+    writeFileSync(join(upstream, "README.md"), "hi");
+    await $`git -c user.email=t@t -c user.name=t add README.md`.cwd(upstream);
+    await $`git -c user.email=t@t -c user.name=t commit -qm r`.cwd(upstream);
+    await pullMarketplace("official");
+    expect(existsSync(join(marketplaceRepoDir("official"), "README.md"))).toBe(true);
+  });
+  it("is a no-op on symlinked marketplaces", async () => {
+    await addMarketplace(upstream, { id: "local-dev", local: true });
+    await pullMarketplace("local-dev"); // must not throw
+  });
+});
+
+describe("shouldRefresh", () => {
+  it("refreshes when no updatedAt", () => {
+    expect(shouldRefresh({ id: "x", url: "" }, 900)).toBe(true);
+  });
+  it("does not refresh when within TTL", () => {
+    expect(shouldRefresh({ id: "x", url: "", updatedAt: new Date().toISOString() }, 900)).toBe(false);
+  });
+  it("refreshes when older than TTL", () => {
+    const old = new Date(Date.now() - 1000 * 60 * 60).toISOString();
+    expect(shouldRefresh({ id: "x", url: "", updatedAt: old }, 900)).toBe(true);
+  });
+  it("ttl=0 disables refresh", () => {
+    expect(shouldRefresh({ id: "x", url: "" }, 0)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `bun test src/core/marketplace.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `src/core/marketplace.ts`**
+
+```ts
+import { existsSync, mkdirSync, symlinkSync, readFileSync, rmSync, statSync, lstatSync } from "fs";
+import { basename, join, isAbsolute } from "path";
+import { $ } from "bun";
+import type { MarketplaceCatalog, MarketplaceRef } from "../types/plugin.js";
+import {
+  ensureKaizenHome, loadKaizenGlobalConfig, saveKaizenGlobalConfig,
+  marketplaceDir, marketplaceRepoDir,
+} from "./kaizen-config.js";
+
+export class MarketplaceCatalogInvalidError extends Error {
+  constructor(msg: string) { super(msg); this.name = "MarketplaceCatalogInvalidError"; }
+}
+
+export interface AddMarketplaceOpts {
+  id?: string;
+  /** Treat `url` as an absolute local directory; symlink rather than clone. */
+  local?: boolean;
+}
+
+export async function addMarketplace(url: string, opts: AddMarketplaceOpts = {}): Promise<void> {
+  await ensureKaizenHome();
+  const id = opts.id ?? deriveId(url);
+  const mDir = marketplaceDir(id);
+  const repoDir = marketplaceRepoDir(id);
+
+  const cfg = await loadKaizenGlobalConfig();
+  cfg.marketplaces ??= [];
+
+  // Idempotency.
+  if (cfg.marketplaces.some((m) => m.id === id)) return;
+
+  mkdirSync(mDir, { recursive: true });
+  if (opts.local || isAbsolute(url)) {
+    if (!existsSync(url)) throw new Error(`local marketplace path not found: ${url}`);
+    symlinkSync(url, repoDir, "dir");
+  } else {
+    await $`git clone --depth=1 ${url} ${repoDir}`.quiet();
+  }
+
+  const cat = await readCatalog(id);
+  validateCatalog(cat);
+
+  const ref: MarketplaceRef = { id, url, updatedAt: new Date().toISOString() };
+  cfg.marketplaces.push(ref);
+  await saveKaizenGlobalConfig(cfg);
+}
+
+export async function pullMarketplace(id: string): Promise<void> {
+  const repoDir = marketplaceRepoDir(id);
+  if (!existsSync(repoDir)) throw new Error(`marketplace '${id}' is not added`);
+  if (lstatSync(repoDir).isSymbolicLink()) return; // no-op for local dev
+  await $`git -C ${repoDir} pull --depth=1 --ff-only`.quiet();
+
+  const cfg = await loadKaizenGlobalConfig();
+  const ref = cfg.marketplaces?.find((m) => m.id === id);
+  if (ref) {
+    ref.updatedAt = new Date().toISOString();
+    await saveKaizenGlobalConfig(cfg);
+  }
+}
+
+export async function removeMarketplace(id: string): Promise<void> {
+  const cfg = await loadKaizenGlobalConfig();
+  cfg.marketplaces = (cfg.marketplaces ?? []).filter((m) => m.id !== id);
+  await saveKaizenGlobalConfig(cfg);
+  rmSync(marketplaceDir(id), { recursive: true, force: true });
+}
+
+export async function readCatalog(id: string): Promise<MarketplaceCatalog> {
+  const path = join(marketplaceRepoDir(id), ".kaizen", "marketplace.json");
+  if (!existsSync(path)) {
+    throw new MarketplaceCatalogInvalidError(`catalog not found at ${path}`);
+  }
+  const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  const cat = raw as MarketplaceCatalog;
+  validateCatalog(cat);
+  return cat;
+}
+
+export function validateCatalog(cat: MarketplaceCatalog): void {
+  if (!cat || typeof cat !== "object") throw new MarketplaceCatalogInvalidError("not an object");
+  if (cat.version !== "1.0.0") throw new MarketplaceCatalogInvalidError(`unsupported version: ${cat.version}`);
+  if (typeof cat.name !== "string") throw new MarketplaceCatalogInvalidError("missing name");
+  if (typeof cat.url !== "string") throw new MarketplaceCatalogInvalidError("missing url");
+  if (!Array.isArray(cat.entries)) throw new MarketplaceCatalogInvalidError("entries must be an array");
+
+  const seen = new Set<string>();
+  for (const e of cat.entries) {
+    if (e.kind !== "plugin" && e.kind !== "harness") {
+      throw new MarketplaceCatalogInvalidError(`unknown entry kind: ${(e as { kind: string }).kind}`);
+    }
+    if (typeof e.name !== "string" || !/^[a-z0-9-]+$/.test(e.name)) {
+      throw new MarketplaceCatalogInvalidError(`invalid entry name: ${e.name}`);
+    }
+    if (seen.has(e.name)) {
+      throw new MarketplaceCatalogInvalidError(`duplicate entry name: ${e.name}`);
+    }
+    seen.add(e.name);
+    if (!Array.isArray(e.versions) || e.versions.length === 0) {
+      throw new MarketplaceCatalogInvalidError(`entry '${e.name}' has no versions`);
+    }
+  }
+}
+
+export function shouldRefresh(ref: MarketplaceRef, ttlSeconds: number): boolean {
+  if (ttlSeconds <= 0) return false;
+  if (!ref.updatedAt) return true;
+  const ageMs = Date.now() - new Date(ref.updatedAt).getTime();
+  return ageMs > ttlSeconds * 1000;
+}
+
+/** Fire-and-forget background pull. Swallows errors (logs only). */
+export function refreshInBackground(id: string, log?: (m: string) => void): void {
+  pullMarketplace(id).catch((e) => log?.(`marketplace refresh '${id}' failed: ${String(e)}`));
+}
+
+function deriveId(url: string): string {
+  const base = basename(url).replace(/\.git$/, "");
+  return base || "marketplace";
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `bun test src/core/marketplace.test.ts`
+Expected: PASS. If a test is flaky on symlink-on-CI, adjust symlink type
+argument (`"junction"` on windows not supported — this is mac/linux only).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/marketplace.ts src/core/marketplace.test.ts
+git commit -m "feat(core): marketplace module — git clone/pull, catalog validate, background refresh"
+```
 
 ---
 
-## Phase 5 — Unified Install
+## Phase 4 — Plugin Installer & Loader
 
-### Task 5: Rework `src/commands/install.ts`
+### Task 6: `src/core/plugin-installer.ts`
 
-- [ ] **Step 1: Replace `runInstall` with `runUnifiedInstall(ref, opts)`**
+**Files:**
+- Create: `src/core/plugin-installer.ts`
+- Create: `src/core/plugin-installer.test.ts`
 
-```typescript
-interface InstallOpts {
+Materializes plugin bits at `pluginInstallDir(id, name, version)`. Three source
+types: `file` (copy), `tarball` (download + verify + extract), `npm` (`npm pack`
++ extract; no global `node_modules` involvement). Harness install is a JSON
+copy to `harnessInstallDir/kaizen.json`.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/core/plugin-installer.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { installPlugin, installHarness } from "./plugin-installer.js";
+import { pluginInstallDir, harnessInstallDir, marketplaceRepoDir } from "./kaizen-config.js";
+
+let home: string;
+let upstream: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kz-home-"));
+  process.env.KAIZEN_HOME_OVERRIDE = home;
+  upstream = mkdtempSync(join(tmpdir(), "kz-up-"));
+  // Simulate an "added" marketplace whose repo is the upstream dir (symlink).
+  mkdirSync(join(home, "marketplaces", "m"), { recursive: true });
+  symlinkSync(upstream, marketplaceRepoDir("m"), "dir");
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  rmSync(upstream, { recursive: true, force: true });
+  delete process.env.KAIZEN_HOME_OVERRIDE;
+});
+
+describe("installPlugin — file source", () => {
+  it("copies plugin contents into pluginInstallDir", async () => {
+    const pluginSrc = join(upstream, "plugins", "demo");
+    mkdirSync(pluginSrc, { recursive: true });
+    writeFileSync(join(pluginSrc, "package.json"), JSON.stringify({ name: "demo", version: "1.0.0", main: "index.js" }));
+    writeFileSync(join(pluginSrc, "index.js"), "export default { name: 'demo', apiVersion: '2', setup(){} };");
+
+    await installPlugin("m", "demo", "1.0.0",
+      { type: "file", path: "plugins/demo" });
+
+    const target = pluginInstallDir("m", "demo", "1.0.0");
+    expect(existsSync(join(target, "package.json"))).toBe(true);
+    expect(existsSync(join(target, "index.js"))).toBe(true);
+  });
+});
+
+describe("installHarness", () => {
+  it("copies the harness JSON into harnessInstallDir/kaizen.json", async () => {
+    const hSrc = join(upstream, "harnesses", "anth.json");
+    mkdirSync(join(upstream, "harnesses"), { recursive: true });
+    const doc = { plugins: ["official/timestamps@1.0.0"] };
+    writeFileSync(hSrc, JSON.stringify(doc));
+
+    await installHarness("m", "anthropic-default", "harnesses/anth.json");
+
+    const target = join(harnessInstallDir("m", "anthropic-default"), "kaizen.json");
+    expect(JSON.parse(readFileSync(target, "utf8"))).toEqual(doc);
+  });
+});
+```
+
+(The `tarball` and `npm` source cases are covered by the integration test in
+Task 16; unit tests would require network or ship heavy fixtures, not worth the
+weight.)
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `bun test src/core/plugin-installer.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `src/core/plugin-installer.ts`**
+
+```ts
+import { cpSync, mkdirSync, existsSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { createHash } from "crypto";
+import { join } from "path";
+import { $ } from "bun";
+import type { PluginSource } from "../types/plugin.js";
+import { marketplaceRepoDir, pluginInstallDir, harnessInstallDir } from "./kaizen-config.js";
+
+export async function installPlugin(
+  marketplaceId: string, name: string, version: string, source: PluginSource,
+): Promise<void> {
+  const target = pluginInstallDir(marketplaceId, name, version);
+  rmSync(target, { recursive: true, force: true });
+  mkdirSync(target, { recursive: true });
+
+  switch (source.type) {
+    case "file": {
+      const src = join(marketplaceRepoDir(marketplaceId), source.path);
+      if (!existsSync(src)) throw new Error(`file source not found in marketplace: ${source.path}`);
+      cpSync(src, target, { recursive: true });
+      return;
+    }
+    case "tarball": {
+      await installTarball(source.url, target, source.sha256);
+      return;
+    }
+    case "npm": {
+      await installNpm(source.name, source.version, target);
+      return;
+    }
+  }
+}
+
+export async function installHarness(
+  marketplaceId: string, name: string, pathInRepo: string,
+): Promise<void> {
+  const src = join(marketplaceRepoDir(marketplaceId), pathInRepo);
+  if (!existsSync(src)) throw new Error(`harness source not found in marketplace: ${pathInRepo}`);
+  const target = harnessInstallDir(marketplaceId, name);
+  mkdirSync(target, { recursive: true });
+  const raw = readFileSync(src);
+  writeFileSync(join(target, "kaizen.json"), raw);
+}
+
+async function installTarball(url: string, target: string, sha256?: string): Promise<void> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`tarball fetch failed: ${url} (${res.status})`);
+  const buf = new Uint8Array(await res.arrayBuffer());
+  if (sha256) {
+    const got = createHash("sha256").update(buf).digest("hex");
+    if (got !== sha256) throw new Error(`tarball sha256 mismatch: want ${sha256}, got ${got}`);
+  }
+  const tmpFile = join(target, "__tarball.tgz");
+  writeFileSync(tmpFile, buf);
+  // Most npm tarballs have a top-level `package/` prefix; strip it.
+  await $`tar -xzf ${tmpFile} -C ${target} --strip-components=1`.quiet();
+  rmSync(tmpFile, { force: true });
+}
+
+async function installNpm(pkgName: string, pkgVersion: string, target: string): Promise<void> {
+  // `npm pack` downloads the tarball into cwd; we run it in a scratch dir and move.
+  const scratch = join(target, "__pack");
+  mkdirSync(scratch, { recursive: true });
+  await $`npm pack ${pkgName}@${pkgVersion}`.cwd(scratch).quiet();
+  const entries = await $`ls ${scratch}`.text();
+  const tgz = entries.trim().split("\n").find((n) => n.endsWith(".tgz"));
+  if (!tgz) throw new Error(`npm pack produced no tarball for ${pkgName}@${pkgVersion}`);
+  await $`tar -xzf ${join(scratch, tgz)} -C ${target} --strip-components=1`.quiet();
+  rmSync(scratch, { recursive: true, force: true });
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `bun test src/core/plugin-installer.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-installer.ts src/core/plugin-installer.test.ts
+git commit -m "feat(core): plugin-installer — file/tarball/npm into marketplaces/<id>/plugins/<n>@<v>/"
+```
+
+---
+
+### Task 7: `src/core/plugin-loader.ts` — absolute-path loader
+
+**Files:**
+- Create: `src/core/plugin-loader.ts`
+- Create: `src/core/plugin-loader.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// src/core/plugin-loader.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { loadPluginFromInstallDir } from "./plugin-loader.js";
+import { pluginInstallDir } from "./kaizen-config.js";
+
+let home: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kz-home-"));
+  process.env.KAIZEN_HOME_OVERRIDE = home;
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  delete process.env.KAIZEN_HOME_OVERRIDE;
+});
+
+describe("loadPluginFromInstallDir", () => {
+  it("imports by absolute path from the install dir (no node_modules)", async () => {
+    const dir = pluginInstallDir("m", "demo", "1.0.0");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"),
+      JSON.stringify({ name: "demo", version: "1.0.0", main: "index.mjs", type: "module" }));
+    writeFileSync(join(dir, "index.mjs"),
+      `export default { name: "demo", apiVersion: "2", async setup() {} };`);
+
+    const plugin = await loadPluginFromInstallDir("m", "demo", "1.0.0");
+    expect(plugin.name).toBe("demo");
+    expect(plugin.apiVersion).toBe("2");
+  });
+
+  it("throws a clear error when install dir is missing", async () => {
+    await expect(loadPluginFromInstallDir("m", "ghost", "9.9.9")).rejects.toThrow(/not installed/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `bun test src/core/plugin-loader.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `src/core/plugin-loader.ts`**
+
+```ts
+import { existsSync, readFileSync } from "fs";
+import { join, isAbsolute } from "path";
+import type { KaizenPlugin } from "../types/plugin.js";
+import { pluginInstallDir } from "./kaizen-config.js";
+
+export async function loadPluginFromInstallDir(
+  marketplaceId: string, name: string, version: string,
+): Promise<KaizenPlugin> {
+  const dir = pluginInstallDir(marketplaceId, name, version);
+  if (!existsSync(dir)) {
+    throw new Error(`plugin '${marketplaceId}/${name}@${version}' is not installed at ${dir}`);
+  }
+  const pkgPath = join(dir, "package.json");
+  if (!existsSync(pkgPath)) throw new Error(`no package.json at ${dir}`);
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { main?: string; module?: string };
+  const entry = pkg.module ?? pkg.main ?? "index.js";
+  const abs = isAbsolute(entry) ? entry : join(dir, entry);
+
+  // Bun and node both accept absolute-path dynamic import.
+  const mod = (await import(abs)) as { default?: KaizenPlugin };
+  if (!mod.default || typeof mod.default !== "object") {
+    throw new Error(`plugin '${name}' at ${abs} has no default export`);
+  }
+  return mod.default;
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `bun test src/core/plugin-loader.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-loader.ts src/core/plugin-loader.test.ts
+git commit -m "feat(core): plugin-loader imports marketplace plugins by absolute path"
+```
+
+---
+
+### Task 8: `plugin-manager.ts` — `isInstalled` + marketplace resolve path
+
+**Files:**
+- Modify: `src/core/plugin-manager.ts`
+- Modify: `src/core/plugin-manager.test.ts`
+
+The plugin manager currently resolves plugins via `createRequire` paths. We do
+**not** need to rewrite all of that in this task — third-party plugin loading
+moves to `plugin-loader.ts`. But the manager does need to answer "is this
+plugin installed?" using the marketplace layout.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `src/core/plugin-manager.test.ts`:
+
+```ts
+import { isInstalled } from "./plugin-manager.js";
+import { pluginInstallDir } from "./kaizen-config.js";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+describe("isInstalled(marketplaceId, name, version)", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kz-home-"));
+    process.env.KAIZEN_HOME_OVERRIDE = home;
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env.KAIZEN_HOME_OVERRIDE;
+  });
+
+  it("returns false when install dir absent", async () => {
+    expect(await isInstalled("m", "demo", "1.0.0")).toBe(false);
+  });
+  it("returns true when install dir has package.json", async () => {
+    const dir = pluginInstallDir("m", "demo", "1.0.0");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), "{}");
+    expect(await isInstalled("m", "demo", "1.0.0")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `bun test src/core/plugin-manager.test.ts`
+Expected: FAIL — `isInstalled` not exported.
+
+- [ ] **Step 3: Add `isInstalled` to `plugin-manager.ts`**
+
+Append (after `findPackageRoot`):
+
+```ts
+import { pluginInstallDir } from "./kaizen-config.js";
+import { existsSync } from "fs";
+
+export async function isInstalled(
+  marketplaceId: string, name: string, version: string,
+): Promise<boolean> {
+  return existsSync(join(pluginInstallDir(marketplaceId, name, version), "package.json"));
+}
+```
+
+(Ensure the `join` / `existsSync` imports already present at top of file are
+reused — do not double-import.)
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `bun test src/core/plugin-manager.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-manager.ts src/core/plugin-manager.test.ts
+git commit -m "feat(core): plugin-manager.isInstalled against marketplace layout"
+```
+
+---
+
+## Phase 5 — `kaizen marketplace` subcommands
+
+### Task 9: `src/commands/marketplace.ts`
+
+**Files:**
+- Create: `src/commands/marketplace.ts`
+
+Thin command layer over `src/core/marketplace.ts`. No new business logic —
+only argv parsing + stdout formatting.
+
+- [ ] **Step 1: Implement the command module**
+
+```ts
+// src/commands/marketplace.ts
+import { rmSync } from "fs";
+import {
+  addMarketplace, pullMarketplace, readCatalog, removeMarketplace,
+} from "../core/marketplace.js";
+import { loadKaizenGlobalConfig } from "../core/kaizen-config.js";
+import { marketplaceDir } from "../core/kaizen-config.js";
+
+export async function cmdMarketplaceAdd(args: { url: string; id?: string; local?: boolean }): Promise<number> {
+  try {
+    await addMarketplace(args.url, { ...(args.id ? { id: args.id } : {}), ...(args.local ? { local: true } : {}) });
+    const id = args.id ?? args.url;
+    const cat = await readCatalog(args.id ?? id); // best-effort
+    const plugins = cat.entries.filter((e) => e.kind === "plugin").length;
+    const harnesses = cat.entries.filter((e) => e.kind === "harness").length;
+    console.log(`Added marketplace '${id}' (${plugins} plugins, ${harnesses} harnesses).`);
+    return 0;
+  } catch (e) {
+    console.error(`kaizen marketplace add: ${(e as Error).message}`);
+    return 1;
+  }
+}
+
+export async function cmdMarketplaceList(): Promise<number> {
+  const cfg = await loadKaizenGlobalConfig();
+  const refs = cfg.marketplaces ?? [];
+  if (refs.length === 0) {
+    console.log("No marketplaces added. Run `kaizen marketplace add <url>`.");
+    return 0;
+  }
+  const rows = await Promise.all(refs.map(async (r) => {
+    try {
+      const cat = await readCatalog(r.id);
+      const plugins = cat.entries.filter((e) => e.kind === "plugin").length;
+      const harnesses = cat.entries.filter((e) => e.kind === "harness").length;
+      return { id: r.id, plugins, harnesses, updated: r.updatedAt ?? "—", url: r.url };
+    } catch {
+      return { id: r.id, plugins: 0, harnesses: 0, updated: r.updatedAt ?? "—", url: r.url };
+    }
+  }));
+  console.log("ID\tPLUGINS\tHARNESSES\tUPDATED\tURL");
+  for (const row of rows) {
+    console.log(`${row.id}\t${row.plugins}\t${row.harnesses}\t${row.updated}\t${row.url}`);
+  }
+  return 0;
+}
+
+export async function cmdMarketplaceRemove(args: { id: string; purgeLockfile?: boolean }): Promise<number> {
+  try {
+    await removeMarketplace(args.id);
+    console.log(`Removed marketplace '${args.id}' (including installed plugins and harnesses).`);
+    // --purge-lockfile handled by caller that has the lockfile path (cli.ts).
+    return 0;
+  } catch (e) {
+    console.error(`kaizen marketplace remove: ${(e as Error).message}`);
+    return 1;
+  }
+}
+
+export async function cmdMarketplaceUpdate(args: { id?: string }): Promise<number> {
+  const cfg = await loadKaizenGlobalConfig();
+  const targets = args.id ? [args.id] : (cfg.marketplaces ?? []).map((m) => m.id);
+  let rc = 0;
+  for (const id of targets) {
+    try {
+      await pullMarketplace(id);
+      console.log(`Updated '${id}'.`);
+    } catch (e) {
+      console.error(`update '${id}' failed: ${(e as Error).message}`);
+      rc = 1;
+    }
+  }
+  return rc;
+}
+
+export async function cmdMarketplaceBrowse(args: { id?: string }): Promise<number> {
+  const cfg = await loadKaizenGlobalConfig();
+  const refs = args.id
+    ? (cfg.marketplaces ?? []).filter((m) => m.id === args.id)
+    : (cfg.marketplaces ?? []);
+  for (const r of refs) {
+    const cat = await readCatalog(r.id);
+    console.log(`\n# ${r.id} (${cat.name})`);
+    console.log("KIND\tNAME\tVERSIONS\tDESCRIPTION");
+    for (const e of cat.entries) {
+      const vs = e.versions.map((v) => v.version).join(",");
+      console.log(`${e.kind}\t${e.name}\t${vs}\t${e.description}`);
+    }
+  }
+  return 0;
+}
+```
+
+- [ ] **Step 2: Smoke-test via a throwaway integration test**
+
+Add a `src/commands/marketplace.test.ts` that simply exercises the happy path
+of `add` → `list` → `browse` → `remove` against a local fixture (use the same
+git-init helper as Task 5). Test files are fixtures for engineers to reason
+about — not a correctness moat (the core module has that coverage).
+
+- [ ] **Step 3: Run tests**
+
+Run: `bun test src/commands/marketplace.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/marketplace.ts src/commands/marketplace.test.ts
+git commit -m "feat(cli): kaizen marketplace {add,list,remove,update,browse}"
+```
+
+---
+
+## Phase 6 — Unified install / uninstall / update
+
+### Task 10: Rework `src/commands/install.ts`
+
+**Files:**
+- Modify: `src/commands/install.ts`
+
+The existing `runInstall({ pluginName, ... })` resolves a plugin by
+`createRequire`. Replace with `runUnifiedInstall(ref, opts)` that:
+
+1. Parses `ref` via `parseRef`.
+2. Loads all added-marketplace catalogs.
+3. Resolves to a `ResolvedEntry`.
+4. Dispatches by `entry.kind`:
+   - `plugin`: `installPlugin(...)` into the install dir → read
+     `package.json` version + `permissions` from plugin's default export →
+     compute hash → run existing consent flow (unchanged) → write lockfile.
+   - `harness`: `installHarness(...)`.
+5. If a project `.kaizen/kaizen.json` exists and this was a plugin install:
+   append the canonical `<id>/<name>@<version>` ref to its `plugins` array
+   (dedupe by canonical form).
+
+- [ ] **Step 1: Replace `install.ts` contents**
+
+```ts
+// src/commands/install.ts
+import { readFileSync, existsSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { KaizenPlugin, PluginPermissions, MarketplaceCatalog } from "../types/plugin.js";
+import { parseRef, resolveRef } from "../core/ref-resolver.js";
+import { loadKaizenGlobalConfig } from "../core/kaizen-config.js";
+import { readCatalog } from "../core/marketplace.js";
+import { installPlugin, installHarness } from "../core/plugin-installer.js";
+import { loadPluginFromInstallDir } from "../core/plugin-loader.js";
+import { pluginInstallDir } from "../core/kaizen-config.js";
+import { readLockfile, writeLockfile, upsertPluginEntry, type LockfileEntry } from "../core/lockfile.js";
+import { canonicalTierGrantHash } from "../core/plugin-hash.js";
+import { renderScopedUAC, renderUnscopedUAC } from "../core/uac-renderer.js";
+import { decideConsent } from "../core/consent-flow.js";
+import { readStdinLine } from "../core/stdin.js";
+import { PROJECT_CONFIG } from "../core/config.js";
+
+export interface UnifiedInstallArgs {
+  ref: string;
   lockfilePath: string;
   allowUnscoped: boolean;
   nonInteractive: boolean;
-  ephemeral?: boolean;   // install to cache instead of node_modules
+}
+
+export async function runUnifiedInstall(args: UnifiedInstallArgs): Promise<number> {
+  const parsed = parseRef(args.ref);
+  const catalogs = await loadAllCatalogs();
+  const resolved = resolveRef(parsed, catalogs);
+
+  if (resolved.entry.kind === "harness") {
+    const hv = resolved.entry.versions.find((v) => v.version === resolved.version)!;
+    await installHarness(resolved.marketplaceId, resolved.entry.name, hv.path);
+    console.log(`installed harness ${resolved.marketplaceId}/${resolved.entry.name}@${resolved.version}`);
+    return 0;
+  }
+
+  // plugin
+  const pv = resolved.pluginVersion!;
+  await installPlugin(resolved.marketplaceId, resolved.entry.name, resolved.version, pv.source);
+
+  const dir = pluginInstallDir(resolved.marketplaceId, resolved.entry.name, resolved.version);
+  const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as { version?: string };
+  const version = pkg.version ?? resolved.version;
+  const plugin = await loadPluginFromInstallDir(resolved.marketplaceId, resolved.entry.name, resolved.version);
+  const permissions: PluginPermissions = plugin.permissions ?? { tier: "trusted" };
+  const hash = canonicalTierGrantHash(permissions);
+
+  const lockfile = readLockfile(args.lockfilePath);
+  const decision = decideConsent({
+    pluginName: resolved.entry.name,
+    version, hash, permissions, lockfile,
+    interactive: !args.nonInteractive && process.stdin.isTTY === true,
+    allowUnscoped: args.allowUnscoped,
+  });
+
+  const canonical = `${resolved.marketplaceId}/${resolved.entry.name}@${resolved.version}`;
+
+  switch (decision.kind) {
+    case "accept":
+      console.log(`plugin '${resolved.entry.name}' already in lockfile (no changes).`);
+      await maybeAppendProjectPlugin(canonical);
+      return 0;
+
+    case "accept-and-record": {
+      writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, resolved.entry.name, decision.entry));
+      await maybeAppendProjectPlugin(canonical);
+      console.log(`plugin '${resolved.entry.name}' recorded (tier: ${decision.entry.tier}).`);
+      return 0;
+    }
+
+    case "prompt-scoped": {
+      const source = `${resolved.marketplaceId}:${resolved.entry.name}@${version}`;
+      process.stdout.write(renderScopedUAC({ pluginName: resolved.entry.name, version, source, permissions }) + "\n> ");
+      const answer = (await readStdinLine()).trim().toLowerCase();
+      if (answer === "a" || answer === "accept") {
+        writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, resolved.entry.name, decision.entry));
+        await maybeAppendProjectPlugin(canonical);
+        console.log(`plugin '${resolved.entry.name}' accepted and recorded.`);
+        return 0;
+      }
+      console.log(`plugin '${resolved.entry.name}' rejected.`);
+      return 1;
+    }
+
+    case "prompt-unscoped": {
+      const source = `${resolved.marketplaceId}:${resolved.entry.name}@${version}`;
+      process.stdout.write(renderUnscopedUAC({ pluginName: resolved.entry.name, version, source, permissions }) + "\n> ");
+      const typed = (await readStdinLine()).trim();
+      if (typed !== resolved.entry.name) {
+        console.log(`plugin '${resolved.entry.name}' rejected (confirmation did not match).`);
+        return 1;
+      }
+      const entry: LockfileEntry = { ...decision.entry, consentMode: "interactive" };
+      writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, resolved.entry.name, entry));
+      await maybeAppendProjectPlugin(canonical);
+      console.log(`plugin '${resolved.entry.name}' accepted as UNSCOPED and recorded.`);
+      return 0;
+    }
+
+    case "refuse":
+      console.error(`install refused: ${decision.reason}`);
+      return 1;
+  }
+}
+
+async function loadAllCatalogs(): Promise<Record<string, MarketplaceCatalog>> {
+  const cfg = await loadKaizenGlobalConfig();
+  const out: Record<string, MarketplaceCatalog> = {};
+  for (const ref of cfg.marketplaces ?? []) {
+    try { out[ref.id] = await readCatalog(ref.id); } catch { /* skip bad */ }
+  }
+  return out;
+}
+
+async function maybeAppendProjectPlugin(canonicalRef: string): Promise<void> {
+  if (!existsSync(PROJECT_CONFIG)) return;
+  const cfg = JSON.parse(readFileSync(PROJECT_CONFIG, "utf8")) as { plugins?: string[] };
+  cfg.plugins ??= [];
+  if (!cfg.plugins.includes(canonicalRef)) {
+    cfg.plugins.push(canonicalRef);
+    writeFileSync(PROJECT_CONFIG, JSON.stringify(cfg, null, 2) + "\n", "utf8");
+  }
 }
 ```
 
-Flow:
-1. Load global config + all cached catalogs.
-2. `parseRef(ref)` → `resolveRef(parsed, marketplaces, catalogs)` → `ResolvedSource`.
-3. Fetch plugin source to a temp dir (npm install, git clone, HTTP fetch, or local
-   path as-is).
-4. Read `KaizenPlugin` default export from the fetched source.
-5. Run existing consent flow (`runInstall` internals — reuse or inline).
-6. Install: if `ephemeral`, copy to `~/.kaizen/cache/<hash>/`; else npm install to
-   `~/.kaizen/node_modules/`.
-7. Write lockfile entry.
-8. If project config exists and not ephemeral: add canonical ref to `plugins` array
-   in `.kaizen/kaizen.json`.
+- [ ] **Step 2: Keep the old `runInstall` as a thin shim for one release**
 
-- [ ] **Step 2: Deprecation shims in `src/commands/manage.ts`**
+At the bottom of the file, add:
 
-`cmdPluginInstall` prints:
+```ts
+/** @deprecated use runUnifiedInstall. Retained for one release for cli.ts callers. */
+export async function runInstall(args: { pluginName: string; lockfilePath: string; allowUnscoped: boolean; nonInteractive: boolean }): Promise<number> {
+  return runUnifiedInstall({
+    ref: args.pluginName,
+    lockfilePath: args.lockfilePath,
+    allowUnscoped: args.allowUnscoped,
+    nonInteractive: args.nonInteractive,
+  });
+}
 ```
-Note: 'kaizen plugin install' is deprecated. Use 'kaizen install <ref>' instead.
+
+- [ ] **Step 3: Run typecheck + all tests**
+
+Run: `bun x tsc --noEmit && bun test`
+Expected: PASS. Fix any type errors surfaced by the rewrite (e.g. imports).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/install.ts
+git commit -m "feat(cli): unified 'kaizen install <ref>' via ref-resolver + installer"
 ```
-Then delegates to `runUnifiedInstall`.
 
 ---
 
-## Phase 6 — Uninstall & Update
+### Task 11: `src/commands/uninstall.ts`
 
-### Task 6: `src/commands/uninstall.ts`
+**Files:**
+- Create: `src/commands/uninstall.ts`
 
-- [ ] **Step 1: `runUninstall(name, opts: { purge: boolean })`**
+- [ ] **Step 1: Implement**
 
-1. Remove from `.kaizen/kaizen.json` plugins array (if present).
-2. If `--purge`: npm uninstall from `~/.kaizen/node_modules/`; delete lockfile entry.
-3. Print result.
+```ts
+// src/commands/uninstall.ts
+import { existsSync, readFileSync, writeFileSync, rmSync } from "fs";
+import { PROJECT_CONFIG } from "../core/config.js";
+import { readLockfile, writeLockfile, removePluginEntry } from "../core/lockfile.js";
+import { loadKaizenGlobalConfig } from "../core/kaizen-config.js";
+import { readCatalog } from "../core/marketplace.js";
+import { parseRef, resolveRef } from "../core/ref-resolver.js";
+import { pluginInstallDir } from "../core/kaizen-config.js";
 
-### Task 7: `src/commands/update.ts`
+export interface UninstallArgs {
+  ref: string;
+  lockfilePath: string;
+  purge: boolean;
+}
 
-- [ ] **Step 1: `runUpdate(ref?, opts)`**
+export async function runUninstall(args: UninstallArgs): Promise<number> {
+  // Parse the ref so we can purge the correct install dir.
+  const parsed = parseRef(args.ref);
+  const cfg = await loadKaizenGlobalConfig();
+  const catalogs: Record<string, import("../types/plugin.js").MarketplaceCatalog> = {};
+  for (const m of cfg.marketplaces ?? []) {
+    try { catalogs[m.id] = await readCatalog(m.id); } catch {}
+  }
 
-1. If no ref: update all plugins in `.kaizen/kaizen.json`.
-2. Resolve current version from lockfile.
-3. Resolve latest available from catalog or npm.
-4. If version changed: re-run consent flow, install, update lockfile.
-5. If tier/grants unchanged and only version changed: silent update.
+  // Resolve purely for the canonical name; fall back to the parsed name if unresolvable.
+  let name: string = parsed.kind === "legacy-npm" ? parsed.name.replace(/^kaizen-plugin-/, "") : parsed.name;
+  let canonicalPrefix: string | undefined;
+  try {
+    const r = resolveRef(parsed, catalogs);
+    name = r.entry.name;
+    canonicalPrefix = `${r.marketplaceId}/${r.entry.name}@`;
+
+    if (args.purge) {
+      rmSync(pluginInstallDir(r.marketplaceId, r.entry.name, r.version), { recursive: true, force: true });
+    }
+  } catch { /* uninstall still removes from harness + lockfile */ }
+
+  // Remove from project harness.
+  if (existsSync(PROJECT_CONFIG)) {
+    const h = JSON.parse(readFileSync(PROJECT_CONFIG, "utf8")) as { plugins?: string[] };
+    const before = h.plugins?.length ?? 0;
+    h.plugins = (h.plugins ?? []).filter((p) =>
+      p !== name && (canonicalPrefix ? !p.startsWith(canonicalPrefix) : true),
+    );
+    if ((h.plugins?.length ?? 0) !== before) {
+      writeFileSync(PROJECT_CONFIG, JSON.stringify(h, null, 2) + "\n", "utf8");
+    }
+  }
+
+  // Remove from lockfile when --purge.
+  if (args.purge) {
+    const lf = readLockfile(args.lockfilePath);
+    writeLockfile(args.lockfilePath, removePluginEntry(lf, name));
+  }
+
+  console.log(`uninstalled ${name}${args.purge ? " (purged bits + lockfile)" : ""}`);
+  return 0;
+}
+```
+
+- [ ] **Step 2: Minimal test**
+
+Create `src/commands/uninstall.test.ts` exercising: harness array dedupe by
+canonical ref, lockfile removal on `--purge`, install-dir removal on `--purge`.
+
+- [ ] **Step 3: Run test**
+
+Run: `bun test src/commands/uninstall.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/uninstall.ts src/commands/uninstall.test.ts
+git commit -m "feat(cli): kaizen uninstall <ref> [--purge]"
+```
+
+---
+
+### Task 12: `src/commands/update.ts` — silent vs prompting
+
+**Files:**
+- Create: `src/commands/update.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+// src/commands/update.ts
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { MarketplaceCatalog, PluginPermissions } from "../types/plugin.js";
+import { parseRef, resolveRef } from "../core/ref-resolver.js";
+import { loadKaizenGlobalConfig } from "../core/kaizen-config.js";
+import { readCatalog } from "../core/marketplace.js";
+import { installPlugin } from "../core/plugin-installer.js";
+import { loadPluginFromInstallDir } from "../core/plugin-loader.js";
+import { pluginInstallDir } from "../core/kaizen-config.js";
+import { readLockfile, writeLockfile, upsertPluginEntry } from "../core/lockfile.js";
+import { canonicalTierGrantHash } from "../core/plugin-hash.js";
+import { runUnifiedInstall } from "./install.js";
+
+export interface UpdateArgs {
+  ref?: string;             // undefined = update all installed
+  lockfilePath: string;
+  allowUnscoped: boolean;
+  nonInteractive: boolean;
+}
+
+export async function runUpdate(args: UpdateArgs): Promise<number> {
+  const cfg = await loadKaizenGlobalConfig();
+  const catalogs: Record<string, MarketplaceCatalog> = {};
+  for (const m of cfg.marketplaces ?? []) {
+    try { catalogs[m.id] = await readCatalog(m.id); } catch {}
+  }
+
+  const lockfile = readLockfile(args.lockfilePath);
+  const targets = args.ref
+    ? [parseRef(args.ref)]
+    : Object.keys(lockfile.plugins).map((n) => parseRef(n));
+
+  let rc = 0;
+  for (const parsed of targets) {
+    const resolved = resolveRef(parsed, catalogs);
+    if (resolved.entry.kind !== "plugin") continue; // harnesses have no updater
+    const name = resolved.entry.name;
+    const latest = resolved.version;
+    const lfEntry = lockfile.plugins[name];
+    if (lfEntry && lfEntry.version === latest) continue; // already latest
+
+    await installPlugin(resolved.marketplaceId, name, latest, resolved.pluginVersion!.source);
+    const plugin = await loadPluginFromInstallDir(resolved.marketplaceId, name, latest);
+    const permissions: PluginPermissions = plugin.permissions ?? { tier: "trusted" };
+    const newHash = canonicalTierGrantHash(permissions);
+
+    if (lfEntry && lfEntry.hash === newHash) {
+      // Silent update.
+      writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, name, {
+        ...lfEntry, version: latest,
+      }));
+      console.log(`silently updated ${resolved.marketplaceId}/${name} → ${latest}`);
+      continue;
+    }
+
+    // Hash differs — re-run consent via runUnifiedInstall with the canonical ref.
+    const code = await runUnifiedInstall({
+      ref: `${resolved.marketplaceId}/${name}@${latest}`,
+      lockfilePath: args.lockfilePath,
+      allowUnscoped: args.allowUnscoped,
+      nonInteractive: args.nonInteractive,
+    });
+    if (code !== 0) rc = code;
+  }
+  return rc;
+}
+```
+
+- [ ] **Step 2: Test silent vs re-prompt**
+
+Create `src/commands/update.test.ts`:
+- Fixture: local marketplace with plugin v1.0.0 (`tier: trusted`) and v1.0.1
+  (identical permissions) → `runUpdate` silently bumps, no stdin.
+- Fixture: v1.0.1 with a different `fs.read` grant → `runUpdate` dispatches
+  to `runUnifiedInstall`, which prompts (test with `nonInteractive: true` +
+  `--allow-unscoped` to avoid actual TTY).
+
+- [ ] **Step 3: Run test**
+
+Run: `bun test src/commands/update.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/update.ts src/commands/update.test.ts
+git commit -m "feat(cli): kaizen update [<ref>] with silent vs re-prompt by tier/grant hash"
+```
 
 ---
 
 ## Phase 7 — Harness Bootstrap
 
-### Task 8: Bootstrap-on-startup in `src/cli.ts`
+### Task 13: `src/core/bootstrap.ts` — `bootstrapMissingPlugins`
 
-- [ ] **Step 1: Extend `--harness` arg to accept marketplace ref and URL**
+**Files:**
+- Create: `src/core/bootstrap.ts`
+- Create: `src/core/bootstrap.test.ts`
 
-Current: only file path. New: detect form, fetch if URL/marketplace ref.
+Bootstrap takes a harness config + args and:
+1. For each harness `marketplaces` entry not in `~/.kaizen/kaizen.json`:
+   run `addMarketplace` (same code path as `kaizen marketplace add`).
+   Failure is fatal if any plugin ref depends on that marketplace; otherwise warn.
+2. For each plugin ref in `plugins`:
+   - Must be canonical (`<id>/<name>@<version>`) in a harness file (spec
+     requirement). Shorthand in the harness file is a **parse error** here.
+     Legacy `kaizen-plugin-*` remains accepted for one release.
+   - If `isInstalled(...)` returns false: run consent (skip if
+     `--trust-lockfile` covers it via lockfile-entry existence) and install.
 
-- [ ] **Step 2: Implement `bootstrapMissingPlugins(harnessConfig, opts)`**
+- [ ] **Step 1: Write failing test**
 
+```ts
+// src/core/bootstrap.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { $ } from "bun";
+import { bootstrapMissingPlugins } from "./bootstrap.js";
+import { loadKaizenGlobalConfig, pluginInstallDir } from "./kaizen-config.js";
+import { addMarketplace } from "./marketplace.js";
+import { existsSync } from "fs";
+
+let home: string;
+let upstream: string;
+
+beforeEach(async () => {
+  home = mkdtempSync(join(tmpdir(), "kz-home-"));
+  process.env.KAIZEN_HOME_OVERRIDE = home;
+  upstream = mkdtempSync(join(tmpdir(), "kz-up-"));
+  mkdirSync(join(upstream, ".kaizen"), { recursive: true });
+  mkdirSync(join(upstream, "plugins", "demo"), { recursive: true });
+  writeFileSync(join(upstream, "plugins", "demo", "package.json"),
+    JSON.stringify({ name: "demo", version: "1.0.0", main: "index.mjs", type: "module" }));
+  writeFileSync(join(upstream, "plugins", "demo", "index.mjs"),
+    `export default { name: "demo", apiVersion: "2", async setup() {} };`);
+  writeFileSync(join(upstream, ".kaizen", "marketplace.json"), JSON.stringify({
+    version: "1.0.0", name: "M", url: upstream,
+    entries: [{ kind: "plugin", name: "demo", description: "",
+      versions: [{ version: "1.0.0", source: { type: "file", path: "plugins/demo" } }] }],
+  }));
+  await $`git init -q`.cwd(upstream);
+  await $`git -c user.email=t@t -c user.name=t add .`.cwd(upstream);
+  await $`git -c user.email=t@t -c user.name=t commit -qm init`.cwd(upstream);
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  rmSync(upstream, { recursive: true, force: true });
+  delete process.env.KAIZEN_HOME_OVERRIDE;
+});
+
+describe("bootstrapMissingPlugins", () => {
+  it("adds missing marketplace from harness and installs missing plugin", async () => {
+    const lockfilePath = join(home, "kaizen.permissions.lock");
+    const report = await bootstrapMissingPlugins(
+      { plugins: ["m/demo@1.0.0"], marketplaces: [{ id: "m", url: upstream }] },
+      { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: true },
+    );
+    expect(report.marketplacesAdded).toContain("m");
+    expect(report.pluginsInstalled).toContain("m/demo@1.0.0");
+    expect(existsSync(pluginInstallDir("m", "demo", "1.0.0"))).toBe(true);
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.marketplaces?.some((mk) => mk.id === "m")).toBe(true);
+  });
+
+  it("rejects shorthand refs in harness files", async () => {
+    const lockfilePath = join(home, "kaizen.permissions.lock");
+    await expect(bootstrapMissingPlugins(
+      { plugins: ["demo"], marketplaces: [] },
+      { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: false },
+    )).rejects.toThrow(/canonical/i);
+  });
+
+  it("--trust-lockfile + --non-interactive fails fast if lockfile missing a plugin", async () => {
+    await addMarketplace(upstream, { id: "m", local: true });
+    const lockfilePath = join(home, "kaizen.permissions.lock");
+    await expect(bootstrapMissingPlugins(
+      { plugins: ["m/demo@1.0.0"], marketplaces: [] },
+      { lockfilePath, trustLockfile: true, nonInteractive: true, allowUnscoped: false },
+    )).rejects.toThrow(/not in lockfile/i);
+  });
+});
 ```
-For each plugin ref in harnessConfig.plugins:
-  1. Check if already installed (existing isInstalled() check).
-  2. If not installed:
-     a. Resolve ref.
-     b. Run consent flow (skip if --trust-lockfile covers it).
-     c. Install (to node_modules if interactive, cache if ephemeral URL harness).
-  3. Continue to next plugin.
-```
 
-If any consent is denied: fatal with a summary of what was denied.
-If `--non-interactive --trust-lockfile`: fail fast if any plugin missing from lockfile.
+- [ ] **Step 2: Run test, expect failure**
 
-- [ ] **Step 3: Temporary marketplace registration from harness `marketplaces` section**
+Run: `bun test src/core/bootstrap.test.ts`
+Expected: FAIL — module missing.
 
-If harness has a `marketplaces` array, register each entry temporarily (in-memory)
-for this run. Do not write to `~/.kaizen/kaizen.json`.
+- [ ] **Step 3: Implement `src/core/bootstrap.ts`**
 
----
+```ts
+import type { KaizenConfig, MarketplaceRef } from "../types/plugin.js";
+import { loadKaizenGlobalConfig } from "./kaizen-config.js";
+import { addMarketplace } from "./marketplace.js";
+import { parseRef } from "./ref-resolver.js";
+import { readLockfile } from "./lockfile.js";
+import { runUnifiedInstall } from "../commands/install.js";
+import { isInstalled } from "./plugin-manager.js";
 
-## Phase 8 — Wire CLI
+export interface BootstrapOpts {
+  lockfilePath: string;
+  trustLockfile: boolean;
+  nonInteractive: boolean;
+  allowUnscoped: boolean;
+}
 
-### Task 9: Update `src/cli.ts`
+export interface BootstrapReport {
+  marketplacesAdded: string[];
+  pluginsInstalled: string[];
+}
 
-- [ ] **Step 1: Add `kaizen marketplace` subcommand routing**
+export async function bootstrapMissingPlugins(
+  harness: KaizenConfig, opts: BootstrapOpts,
+): Promise<BootstrapReport> {
+  const report: BootstrapReport = { marketplacesAdded: [], pluginsInstalled: [] };
 
-```typescript
-if (subcommand === "marketplace") {
-  const sub = rawArgs[1];
-  // route to cmdMarketplaceAdd / List / Remove / Update / Browse
+  // 1. Add any missing marketplaces listed in the harness.
+  const global = await loadKaizenGlobalConfig();
+  const knownIds = new Set((global.marketplaces ?? []).map((m) => m.id));
+  const harnessMarkets: MarketplaceRef[] = harness.marketplaces ?? [];
+
+  for (const m of harnessMarkets) {
+    if (knownIds.has(m.id)) continue;
+    try {
+      console.log(`Adding marketplace ${m.id} from ${m.url}`);
+      await addMarketplace(m.url, { id: m.id });
+      report.marketplacesAdded.push(m.id);
+    } catch (e) {
+      // Fatal only if a plugin ref depends on this marketplace.
+      const needed = (harness.plugins ?? []).some((p) => p.startsWith(`${m.id}/`));
+      if (needed) {
+        throw new Error(`cannot add marketplace ${m.id} from ${m.url}: ${(e as Error).message}`);
+      }
+      console.warn(`warning: marketplace ${m.id} could not be added: ${(e as Error).message}`);
+    }
+  }
+
+  // 2. Install missing plugins.
+  const lockfile = readLockfile(opts.lockfilePath);
+  for (const refStr of harness.plugins ?? []) {
+    const parsed = parseRef(refStr);
+
+    if (parsed.kind === "shorthand") {
+      throw new Error(
+        `harness plugin ref '${refStr}' is shorthand. ` +
+        `Harness plugin refs must be canonical '<marketplace>/<name>@<version>'.`,
+      );
+    }
+
+    // Canonicalize the install-dir check.
+    let marketplaceId: string;
+    let name: string;
+    let version: string | undefined;
+    if (parsed.kind === "marketplace") {
+      marketplaceId = parsed.marketplaceId;
+      name = parsed.name;
+      version = parsed.version;
+    } else {
+      // legacy-npm — strip prefix, pretend `official`.
+      marketplaceId = "official";
+      name = parsed.name.replace(/^kaizen-plugin-/, "");
+      version = undefined;
+    }
+    if (!version) {
+      throw new Error(`harness plugin ref '${refStr}' must include an explicit version`);
+    }
+
+    if (await isInstalled(marketplaceId, name, version)) continue;
+
+    if (opts.trustLockfile) {
+      if (!lockfile.plugins[name]) {
+        throw new Error(`plugin '${name}' not in lockfile (trust-lockfile mode); run 'kaizen install ${refStr}' first`);
+      }
+    }
+
+    const code = await runUnifiedInstall({
+      ref: refStr,
+      lockfilePath: opts.lockfilePath,
+      allowUnscoped: opts.allowUnscoped,
+      nonInteractive: opts.nonInteractive,
+    });
+    if (code !== 0) throw new Error(`bootstrap install failed for ${refStr}`);
+    report.pluginsInstalled.push(refStr);
+  }
+
+  return report;
 }
 ```
 
-- [ ] **Step 2: Add `kaizen uninstall <ref>` routing**
+- [ ] **Step 4: Run test, verify pass**
 
-- [ ] **Step 3: Add `kaizen update [<ref>]` routing**
+Run: `bun test src/core/bootstrap.test.ts`
+Expected: PASS.
 
-- [ ] **Step 4: Update `kaizen install` routing** to use `runUnifiedInstall`.
+- [ ] **Step 5: Commit**
 
-- [ ] **Step 5: Update `kaizen --harness` path** to call `bootstrapMissingPlugins`
-before `bootstrap(kaizenConfig, builtins)`.
+```bash
+git add src/core/bootstrap.ts src/core/bootstrap.test.ts
+git commit -m "feat(core): bootstrap — add missing marketplaces + install missing plugins for --harness"
+```
 
 ---
 
-## Phase 9 — Tests & Integration
+## Phase 8 — CLI wiring
 
-### Task 10: Integration tests
+### Task 14: `src/cli.ts` — wire new subcommands + flags + refresh
 
-- [ ] **Step 1: End-to-end: local marketplace**
+**Files:**
+- Modify: `src/cli.ts`
 
-Create a temp local marketplace dir with a `file`-source plugin. Run:
-1. `kaizen marketplace add <dir>` — catalog loaded.
-2. `kaizen install local-market/test-plugin` — plugin installed, lockfile written.
-3. `kaizen marketplace list` — shows the marketplace.
-4. `kaizen uninstall test-plugin --purge` — plugin removed.
+- [ ] **Step 1: Route `kaizen marketplace <sub>`**
 
-- [ ] **Step 2: Backward compatibility**
+Insert after the `kaizen apply` block and before the `kaizen install` block:
 
-Existing harness file with `"plugins": ["core-events", "core-executor-anthropic"]`
-(bare npm names) loads without modification. Verify no errors or deprecation noise.
+```ts
+if (subcommand === "marketplace") {
+  const {
+    cmdMarketplaceAdd, cmdMarketplaceList, cmdMarketplaceRemove,
+    cmdMarketplaceUpdate, cmdMarketplaceBrowse,
+  } = await import("./commands/marketplace.js");
+  const sub = rawArgs[1];
+  const rest = rawArgs.slice(2);
+  const idFlag = rest.indexOf("--id");
+  const id = idFlag >= 0 ? rest[idFlag + 1] : undefined;
 
-- [ ] **Step 3: Bootstrap test**
+  let code = 0;
+  switch (sub) {
+    case "add": {
+      const url = rest.find((a) => !a.startsWith("--") && a !== id);
+      if (!url) { console.error("usage: kaizen marketplace add <url> [--id <id>]"); process.exit(2); }
+      code = await cmdMarketplaceAdd({ url, ...(id ? { id } : {}) });
+      break;
+    }
+    case "list":
+      code = await cmdMarketplaceList();
+      break;
+    case "remove": {
+      const target = rest.find((a) => !a.startsWith("--"));
+      if (!target) { console.error("usage: kaizen marketplace remove <id>"); process.exit(2); }
+      code = await cmdMarketplaceRemove({ id: target });
+      break;
+    }
+    case "update": {
+      const target = rest.find((a) => !a.startsWith("--"));
+      code = await cmdMarketplaceUpdate(target ? { id: target } : {});
+      break;
+    }
+    case "browse": {
+      const target = rest.find((a) => !a.startsWith("--"));
+      code = await cmdMarketplaceBrowse(target ? { id: target } : {});
+      break;
+    }
+    default:
+      console.error("Usage: kaizen marketplace {add|list|remove|update|browse} [args]");
+      code = 2;
+  }
+  process.exit(code);
+}
+```
 
-Write a harness JSON referencing a local marketplace plugin. Run `kaizen --harness
-<file>` with missing plugin — bootstrap triggers consent + install, then kaizen starts.
+- [ ] **Step 2: Rework `kaizen install` to use unified installer**
+
+Replace existing install block with:
+
+```ts
+if (subcommand === "install") {
+  const rest = rawArgs.slice(1);
+  const ref = rest.find((a) => !a.startsWith("--"));
+  if (!ref) { console.error("usage: kaizen install <ref> [--allow-unscoped] [--non-interactive]"); process.exit(2); }
+  const { runUnifiedInstall } = await import("./commands/install.js");
+  const code = await runUnifiedInstall({
+    ref,
+    lockfilePath: join(process.cwd(), "kaizen.permissions.lock"),
+    allowUnscoped: rest.includes("--allow-unscoped"),
+    nonInteractive: rest.includes("--non-interactive"),
+  });
+  process.exit(code);
+}
+```
+
+- [ ] **Step 3: Add `kaizen uninstall <ref>` routing**
+
+Add after install block:
+
+```ts
+if (subcommand === "uninstall") {
+  const rest = rawArgs.slice(1);
+  const ref = rest.find((a) => !a.startsWith("--"));
+  if (!ref) { console.error("usage: kaizen uninstall <ref> [--purge]"); process.exit(2); }
+  const { runUninstall } = await import("./commands/uninstall.js");
+  const code = await runUninstall({
+    ref,
+    lockfilePath: join(process.cwd(), "kaizen.permissions.lock"),
+    purge: rest.includes("--purge"),
+  });
+  process.exit(code);
+}
+```
+
+- [ ] **Step 4: Add `kaizen update [<ref>]` routing**
+
+```ts
+if (subcommand === "update") {
+  const rest = rawArgs.slice(1);
+  const ref = rest.find((a) => !a.startsWith("--"));
+  const { runUpdate } = await import("./commands/update.js");
+  const code = await runUpdate({
+    ...(ref ? { ref } : {}),
+    lockfilePath: join(process.cwd(), "kaizen.permissions.lock"),
+    allowUnscoped: rest.includes("--allow-unscoped"),
+    nonInteractive: rest.includes("--non-interactive"),
+  });
+  process.exit(code);
+}
+```
+
+- [ ] **Step 5: Extend `--harness` parsing: reject raw URLs; dispatch marketplace refs**
+
+In `parseRunArgs`, if `harness` is set and matches `/^https?:\/\//`, call
+`fatal("raw URL harnesses are not supported — publish the harness in a marketplace and use --harness <id>/<name>@<version>")`.
+
+Then, **before** `resolveConfig`, call new helper `materializeHarnessArg`:
+
+```ts
+function materializeHarnessArg(arg?: string): string | undefined {
+  if (arg === undefined) return undefined;
+  if (/^https?:\/\//i.test(arg)) fatal("raw URL harnesses are not supported (see --harness docs)");
+  if (arg.startsWith("./") || arg.startsWith("/") || arg.startsWith("../")) return arg; // local path
+  if (arg.includes("/")) {
+    // Marketplace ref — dispatch to installHarness so the file lands at
+    // ~/.kaizen/marketplaces/<id>/harnesses/<name>/kaizen.json, then return
+    // that path for resolveConfig to read.
+    // (Implementation: parseRef + resolveRef + installHarness + return absolute path.)
+    // See helper below.
+    return resolveMarketplaceHarnessSync(arg);
+  }
+  return arg; // bare name — existing built-in / project / home lookup via loadHarnessConfig
+}
+```
+
+Because `materializeHarnessArg` needs async work (catalog read), move the
+harness block to its own `await` path — see Step 6.
+
+- [ ] **Step 6: Add bootstrap call before `bootstrap(kaizenConfig, builtins)`**
+
+Replace the final block (starting at the `parseRunArgs` call) with:
+
+```ts
+const parsed = parseRunArgs(rawArgs);
+
+if (parsed.harness !== undefined && /^https?:\/\//i.test(parsed.harness)) {
+  fatal("raw URL harnesses are not supported — publish the harness in a marketplace and use --harness <id>/<name>@<version>");
+}
+
+const trustLockfile = rawArgs.includes("--trust-lockfile");
+const nonInteractive = rawArgs.includes("--non-interactive");
+const allowUnscopedFlag = rawArgs.includes("--allow-unscoped");
+
+// Materialize marketplace-ref harnesses to a concrete path.
+let harnessArg = parsed.harness;
+if (harnessArg !== undefined && harnessArg.includes("/") &&
+    !harnessArg.startsWith("./") && !harnessArg.startsWith("/") && !harnessArg.startsWith("../")) {
+  const { parseRef, resolveRef } = await import("./core/ref-resolver.js");
+  const { loadKaizenGlobalConfig, harnessInstallDir } = await import("./core/kaizen-config.js");
+  const { readCatalog } = await import("./core/marketplace.js");
+  const { installHarness } = await import("./core/plugin-installer.js");
+  const cfg = await loadKaizenGlobalConfig();
+  const catalogs: Record<string, import("./types/plugin.js").MarketplaceCatalog> = {};
+  for (const m of cfg.marketplaces ?? []) {
+    try { catalogs[m.id] = await readCatalog(m.id); } catch {}
+  }
+  const r = resolveRef(parseRef(harnessArg), catalogs);
+  if (r.entry.kind !== "harness") fatal(`--harness ref '${harnessArg}' does not resolve to a harness entry`);
+  const hv = r.entry.versions.find((v) => v.version === r.version)!;
+  await installHarness(r.marketplaceId, r.entry.name, hv.path);
+  harnessArg = join(harnessInstallDir(r.marketplaceId, r.entry.name), "kaizen.json");
+}
+
+const kaizenConfig = resolveConfig({
+  ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
+  ...(parsed.configPath !== undefined ? { configPath: parsed.configPath } : {}),
+});
+
+// Bootstrap any missing marketplaces + plugins referenced by the harness.
+if (kaizenConfig.marketplaces || (kaizenConfig.plugins ?? []).some((p) => p.includes("/"))) {
+  const { bootstrapMissingPlugins } = await import("./core/bootstrap.js");
+  await bootstrapMissingPlugins(kaizenConfig, {
+    lockfilePath: join(process.cwd(), "kaizen.permissions.lock"),
+    trustLockfile, nonInteractive, allowUnscoped: allowUnscopedFlag,
+  });
+}
+
+if (parsed.allowDestructive) { /* … existing allow-destructive logic … */ }
+if (parsed.prompt) { /* … existing prompt wiring … */ }
+
+// Background marketplace refresh (non-blocking).
+{
+  const { loadKaizenGlobalConfig } = await import("./core/kaizen-config.js");
+  const { shouldRefresh, refreshInBackground } = await import("./core/marketplace.js");
+  const cfg = await loadKaizenGlobalConfig();
+  const ttl = cfg.marketplaceUpdateTTL ?? 900;
+  for (const m of cfg.marketplaces ?? []) {
+    if (shouldRefresh(m, ttl)) refreshInBackground(m.id);
+  }
+}
+
+await bootstrap(kaizenConfig, builtins);
+```
+
+(Trim the existing `allowDestructive` / `prompt` logic back in where the
+comments indicate — do not duplicate.)
+
+- [ ] **Step 7: Typecheck + test**
+
+Run: `bun x tsc --noEmit && bun test`
+Expected: PASS. Fix any fallout (particularly `FLAGS_WITH_VALUE` must still
+include `--harness` + `--config`; `--trust-lockfile`, `--non-interactive`, and
+`--allow-unscoped` are boolean).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cli.ts
+git commit -m "feat(cli): wire marketplace, uninstall, update; --harness accepts marketplace refs; bootstrap + background refresh"
+```
+
+---
+
+### Task 15: Deprecation shims & legacy resolver
+
+**Files:**
+- Modify: `src/commands/manage.ts`
+
+- [ ] **Step 1: Add deprecation notices**
+
+In `cmdPluginInstall(name)`, at the top:
+
+```ts
+console.warn("note: 'kaizen plugin install' is deprecated. Use 'kaizen install <ref>'.");
+```
+
+If `name` matches `/^kaizen-plugin-/`, console.warn with:
+```
+legacy plugin name '<name>' — auto-resolving against 'official' marketplace (deprecated, remove before v-next)
+```
+and delegate to `runUnifiedInstall({ ref: name, ... })` instead of the
+existing install flow.
+
+Same pattern for `cmdPluginRemove`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/commands/manage.ts
+git commit -m "refactor(cli): deprecate 'kaizen plugin install/remove'; auto-resolve legacy kaizen-plugin-* against 'official'"
+```
+
+---
+
+## Phase 9 — Integration
+
+### Task 16: End-to-end integration test (local git marketplace)
+
+**Files:**
+- Create: `tests/integration/marketplace.integration.test.ts`
+
+Covers the golden path: clone a real local git marketplace with a `file`-source
+plugin, install, load, uninstall.
+
+- [ ] **Step 1: Write the integration test**
+
+```ts
+// tests/integration/marketplace.integration.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { $ } from "bun";
+import { addMarketplace } from "../../src/core/marketplace.js";
+import { runUnifiedInstall } from "../../src/commands/install.js";
+import { runUninstall } from "../../src/commands/uninstall.js";
+import { pluginInstallDir } from "../../src/core/kaizen-config.js";
+
+describe("integration: local git marketplace, file-source plugin", () => {
+  let home: string; let upstream: string; let project: string;
+  beforeEach(async () => {
+    home = mkdtempSync(join(tmpdir(), "kz-home-"));
+    upstream = mkdtempSync(join(tmpdir(), "kz-up-"));
+    project = mkdtempSync(join(tmpdir(), "kz-proj-"));
+    process.env.KAIZEN_HOME_OVERRIDE = home;
+
+    mkdirSync(join(upstream, "plugins", "demo"), { recursive: true });
+    writeFileSync(join(upstream, "plugins", "demo", "package.json"),
+      JSON.stringify({ name: "demo", version: "1.0.0", main: "index.mjs", type: "module" }));
+    writeFileSync(join(upstream, "plugins", "demo", "index.mjs"),
+      `export default { name: "demo", apiVersion: "2", async setup() {} };`);
+    mkdirSync(join(upstream, ".kaizen"), { recursive: true });
+    writeFileSync(join(upstream, ".kaizen", "marketplace.json"), JSON.stringify({
+      version: "1.0.0", name: "Local", url: upstream,
+      entries: [{ kind: "plugin", name: "demo", description: "",
+        versions: [{ version: "1.0.0", source: { type: "file", path: "plugins/demo" } }] }],
+    }));
+    await $`git init -q`.cwd(upstream);
+    await $`git -c user.email=t@t -c user.name=t add .`.cwd(upstream);
+    await $`git -c user.email=t@t -c user.name=t commit -qm init`.cwd(upstream);
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(upstream, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+    delete process.env.KAIZEN_HOME_OVERRIDE;
+  });
+
+  it("add → install → uninstall --purge", async () => {
+    await addMarketplace(upstream, { id: "local" });
+    const lock = join(project, "kaizen.permissions.lock");
+
+    const code = await runUnifiedInstall({
+      ref: "local/demo@1.0.0", lockfilePath: lock,
+      allowUnscoped: false, nonInteractive: true,
+    });
+    expect(code).toBe(0);
+    expect(existsSync(pluginInstallDir("local", "demo", "1.0.0"))).toBe(true);
+
+    const code2 = await runUninstall({ ref: "local/demo@1.0.0", lockfilePath: lock, purge: true });
+    expect(code2).toBe(0);
+    expect(existsSync(pluginInstallDir("local", "demo", "1.0.0"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `bun test tests/integration/marketplace.integration.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Full test run**
+
+Run: `bun test`
+Expected: PASS across the whole suite.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/marketplace.integration.test.ts
+git commit -m "test(integration): marketplace add → install → uninstall e2e"
+```
 
 ---
 
 ## Phase 10 — Docs
 
-### Task 11: Documentation updates
+### Task 17: Documentation updates
 
-- [ ] Update `docs/architecture.md` — kaizen-level config, marketplace resolution in
-  plugin resolution order.
-- [ ] Update `README.md` — add `kaizen marketplace` to commands reference.
-- [ ] Add marketplace section to `docs/plugin-api.md` — "Installing from a marketplace".
+**Files:**
+- Modify: `docs/architecture.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Update `docs/architecture.md`**
+
+Add a new section **"Marketplaces & plugin resolution"** with:
+- The install tree under `~/.kaizen/marketplaces/<id>/{repo,plugins/<n>@<v>,harnesses/<n>}`.
+- The two ref forms (marketplace-qualified + shorthand) and the rejection list.
+- The fact that third-party plugins are imported by absolute path — **not**
+  via `node_modules`.
+- Reference `src/core/kaizen-config.ts` as the owner of all `~/.kaizen/` paths.
+
+- [ ] **Step 2: Update `README.md`**
+
+Under "Commands", replace the existing install docs with:
+```
+kaizen marketplace add <url> [--id <id>]
+kaizen marketplace list
+kaizen marketplace remove <id>
+kaizen marketplace update [<id>]
+kaizen marketplace browse [<id>]
+kaizen install <ref>                # <marketplace>/<name>[@<version>] or shorthand
+kaizen uninstall <ref> [--purge]
+kaizen update [<ref>]
+kaizen --harness <file|ref>         # raw URLs rejected; publish harness in a marketplace
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture.md README.md
+git commit -m "docs: marketplace resolution, unified install CLI, install tree"
+```
+
+---
+
+## Self-review checklist (run after plan execution, before PR)
+
+1. `bun x tsc --noEmit` → 0 errors.
+2. `bun test` → all pass (unit + integration).
+3. `rg "~\\/\\.kaizen" src/` → only appears in `src/core/kaizen-config.ts`
+   and (transitionally) `src/core/config.ts` (legacy harness paths).
+4. `rg "node_modules" src/commands src/core/plugin-installer.ts
+     src/core/plugin-loader.ts` → no hits except intentional docstrings.
+5. Every public function added has at least one unit test.
+6. Every error message from the spec's error-handling table is emitted by the
+   corresponding code path (grep for message fragments in the tests).
+7. Deprecation notices print on legacy command paths.

--- a/docs/superpowers/plans/2026-04-18-plugin-scaffolder-standards.md
+++ b/docs/superpowers/plans/2026-04-18-plugin-scaffolder-standards.md
@@ -1,0 +1,342 @@
+# Plugin & Marketplace Scaffolders + Coding Standards — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `kaizen plugin create`, `kaizen marketplace create`, `kaizen plugin
+validate`, `kaizen marketplace validate`, and `docs/plugin-standards.md`. After
+this plan, a new plugin author has a fully standards-compliant scaffold in seconds,
+and existing authors can check compliance with a single command.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md`
+
+**Prerequisites:**
+- Spec 1 (marketplace format) — `kaizen marketplace create` emits `.kaizen/marketplace.json`
+- Spec 2 (unified config) — scaffolded plugins emit `config.schema` pattern
+
+Both can be implemented in parallel; integrate templates after Specs 1+2 land.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/commands/plugin-create.ts` — `kaizen plugin create` scaffolder
+- `src/commands/plugin-create.test.ts`
+- `src/commands/marketplace-create.ts` — `kaizen marketplace create` scaffolder
+- `src/commands/marketplace-create.test.ts`
+- `src/commands/plugin-validate.ts` — plugin validator
+- `src/commands/plugin-validate.test.ts`
+- `src/commands/marketplace-validate.ts` — marketplace catalog validator
+- `src/commands/marketplace-validate.test.ts`
+- `docs/plugin-standards.md` — coding standards document
+
+**Modified files:**
+- `src/cli.ts` — wire new subcommands
+
+---
+
+## Phase 1 — Standards Document
+
+### Task 1: Write `docs/plugin-standards.md`
+
+Write the full standards document first — it drives what the validator checks.
+
+- [ ] **Step 1: Write `docs/plugin-standards.md`**
+
+Content covers (see spec for full outline):
+1. Package structure (required files, package.json fields)
+2. Plugin manifest (required fields, apiVersion)
+3. Permission tier selection
+4. Capability naming
+5. Configuration (config.schema, secrets pattern)
+6. Testing (bun:test, makeCtx pattern, coverage expectations)
+7. Error handling (return vs throw conventions)
+8. Event handling
+9. Publishing (keywords, README sections, marketplace submission)
+10. API version pinning
+
+Each rule is marked `[required]` (checked by `kaizen plugin validate`) or
+`[guideline]` (informational only).
+
+---
+
+## Phase 2 — Plugin Validator
+
+Implement the validator before the scaffolder — the scaffolder must produce output
+that passes validation.
+
+### Task 2: Implement `src/commands/plugin-validate.ts`
+
+- [ ] **Step 1: Define `ValidationResult` type**
+
+```typescript
+export interface ValidationResult {
+  rule: string;
+  status: "pass" | "fail" | "warn";
+  message?: string;
+}
+```
+
+- [ ] **Step 2: Implement structural checks**
+
+```typescript
+async function checkPackageJson(dir: string): Promise<ValidationResult[]>
+```
+
+Checks (each returns a `ValidationResult`):
+- `package.json` exists.
+- `name` present and matches `^[a-z][a-z0-9-]*$`.
+- `"type"` equals `"module"`.
+- `exports["."]` present.
+- `keywords` includes `"kaizen-plugin"`.
+- `version` present and semver.
+
+- [ ] **Step 3: Implement manifest checks**
+
+Load the plugin's default export (dynamic import of the entry point from
+`exports["."]`):
+- `plugin.name` matches `package.json` name.
+- `plugin.apiVersion` present and is semver string.
+- `plugin.permissions` present.
+- `plugin.permissions.tier` is `"trusted"` | `"scoped"` | `"unscoped"`.
+- If `tier === "scoped"`: at least one grant key populated.
+- `plugin.capabilities` field present (object, may be empty).
+
+- [ ] **Step 4: Implement config schema checks**
+
+If `plugin.config` declared:
+- `plugin.config.schema` is a valid JSON Schema (use `validateSchemaItself` from
+  Spec 2's `config-validator.ts`).
+- Every key in `plugin.config.secrets` appears in `plugin.config.schema.properties`.
+- Every key in `plugin.config.secrets` appears in `plugin.permissions.env`.
+
+- [ ] **Step 5: Implement import scan**
+
+Static scan of the plugin entry file for forbidden imports. Use `Bun.Transpiler` to
+extract imports:
+
+```typescript
+async function scanImports(filePath: string): Promise<string[]>
+```
+
+For TRUSTED and SCOPED plugins, flag any direct import of:
+- `node:fs`, `node:child_process`, `node:worker_threads`, `bun:ffi`
+- The bare equivalents without `node:` prefix where unambiguous.
+
+Emit as `warn` (not `fail`) — the runtime enforcer is the authoritative gate;
+the static scan is an early signal. Add comment in output:
+`"Note: runtime enforcer will block this regardless of validate status."`
+
+- [ ] **Step 6: Check for tests and README**
+
+- `*.test.ts` file exists in the plugin directory.
+- `README.md` exists.
+
+- [ ] **Step 7: Implement `runPluginValidate(dir: string)`**
+
+Collect all results, print pass/fail/warn per rule, print summary. Exit 0 if no
+failures, exit 1 if any failures.
+
+- [ ] **Step 8: Write `src/commands/plugin-validate.test.ts`**
+
+For each rule: a passing fixture and a failing fixture. Keep fixtures minimal —
+inline as temp dirs in tests, not checked-in fixtures.
+
+---
+
+## Phase 3 — Marketplace Validator
+
+### Task 3: Implement `src/commands/marketplace-validate.ts`
+
+- [ ] **Step 1: Implement `runMarketplaceValidate(dir: string)`**
+
+Checks:
+- `.kaizen/marketplace.json` exists.
+- `version` equals `"1.0.0"`.
+- `name` non-empty string.
+- `url` non-empty string.
+- `plugins` is an array.
+- `harnesses` is an array.
+- Each plugin entry: `name`, `description`, `versions` (array, non-empty).
+- Each harness entry: `name`, `description`, `versions` (array, non-empty).
+- Each version entry: `version` (semver), `source` present.
+- `file` source paths: `existsSync(join(dir, entry.source.path))`.
+
+- [ ] **Step 2: Write `src/commands/marketplace-validate.test.ts`**
+
+Valid catalog, missing required fields, bad version, missing file source.
+
+---
+
+## Phase 4 — Plugin Scaffolder
+
+### Task 4: Implement `src/commands/plugin-create.ts`
+
+- [ ] **Step 1: Implement `promptPluginConfig(): Promise<PluginScaffoldConfig>`**
+
+Use readline (or `@inquirer/prompts` if added as a dev dep) for interactive prompts.
+
+```typescript
+interface PluginScaffoldConfig {
+  name: string;
+  description: string;
+  tier: "trusted" | "scoped" | "unscoped";
+  grants: Array<"fs" | "net" | "env" | "exec" | "events">;
+  provides: string[];
+  consumes: string[];
+  hasConfig: boolean;
+  configKeys: Array<{ name: string; type: string; required: boolean; secret: boolean }>;
+}
+```
+
+`--defaults` flag: skip all prompts, use `<path>` basename as name, tier=trusted,
+no grants, no capabilities, no config.
+
+- [ ] **Step 2: Implement file generators**
+
+```typescript
+function generatePackageJson(cfg: PluginScaffoldConfig): string
+function generateTsConfig(): string
+function generateIndexTs(cfg: PluginScaffoldConfig): string
+function generateIndexTestTs(cfg: PluginScaffoldConfig): string
+function generateReadme(cfg: PluginScaffoldConfig): string
+```
+
+Each returns a string. Follow templates from the spec exactly.
+
+- [ ] **Step 3: Implement `runPluginCreate(targetPath: string, opts)`**
+
+1. Check `targetPath` does not exist. If exists: error.
+2. Run prompts (or use defaults).
+3. `mkdirSync(targetPath, { recursive: true })`.
+4. Write each file.
+5. `mkdirSync(join(targetPath, ".kaizen"), { recursive: true })`.
+6. `writeFileSync(join(targetPath, ".kaizen", ".gitkeep"), "")`.
+7. Print:
+   ```
+   Created plugin scaffold at ./my-plugin
+   Next steps:
+     cd my-plugin
+     bun install
+     bun test
+     kaizen plugin validate .
+   ```
+
+- [ ] **Step 4: Write `src/commands/plugin-create.test.ts`**
+
+- Non-interactive (`--defaults`): generates all files, all files pass `kaizen plugin
+  validate` (call the validator programmatically in the test).
+- `bun test` passes on the scaffolded output (run as subprocess in test).
+- Target path already exists → error.
+
+---
+
+## Phase 5 — Marketplace Scaffolder
+
+### Task 5: Implement `src/commands/marketplace-create.ts`
+
+- [ ] **Step 1: Implement `promptMarketplaceConfig()`**
+
+Prompts: name, description, URL. `--defaults`: use `<path>` basename as name.
+
+- [ ] **Step 2: Implement `runMarketplaceCreate(targetPath, opts)`**
+
+1. Check `targetPath` does not exist.
+2. Prompt.
+3. Create:
+   - `<path>/.kaizen/marketplace.json` (from spec template).
+   - `<path>/plugins/.gitkeep`.
+   - `<path>/harnesses/.gitkeep`.
+   - `<path>/README.md`.
+4. Print next steps including `kaizen marketplace validate .`.
+
+- [ ] **Step 3: Write `src/commands/marketplace-create.test.ts`**
+
+Non-interactive: generates files, `kaizen marketplace validate .` passes.
+
+---
+
+## Phase 6 — Wire CLI
+
+### Task 6: Update `src/cli.ts`
+
+- [ ] **Step 1: Add `kaizen plugin create <path>` routing**
+
+In the `if (subcommand === "plugin")` block:
+```typescript
+if (pluginSub === "create") {
+  const { runPluginCreate } = await import("./commands/plugin-create.js");
+  const targetPath = name ?? ".";
+  const code = await runPluginCreate(targetPath, { defaults: rest.includes("--defaults") });
+  process.exit(code);
+}
+```
+
+- [ ] **Step 2: Add `kaizen plugin validate [<path>]` routing**
+
+```typescript
+if (pluginSub === "validate") {
+  const { runPluginValidate } = await import("./commands/plugin-validate.js");
+  const targetPath = name ?? ".";
+  const code = await runPluginValidate(targetPath);
+  process.exit(code);
+}
+```
+
+- [ ] **Step 3: Add `kaizen marketplace create <path>` routing**
+
+In the `if (subcommand === "marketplace")` block:
+```typescript
+if (sub === "create") {
+  const { runMarketplaceCreate } = await import("./commands/marketplace-create.js");
+  const targetPath = rawArgs[2] ?? ".";
+  const code = await runMarketplaceCreate(targetPath, { defaults: rawArgs.includes("--defaults") });
+  process.exit(code);
+}
+```
+
+- [ ] **Step 4: Add `kaizen marketplace validate [<path>]` routing**
+
+```typescript
+if (sub === "validate") {
+  const { runMarketplaceValidate } = await import("./commands/marketplace-validate.js");
+  const targetPath = rawArgs[2] ?? ".";
+  const code = await runMarketplaceValidate(targetPath);
+  process.exit(code);
+}
+```
+
+- [ ] **Step 5: Update help text for `kaizen plugin` and `kaizen marketplace`**
+
+Add `create` and `validate` to the usage strings.
+
+---
+
+## Phase 7 — Integration & Docs
+
+### Task 7: End-to-end integration test
+
+- [ ] **Step 1: Full workflow test**
+
+```
+kaizen plugin create ./test-plugin --defaults
+cd test-plugin && bun install && bun test
+kaizen plugin validate ./test-plugin       # must exit 0
+```
+Run this as a subprocess-based integration test.
+
+- [ ] **Step 2: Marketplace workflow test**
+
+```
+kaizen marketplace create ./test-market --defaults
+kaizen marketplace validate ./test-market  # must exit 0
+```
+
+### Task 8: Documentation
+
+- [ ] Update `README.md` commands reference: add `kaizen plugin create/validate` and
+  `kaizen marketplace create/validate`.
+- [ ] Update `docs/plugin-api.md`: add "Creating a plugin" section that links to
+  `kaizen plugin create` and `docs/plugin-standards.md`.
+- [ ] Verify `docs/plugin-standards.md` is complete and all `[required]` rules have
+  corresponding validator checks.

--- a/docs/superpowers/plans/2026-04-18-plugin-scaffolder-standards.md
+++ b/docs/superpowers/plans/2026-04-18-plugin-scaffolder-standards.md
@@ -10,10 +10,17 @@ and existing authors can check compliance with a single command.
 **Spec:** `docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md`
 
 **Prerequisites:**
-- Spec 1 (marketplace format) — `kaizen marketplace create` emits `.kaizen/marketplace.json`
-- Spec 2 (unified config) — scaffolded plugins emit `config.schema` pattern
+- Spec 1 (marketplace format) — `kaizen marketplace create` emits
+  `.kaizen/marketplace.json` using the `entries[]` catalog shape with
+  `kind: "plugin" | "harness"` tags and names unique across kinds.
+- Spec 2 (unified config + secrets) — scaffolded plugins emit `config.schema`
+  with `secrets: [...]` declarations, access secrets via `ctx.secrets.get()`,
+  and (when any secret is declared) explicitly list
+  `core-secrets:provider` in `capabilities.consumes`.
 
 Both can be implemented in parallel; integrate templates after Specs 1+2 land.
+This plan assumes Specs 1 and 2 are at least in draft with the current
+revisions — templates here are written against those revisions.
 
 ---
 
@@ -108,7 +115,17 @@ If `plugin.config` declared:
 - `plugin.config.schema` is a valid JSON Schema (use `validateSchemaItself` from
   Spec 2's `config-validator.ts`).
 - Every key in `plugin.config.secrets` appears in `plugin.config.schema.properties`.
-- Every key in `plugin.config.secrets` appears in `plugin.permissions.env`.
+- If `plugin.config.secrets` is non-empty and `capabilities.consumes` does NOT
+  include `"core-secrets:provider"`: emit a `warn`-level `ValidationResult`
+  with message "core-secrets:provider dependency is implicit per Spec 2; list
+  it explicitly for discoverability." Never fail on this — the dep is
+  implicit and the runtime enforcer treats it as declared.
+
+**Not checked here (intentionally):** Provider-existence for
+`StructuredSecretRef.provider` names. That requires a live harness and
+provider registry; it is enforced at `kaizen install` and `kaizen run`, not
+by static `plugin validate`. Do NOT cross-reference `config.secrets` against
+`permissions.env` — Spec 2 decouples secrets from env grants.
 
 - [ ] **Step 5: Implement import scan**
 
@@ -150,21 +167,41 @@ inline as temp dirs in tests, not checked-in fixtures.
 
 - [ ] **Step 1: Implement `runMarketplaceValidate(dir: string)`**
 
-Checks:
+Checks (against the Spec 1 `entries[]` catalog shape):
 - `.kaizen/marketplace.json` exists.
 - `version` equals `"1.0.0"`.
 - `name` non-empty string.
 - `url` non-empty string.
-- `plugins` is an array.
-- `harnesses` is an array.
-- Each plugin entry: `name`, `description`, `versions` (array, non-empty).
-- Each harness entry: `name`, `description`, `versions` (array, non-empty).
-- Each version entry: `version` (semver), `source` present.
-- `file` source paths: `existsSync(join(dir, entry.source.path))`.
+- `entries` is an array.
+- **Legacy shape rejection.** If the catalog has top-level `plugins` or
+  `harnesses` arrays (the pre-revision shape), fail with a migration error:
+  "marketplace.json uses the legacy `{plugins, harnesses}` shape; convert to
+  `entries[]` with `kind` tags per Spec 1."
+- Each entry has `kind ∈ {"plugin", "harness"}`.
+- Each entry `name` matches `^[a-z][a-z0-9-]*$`.
+- Names unique across **all** entries (a plugin and harness cannot share a
+  name).
+- Each entry has `description` (non-empty), `versions` (array, non-empty).
+- Each version entry: `version` (semver parse).
+- **Plugin versions** require `source`; validate as a tagged union:
+  - `source.type === "npm"`: `name` (non-empty), `version` (semver).
+  - `source.type === "tarball"`: `url` (non-empty); optional `sha256`
+    (hex, 64 chars).
+  - `source.type === "file"`: `path` (non-empty);
+    `existsSync(join(dir, source.path))`.
+- **Harness versions** require `path` (non-empty);
+  `existsSync(join(dir, version.path))`.
+- Optional `minKaizenVersion`: if present, must be a valid semver range.
 
 - [ ] **Step 2: Write `src/commands/marketplace-validate.test.ts`**
 
-Valid catalog, missing required fields, bad version, missing file source.
+- Valid `entries[]` catalog (mixed plugin + harness).
+- Legacy `{plugins, harnesses}` catalog → migration error.
+- Cross-kind name collision → fatal.
+- Each source-type variant (`npm`, `tarball`, `file`) — valid + malformed.
+- Missing `file` source path on disk → fatal.
+- Missing harness `path` on disk → fatal.
+- Bad semver in `version` or `minKaizenVersion`.
 
 ---
 
@@ -202,7 +239,48 @@ function generateIndexTestTs(cfg: PluginScaffoldConfig): string
 function generateReadme(cfg: PluginScaffoldConfig): string
 ```
 
-Each returns a string. Follow templates from the spec exactly.
+Each returns a string. Follow templates from the spec exactly. Key behaviours
+the generators must implement:
+
+- **`generateIndexTs`:**
+  - Import type from `"kaizen/types"`. (In-tree scaffolding is not supported
+    — see spec Future Work.)
+  - If `cfg.configKeys` has any `secret: true` entry: include
+    `"core-secrets:provider"` in `capabilities.consumes` alongside any
+    user-specified consumes.
+  - Do NOT add an `env:` grant for secret keys (secrets are decoupled from
+    the permissions env surface).
+  - `config.secrets` lists every secret key; `config.schema.properties`
+    includes every config key (secret or not); `config.defaults` only for
+    non-secret keys with reasonable defaults.
+  - `setup()` body demonstrates `await ctx.secrets.get("<first-secret>")` if
+    any secrets exist, and a `ctx.log` call.
+
+- **`generateIndexTestTs`:**
+  - `makeCtx()` helper exposes async `ctx.secrets.get/refresh` (returning
+    `Promise<string | undefined>`) and a `ctx.config` object pre-populated
+    from `config.defaults`.
+  - One test asserts plugin metadata; one test calls `plugin.setup(ctx)`
+    with a stubbed secret value and asserts `ctx.log` was called.
+
+- **`generateReadme`:**
+  - Install example uses a placeholder marketplace-qualified ref
+    (`<marketplace>/<plugin-name>`), with a footnote explaining shorthand is
+    accepted at the CLI and canonicalised into harness files.
+  - Config table includes a `Secret` column (yes/no).
+  - Harness snippet uses canonical `<marketplace>/<plugin-name>@<version>`
+    for the plugin ref and a bare-string secret ref (default provider
+    `kaizen`); shows the structured `{ provider, ref }` alternative
+    immediately after.
+  - Includes `kaizen config set-secret <plugin> <key>` as the recommended
+    way to populate a secret.
+  - Permissions section explicitly notes that secrets do NOT need an `env`
+    grant.
+
+- **`generatePackageJson`:** unchanged from prior draft — still emits
+  `"type": "module"`, `exports["."]`, `"kaizen-plugin"` keyword, and
+  `peerDependencies: { "kaizen": "*" }` (the peer dep is authoritative once
+  Spec 4 ships `kaizen` as an npm package).
 
 - [ ] **Step 3: Implement `runPluginCreate(targetPath: string, opts)`**
 
@@ -244,10 +322,14 @@ Prompts: name, description, URL. `--defaults`: use `<path>` basename as name.
 1. Check `targetPath` does not exist.
 2. Prompt.
 3. Create:
-   - `<path>/.kaizen/marketplace.json` (from spec template).
+   - `<path>/.kaizen/marketplace.json` — emit the Spec 1 `entries[]` shape
+     (top-level `version`, `name`, `description`, `url`, `entries: []`). Do
+     NOT emit legacy `plugins: []` / `harnesses: []` fields.
    - `<path>/plugins/.gitkeep`.
    - `<path>/harnesses/.gitkeep`.
-   - `<path>/README.md`.
+   - `<path>/README.md` — include a short section showing how to add a
+     plugin entry (with `kind: "plugin"`) and a harness entry (with
+     `kind: "harness"`), referencing the tagged-union source shape.
 4. Print next steps including `kaizen marketplace validate .`.
 
 - [ ] **Step 3: Write `src/commands/marketplace-create.test.ts`**
@@ -316,7 +398,7 @@ Add `create` and `validate` to the usage strings.
 
 ### Task 7: End-to-end integration test
 
-- [ ] **Step 1: Full workflow test**
+- [ ] **Step 1: Full workflow test (default scaffold, no secrets)**
 
 ```
 kaizen plugin create ./test-plugin --defaults
@@ -324,6 +406,18 @@ cd test-plugin && bun install && bun test
 kaizen plugin validate ./test-plugin       # must exit 0
 ```
 Run this as a subprocess-based integration test.
+
+- [ ] **Step 1b: Workflow test (scaffold with secrets)**
+
+Non-interactive variant that drives the prompts with a secret key selected.
+Verify:
+- Generated `index.ts` lists `core-secrets:provider` in `consumes`.
+- Generated `config.secrets` includes the selected key and it appears in
+  `config.schema.properties`.
+- Generated `index.test.ts` `makeCtx()` exposes async
+  `ctx.secrets.get/refresh`.
+- `bun test` passes.
+- `kaizen plugin validate .` exits 0 (no `permissions.env` grant required).
 
 - [ ] **Step 2: Marketplace workflow test**
 

--- a/docs/superpowers/plans/2026-04-18-plugin-scaffolder-standards.md
+++ b/docs/superpowers/plans/2026-04-18-plugin-scaffolder-standards.md
@@ -191,7 +191,9 @@ Checks (against the Spec 1 `entries[]` catalog shape):
     `existsSync(join(dir, source.path))`.
 - **Harness versions** require `path` (non-empty);
   `existsSync(join(dir, version.path))`.
-- Optional `minKaizenVersion`: if present, must be a valid semver range.
+- Optional `minKaizenVersion`: if present, must be a bare semver (reject
+  ranges like `^1.4.0` or `>=1.4.0` — field semantics per Spec 1 is
+  ">= this version", like k8s minimum version).
 
 - [ ] **Step 2: Write `src/commands/marketplace-validate.test.ts`**
 

--- a/docs/superpowers/plans/2026-04-18-unified-plugin-config.md
+++ b/docs/superpowers/plans/2026-04-18-unified-plugin-config.md
@@ -1,0 +1,365 @@
+# Unified Plugin Configuration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add declared config schema (`config.schema`), validated typed access via
+`ctx.config`, secrets resolution, a merge pipeline with defined precedence, and a
+`kaizen config` CLI. After this plan, a misconfigured plugin fails at startup with
+a clear error, and the `api_key_env` indirection anti-pattern is eliminated.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md`
+
+**Prerequisites:** Spec 1 (marketplace) may ship in parallel; this plan depends on
+the kaizen-level config layer (`~/.kaizen/kaizen.json` `defaults` field) from Spec 1.
+Can be implemented in parallel but integration tested after Spec 1 lands.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/core/config-validator.ts` — ajv wrapper for plugin config schemas
+- `src/core/config-validator.test.ts`
+- `src/core/config-merge.ts` — merge pipeline: defaults → global → harness → env
+- `src/core/config-merge.test.ts`
+- `src/commands/config.ts` — `kaizen config show|get|set`
+
+**Modified files:**
+- `src/types/plugin.ts` — add `PluginConfigDeclaration` + `config` field to `KaizenPlugin`
+- `src/core/loader.ts` — validate + merge config before `setup(ctx)`
+- `src/core/context.ts` — pass merged config to `ctx.config`; resolve secrets
+- `src/cli.ts` — wire `kaizen config` subcommand
+
+---
+
+## Phase 1 — Types
+
+### Task 1: Add config declaration types
+
+**File:** `src/types/plugin.ts`
+
+- [ ] **Step 1: Add `PluginConfigDeclaration`**
+
+```typescript
+export interface PluginConfigDeclaration {
+  /**
+   * JSON Schema (draft-07) for the plugin's config namespace.
+   * `type: "object"` is assumed at the root.
+   */
+  schema?: Record<string, unknown>;
+  /**
+   * Default values. Lowest-precedence layer in the merge pipeline.
+   */
+  defaults?: Record<string, unknown>;
+  /**
+   * Config keys whose values are environment variable NAMES.
+   * Core resolves these to the actual env var value during merge.
+   * Each key here should appear in `permissions.env`.
+   */
+  secrets?: string[];
+}
+```
+
+- [ ] **Step 2: Add `config` field to `KaizenPlugin`**
+
+```typescript
+interface KaizenPlugin {
+  // ... existing fields ...
+  config?: PluginConfigDeclaration;
+}
+```
+
+---
+
+## Phase 2 — Config Validator
+
+### Task 2: Implement `src/core/config-validator.ts`
+
+- [ ] **Step 1: Create ajv instance (reuse pattern from `tool-registry.ts`)**
+
+```typescript
+import Ajv from "ajv";
+const ajv = new Ajv({ allErrors: true });
+
+export interface ConfigValidationError {
+  path: string;
+  message: string;
+}
+
+export function validateConfig(
+  schema: Record<string, unknown>,
+  data: Record<string, unknown>,
+): ConfigValidationError[] {
+  const validate = ajv.compile({ type: "object", ...schema });
+  if (validate(data)) return [];
+  return (validate.errors ?? []).map((e) => ({
+    path: e.instancePath || "/",
+    message: e.message ?? "invalid",
+  }));
+}
+
+export function validateSchemaItself(schema: Record<string, unknown>): boolean {
+  try {
+    ajv.compile(schema);
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 2: Write `src/core/config-validator.test.ts`**
+
+Tests:
+- Valid config against schema with required fields.
+- Missing required field → error with correct path.
+- Wrong type → error.
+- Nested path error.
+- Empty schema (no validation) → no errors.
+- `validateSchemaItself`: valid schema, invalid schema.
+
+---
+
+## Phase 3 — Merge Pipeline
+
+### Task 3: Implement `src/core/config-merge.ts`
+
+- [ ] **Step 1: Implement `mergePluginConfig`**
+
+```typescript
+export function mergePluginConfig(
+  pluginName: string,
+  declaration: PluginConfigDeclaration | undefined,
+  globalDefaults: Record<string, unknown>,    // from ~/.kaizen/kaizen.json defaults.<plugin>
+  harnessConfig: Record<string, unknown>,     // from kaizen.json <plugin> namespace
+): Record<string, unknown> {
+  const base = { ...(declaration?.defaults ?? {}) };
+  const withGlobal = { ...base, ...globalDefaults };
+  const withHarness = { ...withGlobal, ...harnessConfig };
+  return withHarness;
+}
+```
+
+- [ ] **Step 2: Implement `resolveSecrets`**
+
+```typescript
+export function resolveSecrets(
+  config: Record<string, unknown>,
+  secrets: string[],
+): { resolved: Record<string, unknown>; missing: string[] } {
+  const resolved = { ...config };
+  const missing: string[] = [];
+
+  for (const key of secrets) {
+    const envName = config[key] as string | undefined;
+    if (!envName) {
+      missing.push(key);
+      continue;
+    }
+    const value = process.env[envName];
+    if (value !== undefined) {
+      resolved[key] = value;
+    } else {
+      resolved[key] = undefined;
+      missing.push(key);
+    }
+  }
+
+  return { resolved, missing };
+}
+```
+
+- [ ] **Step 3: Write `src/core/config-merge.test.ts`**
+
+Tests:
+- Merge order: plugin defaults < global < harness (right wins at each step).
+- Secrets resolved from env.
+- Secrets env var missing → key is `undefined` in resolved.
+- No declaration → returns raw harness config unchanged.
+- Deep objects are shallow-merged (not deep-merged — document this explicitly).
+
+---
+
+## Phase 4 — Loader Integration
+
+### Task 4: Validate and merge config in `src/core/loader.ts`
+
+- [ ] **Step 1: Import `mergePluginConfig`, `resolveSecrets`, `validateConfig`**
+
+- [ ] **Step 2: In `setupPlugin(plugin, ctx, harnessConfig, globalConfig)`:**
+
+After resolving the plugin but before calling `plugin.setup(ctx)`:
+
+```typescript
+// 1. Merge config
+const globalPluginDefaults =
+  (globalConfig.defaults as Record<string, unknown> | undefined)?.[plugin.name] ?? {};
+const harnessPluginConfig =
+  (harnessConfig[plugin.name] as Record<string, unknown> | undefined) ?? {};
+let mergedConfig = mergePluginConfig(
+  plugin.name,
+  plugin.config,
+  globalPluginDefaults,
+  harnessPluginConfig,
+);
+
+// 2. Resolve secrets
+if (plugin.config?.secrets?.length) {
+  const { resolved, missing } = resolveSecrets(mergedConfig, plugin.config.secrets);
+  mergedConfig = resolved;
+
+  // Check if any missing secrets are required by schema
+  const requiredKeys = (plugin.config.schema as any)?.required ?? [];
+  const missingRequired = missing.filter((k) => requiredKeys.includes(k));
+  if (missingRequired.length > 0) {
+    const envNames = missingRequired
+      .map((k) => harnessPluginConfig[k] ?? k)
+      .join(", ");
+    fatal(`${plugin.name}: required secret(s) missing. Set env var(s): ${envNames}`);
+  }
+}
+
+// 3. Validate
+if (plugin.config?.schema) {
+  if (!validateSchemaItself(plugin.config.schema)) {
+    fatal(`${plugin.name}: config.schema is not a valid JSON Schema`);
+  }
+  const errors = validateConfig(plugin.config.schema, mergedConfig);
+  if (errors.length > 0) {
+    const detail = errors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
+    fatal(`${plugin.name} config invalid:\n${detail}`);
+  }
+}
+```
+
+- [ ] **Step 3: Pass `mergedConfig` to `createPluginContext`**
+
+`createPluginContext` currently reads config from the raw harness. Change it to
+accept a pre-merged config object.
+
+---
+
+## Phase 5 — Context Surface
+
+### Task 5: Update `src/core/context.ts`
+
+- [ ] **Step 1: Accept `mergedConfig` parameter**
+
+`createPluginContext(plugin, mergedConfig, ...)` — replace the current direct
+harness config lookup.
+
+- [ ] **Step 2: Expose as `ctx.config`**
+
+`ctx.config` returns `mergedConfig`. Type: `Record<string, unknown>` (unchanged at
+the TypeScript level for v1).
+
+- [ ] **Step 3: Secrets in `ctx.secrets.get(key)`**
+
+`ctx.secrets.get(key)` should also work for config-declared secrets. Update the
+secrets implementation to check `mergedConfig[key]` first (the resolved value), then
+fall back to existing `process.env` lookup for permissions-declared env vars.
+
+---
+
+## Phase 6 — CLI Commands
+
+### Task 6: Implement `src/commands/config.ts`
+
+- [ ] **Step 1: `cmdConfigShow(pluginName?)`**
+
+Load harness config + global config. For each plugin (or the named one):
+1. Build merged config using `mergePluginConfig`.
+2. Collect source annotations (which layer provided each value).
+3. Print table (redact secrets — show `***`).
+4. Print schema table if declared.
+
+- [ ] **Step 2: `cmdConfigGet(pluginDotPath)`**
+
+Parse `<plugin>.<path>` (supports dot-notation for nested keys).
+Build merged config for that plugin.
+Print the value. Redact if secret. Exit 1 if not found.
+
+- [ ] **Step 3: `cmdConfigSet(pluginDotPath, value)`**
+
+Parse `<plugin>.<path>`.
+Load project harness config. Set the value at the path.
+If plugin has a schema: validate the full plugin config after the set.
+Write back to `.kaizen/kaizen.json`. Print confirmation.
+
+- [ ] **Step 4: Wire in `src/cli.ts`**
+
+```typescript
+if (subcommand === "config") {
+  const sub = rawArgs[1];
+  if (sub === "show") { ... }
+  if (sub === "get")  { ... }
+  if (sub === "set")  { ... }
+}
+```
+
+---
+
+## Phase 7 — Migrate Built-in Plugins
+
+### Task 7: Update built-in plugins to use config declaration
+
+- [ ] **Step 1: `core-executor-anthropic/index.ts`**
+
+Add `config` declaration:
+```typescript
+config: {
+  schema: {
+    properties: {
+      model:       { type: "string" },
+      api_key:     { type: "string" },
+    },
+    required: ["api_key"],
+  },
+  defaults: { model: "claude-opus-4-6" },
+  secrets: ["api_key"],
+},
+```
+Update `setup()` to use `ctx.config.api_key` directly (remove `api_key_env` lookup).
+
+- [ ] **Step 2: `core-executor-openai/index.ts`**
+
+Same pattern.
+
+- [ ] **Step 3: `core-cli/index.ts`**
+
+Add config declaration for `clis`, `allow_destructive`, `subprocess_timeout_ms`.
+
+- [ ] **Step 4: Remaining built-ins**
+
+Audit all built-ins for config access. Add declarations where config is read.
+
+---
+
+## Phase 8 — Tests & Docs
+
+### Task 8: Integration tests
+
+- [ ] **Step 1: Plugin with missing required config fails at startup**
+
+Create a test plugin with `required: ["api_key"]`. Load it without providing the key.
+Assert fatal error with correct message.
+
+- [ ] **Step 2: Plugin with wrong type fails at startup**
+
+Pass `timeout_ms: "5000"` (string) where `number` is required. Assert error.
+
+- [ ] **Step 3: Secrets resolved correctly**
+
+Set `process.env.TEST_KEY = "secret"`. Configure plugin with `api_key: "TEST_KEY"`.
+Assert `ctx.config.api_key === "secret"`.
+
+- [ ] **Step 4: Merge precedence**
+
+Plugin defaults `timeout: 5000`. Harness sets `timeout: 3000`. Assert resolved is
+`3000`.
+
+### Task 9: Documentation
+
+- [ ] Update `docs/plugin-api.md` — "Plugin config" section to show new `config`
+  declaration pattern. Mark old `api_key_env` pattern as deprecated.
+- [ ] Add `kaizen config` to `README.md` commands reference.

--- a/docs/superpowers/plans/2026-04-18-unified-plugin-config.md
+++ b/docs/superpowers/plans/2026-04-18-unified-plugin-config.md
@@ -1,17 +1,22 @@
-# Unified Plugin Configuration — Implementation Plan
+# Unified Plugin Configuration & Pluggable Secrets — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add declared config schema (`config.schema`), validated typed access via
-`ctx.config`, secrets resolution, a merge pipeline with defined precedence, and a
-`kaizen config` CLI. After this plan, a misconfigured plugin fails at startup with
-a clear error, and the `api_key_env` indirection anti-pattern is eliminated.
+**Goal:** Add declared config schema, validated typed `ctx.config` (non-secrets only),
+a pluggable secrets system with an OS-portable default provider, async
+`ctx.secrets.get(key)` with background pre-fetch, install-time + load-time
+validation, env-override convention, and a `kaizen config` CLI (including
+`set-secret`). After this plan: a misconfigured plugin fails at `kaizen install`
+with a clear error, `api_key_env` indirection is gone, and secrets live in the OS
+keychain by default with Doppler/Vault as drop-in replacements.
 
 **Spec:** `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md`
 
-**Prerequisites:** Spec 1 (marketplace) may ship in parallel; this plan depends on
-the kaizen-level config layer (`~/.kaizen/kaizen.json` `defaults` field) from Spec 1.
-Can be implemented in parallel but integration tested after Spec 1 lands.
+**Prerequisites:**
+- Spec 1 (marketplace) — provides `src/core/kaizen-config.ts` and the
+  `KaizenGlobalConfig.defaults` slice this plan consumes.
+- Spec 2026-04-17 (capability registry) — provides the `core-secrets:provider`
+  capability slot + dependency ordering.
 
 ---
 
@@ -20,51 +25,80 @@ Can be implemented in parallel but integration tested after Spec 1 lands.
 **New files:**
 - `src/core/config-validator.ts` — ajv wrapper for plugin config schemas
 - `src/core/config-validator.test.ts`
-- `src/core/config-merge.ts` — merge pipeline: defaults → global → harness → env
+- `src/core/config-merge.ts` — merge pipeline + env override + secret separation
 - `src/core/config-merge.test.ts`
-- `src/commands/config.ts` — `kaizen config show|get|set`
+- `src/core/secrets.ts` — `SecretsRegistry`, `createSecretsContext`
+- `src/core/secrets.test.ts`
+- `src/core/secret-providers/types.ts` — `SecretProvider` interface
+- `src/commands/config.ts` — `kaizen config show|get|set|set-secret`
+- `plugins/core-secrets/index.ts` — built-in default provider plugin
+- `plugins/core-secrets/detect.ts` — backend detection (OS + availability)
+- `plugins/core-secrets/keychain-macos.ts`
+- `plugins/core-secrets/keychain-windows.ts`
+- `plugins/core-secrets/keychain-linux.ts`
+- `plugins/core-secrets/file-fallback.ts`
+- `plugins/core-secrets/*.test.ts`
 
 **Modified files:**
-- `src/types/plugin.ts` — add `PluginConfigDeclaration` + `config` field to `KaizenPlugin`
-- `src/core/loader.ts` — validate + merge config before `setup(ctx)`
-- `src/core/context.ts` — pass merged config to `ctx.config`; resolve secrets
+- `src/types/plugin.ts` — add `PluginConfigDeclaration`, `SecretRef`, `config` field
+- `src/core/loader.ts` — merge + validate + prefetch before `setup(ctx)`
+- `src/core/context.ts` — pass merged non-secret config + secrets handle
+- `src/commands/install.ts` — install-time validation step
 - `src/cli.ts` — wire `kaizen config` subcommand
+- Built-in plugins (`core-executor-anthropic`, `core-executor-openai`,
+  `core-cli`, etc.) — adopt `config` declaration + `ctx.secrets`
 
 ---
 
 ## Phase 1 — Types
 
-### Task 1: Add config declaration types
+### Task 1: Add config + secret ref types
 
 **File:** `src/types/plugin.ts`
 
-- [ ] **Step 1: Add `PluginConfigDeclaration`**
+- [ ] **Step 1: `PluginConfigDeclaration`**
 
 ```typescript
 export interface PluginConfigDeclaration {
-  /**
-   * JSON Schema (draft-07) for the plugin's config namespace.
-   * `type: "object"` is assumed at the root.
-   */
   schema?: Record<string, unknown>;
-  /**
-   * Default values. Lowest-precedence layer in the merge pipeline.
-   */
   defaults?: Record<string, unknown>;
-  /**
-   * Config keys whose values are environment variable NAMES.
-   * Core resolves these to the actual env var value during merge.
-   * Each key here should appear in `permissions.env`.
-   */
   secrets?: string[];
 }
 ```
 
-- [ ] **Step 2: Add `config` field to `KaizenPlugin`**
+- [ ] **Step 2: Secret ref types**
+
+```typescript
+export interface StructuredSecretRef {
+  provider: string;
+  ref: string;
+  envOverride?: string;
+}
+
+export type SecretRef = string | StructuredSecretRef;
+```
+
+- [ ] **Step 3: Context types**
+
+```typescript
+export interface SecretsContext {
+  get(key: string): Promise<string | undefined>;
+  refresh(key: string): Promise<string | undefined>;
+}
+
+// Extend PluginContext
+interface PluginContext {
+  // ... existing ...
+  config: Record<string, unknown>;     // non-secret only
+  secrets: SecretsContext;
+}
+```
+
+- [ ] **Step 4: Add `config` field to `KaizenPlugin`**
 
 ```typescript
 interface KaizenPlugin {
-  // ... existing fields ...
+  // ... existing ...
   config?: PluginConfigDeclaration;
 }
 ```
@@ -75,7 +109,7 @@ interface KaizenPlugin {
 
 ### Task 2: Implement `src/core/config-validator.ts`
 
-- [ ] **Step 1: Create ajv instance (reuse pattern from `tool-registry.ts`)**
+- [ ] **Step 1: Create ajv wrapper**
 
 ```typescript
 import Ajv from "ajv";
@@ -99,219 +133,312 @@ export function validateConfig(
 }
 
 export function validateSchemaItself(schema: Record<string, unknown>): boolean {
-  try {
-    ajv.compile(schema);
-    return true;
-  } catch {
-    return false;
-  }
+  try { ajv.compile(schema); return true; } catch { return false; }
 }
 ```
 
-- [ ] **Step 2: Write `src/core/config-validator.test.ts`**
-
-Tests:
-- Valid config against schema with required fields.
-- Missing required field → error with correct path.
-- Wrong type → error.
-- Nested path error.
-- Empty schema (no validation) → no errors.
-- `validateSchemaItself`: valid schema, invalid schema.
+- [ ] **Step 2: Tests** — valid, missing required, wrong type, nested, invalid schema.
 
 ---
 
-## Phase 3 — Merge Pipeline
+## Phase 3 — Merge Pipeline + Env Overrides
 
 ### Task 3: Implement `src/core/config-merge.ts`
 
-- [ ] **Step 1: Implement `mergePluginConfig`**
+- [ ] **Step 1: `mergePluginConfig`**
 
 ```typescript
 export function mergePluginConfig(
-  pluginName: string,
   declaration: PluginConfigDeclaration | undefined,
-  globalDefaults: Record<string, unknown>,    // from ~/.kaizen/kaizen.json defaults.<plugin>
-  harnessConfig: Record<string, unknown>,     // from kaizen.json <plugin> namespace
+  globalDefaults: Record<string, unknown>,
+  harnessConfig: Record<string, unknown>,
 ): Record<string, unknown> {
-  const base = { ...(declaration?.defaults ?? {}) };
-  const withGlobal = { ...base, ...globalDefaults };
-  const withHarness = { ...withGlobal, ...harnessConfig };
-  return withHarness;
+  return {
+    ...(declaration?.defaults ?? {}),
+    ...globalDefaults,
+    ...harnessConfig,
+  };
 }
 ```
 
-- [ ] **Step 2: Implement `resolveSecrets`**
+- [ ] **Step 2: `separateSecrets`** — splits merged config into `{ config, secretRefs }`
+      based on `PluginConfigDeclaration.secrets`. Validates each ref is a string or
+      `{ provider, ref }` object (fatal on malformed).
 
-```typescript
-export function resolveSecrets(
-  config: Record<string, unknown>,
-  secrets: string[],
-): { resolved: Record<string, unknown>; missing: string[] } {
-  const resolved = { ...config };
-  const missing: string[] = [];
+- [ ] **Step 3: `applyEnvOverrides(pluginName, config, schema)`** — walks top-level
+      keys, checks `KAIZEN_<PLUGIN>_<KEY>` env vars, coerces based on schema type
+      (`number` → parseFloat; `boolean` → "true"/"false"; else string).
 
-  for (const key of secrets) {
-    const envName = config[key] as string | undefined;
-    if (!envName) {
-      missing.push(key);
-      continue;
-    }
-    const value = process.env[envName];
-    if (value !== undefined) {
-      resolved[key] = value;
-    } else {
-      resolved[key] = undefined;
-      missing.push(key);
-    }
-  }
+- [ ] **Step 4: `envVarNameFor(pluginName, key)`** — helper applying the
+      upper-snake convention (non-alphanumeric → `_`).
 
-  return { resolved, missing };
-}
-```
-
-- [ ] **Step 3: Write `src/core/config-merge.test.ts`**
-
-Tests:
-- Merge order: plugin defaults < global < harness (right wins at each step).
-- Secrets resolved from env.
-- Secrets env var missing → key is `undefined` in resolved.
-- No declaration → returns raw harness config unchanged.
-- Deep objects are shallow-merged (not deep-merged — document this explicitly).
+- [ ] **Step 5: Tests** — shallow replace, right-wins, env coercion, `envOverride`
+      precedence for secrets, plugin name with non-alphanumeric chars.
 
 ---
 
-## Phase 4 — Loader Integration
+## Phase 4 — Secret Provider Interface + Registry
 
-### Task 4: Validate and merge config in `src/core/loader.ts`
+### Task 4: Define provider interface
 
-- [ ] **Step 1: Import `mergePluginConfig`, `resolveSecrets`, `validateConfig`**
+**File:** `src/core/secret-providers/types.ts`
 
-- [ ] **Step 2: In `setupPlugin(plugin, ctx, harnessConfig, globalConfig)`:**
-
-After resolving the plugin but before calling `plugin.setup(ctx)`:
+- [ ] **Step 1:**
 
 ```typescript
-// 1. Merge config
-const globalPluginDefaults =
-  (globalConfig.defaults as Record<string, unknown> | undefined)?.[plugin.name] ?? {};
-const harnessPluginConfig =
-  (harnessConfig[plugin.name] as Record<string, unknown> | undefined) ?? {};
-let mergedConfig = mergePluginConfig(
-  plugin.name,
+export interface SecretProvider {
+  readonly name: string;
+  get(ref: string): Promise<string | undefined>;
+  set?(ref: string, value: string): Promise<void>;
+  prefetch?(refs: string[]): Promise<void>;
+}
+```
+
+### Task 5: Implement `src/core/secrets.ts`
+
+- [ ] **Step 1: `SecretsRegistry` class**
+
+```typescript
+class SecretsRegistry {
+  private providers = new Map<string, SecretProvider>();
+  private cache = new Map<string, string | undefined>();  // key: `<provider>:<ref>`
+
+  register(provider: SecretProvider): void {
+    if (this.providers.has(provider.name)) {
+      fatal(`secret provider '${provider.name}' already registered`);
+    }
+    this.providers.set(provider.name, provider);
+  }
+
+  getProvider(name: string): SecretProvider | undefined { ... }
+
+  async resolve(pluginName: string, key: string, ref: SecretRef,
+                opts: { bypassCache?: boolean } = {}): Promise<string | undefined> {
+    // 1. envOverride
+    // 2. KAIZEN_<PLUGIN>_<KEY>
+    // 3. Cache (unless bypassCache)
+    // 4. provider.get(ref)
+  }
+
+  async prefetchForPlugin(pluginName: string, declared: Record<string, SecretRef>): Promise<void> {
+    // Group refs by provider; call provider.prefetch?(refs)
+  }
+}
+```
+
+- [ ] **Step 2: `createSecretsContext(registry, pluginName, declaredRefs)`**
+
+Returns the `SecretsContext` handle:
+
+```typescript
+return {
+  get: (key) => {
+    const ref = declaredRefs[key];
+    if (ref !== undefined) return registry.resolve(pluginName, key, ref);
+    // Undeclared: treat as ref against default provider
+    const defaultProvider = registry.getProvider("kaizen");
+    if (!defaultProvider) throw new Error(...);
+    return defaultProvider.get(key);
+  },
+  refresh: (key) => {
+    const ref = declaredRefs[key];
+    if (ref === undefined) return this.get(key);
+    return registry.resolve(pluginName, key, ref, { bypassCache: true });
+  },
+};
+```
+
+- [ ] **Step 3: Tests** — register collision, env override order, cache behaviour,
+      undeclared-key path, missing provider error, refresh bypasses cache.
+
+---
+
+## Phase 5 — Default Provider (`core-secrets` plugin)
+
+### Task 6: Backend detection
+
+**File:** `plugins/core-secrets/detect.ts`
+
+- [ ] **Step 1:** `detectBackend(): "macos" | "windows" | "linux" | "file"`.
+      Honors `KAIZEN_SECRETS_BACKEND=file` override. Falls back to `file` if OS
+      tool (e.g. `secret-tool`) is missing.
+
+### Task 7: Platform backends
+
+- [ ] **Step 1:** `keychain-macos.ts` — shells out to `security add-generic-password`,
+      `security find-generic-password`, scoped under service `kaizen`. Account =
+      `<ref>`.
+
+- [ ] **Step 2:** `keychain-windows.ts` — PowerShell `New-StoredCredential` /
+      `Get-StoredCredential` (or `cmdkey` / `wincred` binding).
+
+- [ ] **Step 3:** `keychain-linux.ts` — `secret-tool store`, `secret-tool lookup`,
+      attribute `service=kaizen`, `account=<ref>`.
+
+- [ ] **Step 4:** `file-fallback.ts` — reads/writes `~/.kaizen/.credentials.json`,
+      chmod 600, JSON `{ "<ref>": "<value>" }`. Creates file on first write with
+      correct perms.
+
+- [ ] **Step 5:** Each backend exports a `SecretProvider`-shaped object with
+      `get` and `set`. `prefetch` is a no-op for keychain backends (cheap reads);
+      for file backend it preloads the JSON once.
+
+### Task 8: `plugins/core-secrets/index.ts`
+
+- [ ] **Step 1:** Plugin entry. Declares:
+
+```typescript
+const plugin: KaizenPlugin = {
+  name: "core-secrets",
+  apiVersion: "2.0.0",
+  permissions: { tier: "trusted" },  // OS keychain + file I/O
+  capabilities: {
+    provides: [{ kind: "core-secrets:provider", name: "kaizen" }],
+  },
+  async setup(ctx) {
+    const backend = pickBackend(detectBackend());
+    ctx.capabilities.register("core-secrets:provider", backend);
+  },
+};
+```
+
+- [ ] **Step 2:** Tests — platform-gated (`describe.skipIf`) for each OS; file
+      fallback always tested.
+
+---
+
+## Phase 6 — Loader Integration
+
+### Task 9: Wire validation + merge + prefetch in `src/core/loader.ts`
+
+- [ ] **Step 1: Install-time validation hook** — called from
+      `src/commands/install.ts` after plugin bits land but before lockfile write:
+
+```typescript
+async function validateInstallTimeConfig(plugin, globalConfig, harnessConfig) {
+  if (!plugin.config?.schema) return;
+  if (!validateSchemaItself(plugin.config.schema)) fatal(...);
+  const merged = mergePluginConfig(plugin.config, globalConfig.defaults?.[plugin.name] ?? {}, harnessConfig[plugin.name] ?? {});
+  const { config, secretRefs } = separateSecrets(merged, plugin.config.secrets ?? []);
+  const errors = validateConfig(plugin.config.schema, config);
+  if (errors.length > 0) fatal(formatErrors(errors));
+  // Provider existence check is LOAD-TIME only — provider plugins may not be
+  // installed yet at the moment this plugin installs. Move to load-time.
+  // (Document: install-time catches shape; load-time catches provider wiring.)
+}
+```
+
+- [ ] **Step 2: Load-time `setupPlugin(plugin, ctx, harnessConfig, globalConfig, registry)`:**
+
+```typescript
+// 1. Merge
+const merged = mergePluginConfig(
   plugin.config,
-  globalPluginDefaults,
-  harnessPluginConfig,
+  globalConfig.defaults?.[plugin.name] ?? {},
+  harnessConfig[plugin.name] ?? {},
 );
 
-// 2. Resolve secrets
-if (plugin.config?.secrets?.length) {
-  const { resolved, missing } = resolveSecrets(mergedConfig, plugin.config.secrets);
-  mergedConfig = resolved;
+// 2. Split secrets
+const { config, secretRefs } = separateSecrets(merged, plugin.config?.secrets ?? []);
 
-  // Check if any missing secrets are required by schema
-  const requiredKeys = (plugin.config.schema as any)?.required ?? [];
-  const missingRequired = missing.filter((k) => requiredKeys.includes(k));
-  if (missingRequired.length > 0) {
-    const envNames = missingRequired
-      .map((k) => harnessPluginConfig[k] ?? k)
-      .join(", ");
-    fatal(`${plugin.name}: required secret(s) missing. Set env var(s): ${envNames}`);
-  }
-}
+// 3. Env overrides on non-secrets
+applyEnvOverrides(plugin.name, config, plugin.config?.schema);
 
-// 3. Validate
+// 4. Validate
 if (plugin.config?.schema) {
-  if (!validateSchemaItself(plugin.config.schema)) {
-    fatal(`${plugin.name}: config.schema is not a valid JSON Schema`);
-  }
-  const errors = validateConfig(plugin.config.schema, mergedConfig);
-  if (errors.length > 0) {
-    const detail = errors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
-    fatal(`${plugin.name} config invalid:\n${detail}`);
+  const errors = validateConfig(plugin.config.schema, config);
+  if (errors.length > 0) fatal(...);
+}
+
+// 5. Check every declared secret's provider is registered
+for (const [key, ref] of Object.entries(secretRefs)) {
+  const providerName = typeof ref === "string" ? "kaizen" : ref.provider;
+  if (!registry.getProvider(providerName)) {
+    fatal(`${plugin.name}: secret '${key}' targets provider '${providerName}' — no plugin provides it`);
   }
 }
+
+// 6. Prefetch
+await registry.prefetchForPlugin(plugin.name, secretRefs);
+
+// 7. Build context
+const secrets = createSecretsContext(registry, plugin.name, secretRefs);
+const ctx = createPluginContext(plugin, config, secrets, ...);
+await plugin.setup(ctx);
 ```
 
-- [ ] **Step 3: Pass `mergedConfig` to `createPluginContext`**
-
-`createPluginContext` currently reads config from the raw harness. Change it to
-accept a pre-merged config object.
+- [ ] **Step 3:** Thread the `SecretsRegistry` through loader init — one instance
+      per kaizen run, passed into each `setupPlugin` call.
 
 ---
 
-## Phase 5 — Context Surface
+## Phase 7 — Context Surface
 
-### Task 5: Update `src/core/context.ts`
+### Task 10: Update `src/core/context.ts`
 
-- [ ] **Step 1: Accept `mergedConfig` parameter**
+- [ ] **Step 1:** `createPluginContext(plugin, config, secrets, ...)` — replace
+      direct harness-config lookup. `ctx.config` returns the validated non-secret
+      merged object. `ctx.secrets` returns the `SecretsContext` from Phase 6.
 
-`createPluginContext(plugin, mergedConfig, ...)` — replace the current direct
-harness config lookup.
-
-- [ ] **Step 2: Expose as `ctx.config`**
-
-`ctx.config` returns `mergedConfig`. Type: `Record<string, unknown>` (unchanged at
-the TypeScript level for v1).
-
-- [ ] **Step 3: Secrets in `ctx.secrets.get(key)`**
-
-`ctx.secrets.get(key)` should also work for config-declared secrets. Update the
-secrets implementation to check `mergedConfig[key]` first (the resolved value), then
-fall back to existing `process.env` lookup for permissions-declared env vars.
+- [ ] **Step 2: Deprecate `ctx.secrets.get` pre-existing env lookup** (if any).
+      New path is the only path. Keep behaviour for plugins that call
+      `ctx.secrets.get` without declaring `config.secrets` — resolves via default
+      provider.
 
 ---
 
-## Phase 6 — CLI Commands
+## Phase 8 — CLI Commands
 
-### Task 6: Implement `src/commands/config.ts`
+### Task 11: Implement `src/commands/config.ts`
 
-- [ ] **Step 1: `cmdConfigShow(pluginName?)`**
+- [ ] **Step 1: `cmdConfigShow(pluginName?)`** — loads both configs, merges per
+      plugin, prints:
+  - Non-secret keys with source annotation.
+  - Secret keys as `*** (provider: X, ref: Y) [harness|default|global]`.
+  - Compact schema table.
+  - Shallow-merge footnote if nested object replaced.
 
-Load harness config + global config. For each plugin (or the named one):
-1. Build merged config using `mergePluginConfig`.
-2. Collect source annotations (which layer provided each value).
-3. Print table (redact secrets — show `***`).
-4. Print schema table if declared.
+- [ ] **Step 2: `cmdConfigGet(plugin, path)`** — parses space-separated
+      `<plugin> <path>`. Builds merged non-secret config, walks dotted path, prints
+      value. `--reveal` for secrets. Exit 1 if not found.
 
-- [ ] **Step 2: `cmdConfigGet(pluginDotPath)`**
+- [ ] **Step 3: `cmdConfigSet(plugin, path, value)`** — loads project harness
+      (or global with `--global`), sets value at path. Validates whole plugin
+      config against schema before write. Writes atomically.
 
-Parse `<plugin>.<path>` (supports dot-notation for nested keys).
-Build merged config for that plugin.
-Print the value. Redact if secret. Exit 1 if not found.
+- [ ] **Step 4: `cmdConfigSetSecret(plugin, key, opts)`** — interactive prompt
+      (tty-only, hidden input). Resolves target provider (`--provider <name>`
+      overrides default `kaizen`). If `provider.set` is undefined → error.
+      Writes the value via provider, then updates harness (or `--global`) to
+      store `{ provider: <name>, ref: <chosen-ref> }` under
+      `<plugin>.<key>`.
 
-- [ ] **Step 3: `cmdConfigSet(pluginDotPath, value)`**
-
-Parse `<plugin>.<path>`.
-Load project harness config. Set the value at the path.
-If plugin has a schema: validate the full plugin config after the set.
-Write back to `.kaizen/kaizen.json`. Print confirmation.
-
-- [ ] **Step 4: Wire in `src/cli.ts`**
+- [ ] **Step 5: Wire in `src/cli.ts`**
 
 ```typescript
 if (subcommand === "config") {
   const sub = rawArgs[1];
-  if (sub === "show") { ... }
-  if (sub === "get")  { ... }
-  if (sub === "set")  { ... }
+  if (sub === "show")        return cmdConfigShow(rawArgs[2]);
+  if (sub === "get")         return cmdConfigGet(rawArgs[2], rawArgs[3]);
+  if (sub === "set")         return cmdConfigSet(rawArgs[2], rawArgs[3], rawArgs[4], flags);
+  if (sub === "set-secret")  return cmdConfigSetSecret(rawArgs[2], rawArgs[3], flags);
 }
 ```
 
 ---
 
-## Phase 7 — Migrate Built-in Plugins
+## Phase 9 — Migrate Built-in Plugins
 
-### Task 7: Update built-in plugins to use config declaration
+### Task 12: Update built-ins to declare config + use `ctx.secrets`
 
-- [ ] **Step 1: `core-executor-anthropic/index.ts`**
+- [ ] **Step 1: `core-executor-anthropic`**
 
-Add `config` declaration:
 ```typescript
 config: {
   schema: {
     properties: {
-      model:       { type: "string" },
-      api_key:     { type: "string" },
+      model:   { type: "string" },
+      api_key: { type: "string" },
     },
     required: ["api_key"],
   },
@@ -319,47 +446,84 @@ config: {
   secrets: ["api_key"],
 },
 ```
-Update `setup()` to use `ctx.config.api_key` directly (remove `api_key_env` lookup).
 
-- [ ] **Step 2: `core-executor-openai/index.ts`**
+Update `setup()`: `const key = await ctx.secrets.get("api_key");`. Remove
+`api_key_env` indirection.
 
-Same pattern.
+- [ ] **Step 2: `core-executor-openai`** — same pattern.
 
-- [ ] **Step 3: `core-cli/index.ts`**
+- [ ] **Step 3: `core-cli`** — declare config for `clis`, `allow_destructive`,
+      `subprocess_timeout_ms` (no secrets).
 
-Add config declaration for `clis`, `allow_destructive`, `subprocess_timeout_ms`.
+- [ ] **Step 4: Audit remaining built-ins** — add declarations wherever
+      `ctx.config[...]` is currently read.
 
-- [ ] **Step 4: Remaining built-ins**
-
-Audit all built-ins for config access. Add declarations where config is read.
+- [ ] **Step 5: Migration note in `docs/plugin-api.md`** — before/after examples
+      covering schema, secrets, and `ctx.secrets.get`.
 
 ---
 
-## Phase 8 — Tests & Docs
+## Phase 10 — Integration Tests & Docs
 
-### Task 8: Integration tests
+### Task 13: Integration tests
 
-- [ ] **Step 1: Plugin with missing required config fails at startup**
+- [ ] **Step 1: Install-time shape validation** — create fixture plugin with
+      missing required key; assert `kaizen install` fails with correct message.
 
-Create a test plugin with `required: ["api_key"]`. Load it without providing the key.
-Assert fatal error with correct message.
+- [ ] **Step 2: Install-time does NOT check secret value availability** — fixture
+      plugin with required secret; run `kaizen install` in environment with no
+      keychain entry; assert install succeeds.
 
-- [ ] **Step 2: Plugin with wrong type fails at startup**
+- [ ] **Step 3: Load-time provider existence** — remove `core-secrets` (simulate)
+      and load a plugin with declared secrets; assert fatal with clear message.
 
-Pass `timeout_ms: "5000"` (string) where `number` is required. Assert error.
+- [ ] **Step 4: Secret resolution end-to-end (file backend)** —
+      `KAIZEN_SECRETS_BACKEND=file`; `kaizen config set-secret foo api_key`
+      (scripted); assert `ctx.secrets.get("api_key")` returns the value.
 
-- [ ] **Step 3: Secrets resolved correctly**
+- [ ] **Step 5: Env override beats harness** — set
+      `KAIZEN_STRIPE_BILLING_TIMEOUT_MS=999`; assert
+      `ctx.config.timeout_ms === 999` even with harness set to 3000.
 
-Set `process.env.TEST_KEY = "secret"`. Configure plugin with `api_key: "TEST_KEY"`.
-Assert `ctx.config.api_key === "secret"`.
+- [ ] **Step 6: `envOverride` escape hatch** — harness `{ envOverride:
+      "STRIPE_KEY" }`; set `STRIPE_KEY=abc`; assert resolved value is `abc`.
 
-- [ ] **Step 4: Merge precedence**
+- [ ] **Step 7: Undeclared secret via default provider** — plugin calls
+      `ctx.secrets.get("random")` without declaring it; assert default provider
+      is queried.
 
-Plugin defaults `timeout: 5000`. Harness sets `timeout: 3000`. Assert resolved is
-`3000`.
+- [ ] **Step 8: `refresh` bypasses cache** — prime cache, change file-backend
+      value, assert `refresh` returns new value while `get` returns cached.
 
-### Task 9: Documentation
+- [ ] **Step 9: Shallow merge documentation** — harness replaces nested `retry`
+      object; `kaizen config show` surfaces the footnote.
 
-- [ ] Update `docs/plugin-api.md` — "Plugin config" section to show new `config`
-  declaration pattern. Mark old `api_key_env` pattern as deprecated.
-- [ ] Add `kaizen config` to `README.md` commands reference.
+### Task 14: Documentation
+
+- [ ] **Step 1:** Update `docs/plugin-api.md` — "Plugin Config & Secrets" section:
+  - `config` declaration reference.
+  - Secret ref shape + env override convention.
+  - `ctx.config` vs `ctx.secrets.get` distinction.
+  - Shallow-merge caveat with a concrete example.
+  - Deprecation of `api_key_env` pattern.
+
+- [ ] **Step 2:** Update `README.md` — add `kaizen config` commands to reference
+      table; mention OS-keychain default and Doppler/Vault extension point.
+
+- [ ] **Step 3:** Add `docs/plugin-secrets.md` (new) — provider-author guide:
+      how to write a `core-secrets:provider` plugin (Doppler / Vault worked
+      examples).
+
+---
+
+## Rollout & Verification
+
+- [ ] `bun test` passes across macOS + Linux CI. Windows keychain backend tested
+      manually if no Windows CI available (note in PR).
+- [ ] Built-in plugins boot with the new config declarations; existing harnesses
+      continue to work (backward compat verified via fixture).
+- [ ] `kaizen install` against a fixture plugin with bad schema rejects at
+      install time.
+- [ ] `kaizen config set-secret` round-trips through each available OS backend.
+- [ ] `docs/plugin-api.md` and `docs/plugin-secrets.md` reviewed; migration guide
+      lands with the feature branch.

--- a/docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md
+++ b/docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md
@@ -1,45 +1,64 @@
-# Design: Built-in Plugins Repo Decoupling
+# Design: Extract Plugins from Kaizen Binary
 
 Date: 2026-04-18
-Status: APPROVED
+Status: DRAFT
 Related:
 - `docs/architecture.md` (current built-in plugin layout)
-- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — marketplace format this leverages)
+- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — marketplace format + install layout + runtime loader)
+- `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md` (Spec 2 — config schema, secrets, `core-secrets` plugin)
+- `docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md` (Spec 3 — scaffold templates + standards)
 - `docs/plugin-loading.md` (binary loading internals)
 
 ---
 
 ## Problem Statement
 
-All built-in plugins (`core-events`, `core-lifecycle`, `core-ui-terminal`, etc.) live
-in the main kaizen monorepo under `plugins/`. This has several downsides:
+Today, all first-party plugins (`core-events`, `core-lifecycle`, `core-ui-terminal`,
+`core-executor-anthropic`, `core-executor-openai`, `core-executor-debug`,
+`core-executor-shell`, `core-cli`, `core-plugin-manager`, `kaizen-plugin-timestamps`)
+live in the main kaizen monorepo under `plugins/` and are compiled into the binary
+via static imports in `src/cli.ts`. This has several downsides:
 
 - Plugin authors and contributors must clone the entire kaizen repo to work on a plugin.
 - Plugin versioning is coupled to the kaizen release cycle — a fix to
-  `kaizen-plugin-timestamps` requires a kaizen release.
-- The official built-in plugins are a poor reference for third-party authors because
-  they depend on relative imports (`../../src/types/plugin.js`) that don't apply
-  to installed packages.
-- There is no "official marketplace" that third-party authors can reference as the
-  canonical `kaizen-plugin` collection.
+  `timestamps` requires a full kaizen release.
+- First-party plugins are a poor reference for third-party authors: they use
+  relative imports (`../../src/types/plugin.js`) that don't apply to installed
+  packages, and they never exercise the marketplace install/load path.
+- There is no "official marketplace" that third-party authors can reference as
+  the canonical collection of kaizen plugins.
+- Bundling plugins in the binary creates two classes of plugins (embedded vs.
+  marketplace-installed) with different resolution rules — a maintenance tax.
 
-This design decouples the built-in plugins into a dedicated repository (or set of
-repositories) and establishes an official kaizen marketplace — the first instance
-of the marketplace format defined in Spec 1.
+Spec 1 introduced the marketplace format, install layout, and dynamic plugin
+loader (`src/core/plugin-loader.ts`, `import(pluginInstallDir(id, name, ver))`).
+With that machinery in place, the binary no longer needs to embed plugins. This
+spec finishes the decoupling: extracts first-party plugins into a dedicated
+`kaizen-sh/kaizen-plugins` repository, publishes the official marketplace, and
+removes all plugin source from the kaizen-code repo. After this work, the binary
+ships with zero plugins; every plugin is installed from a marketplace.
 
 ---
 
 ## Design Philosophy
 
-- **Keep binary startup unchanged.** The compiled binary still embeds the default
-  plugin stack. Users with no network access, no global npm install, and no
-  `kaizen.json` get a working kaizen. The decoupling is source-level; the
-  binary-level embedding is preserved.
-- **The official marketplace is the reference implementation.** It validates the
-  Spec 1 marketplace format in production and provides a concrete example for
-  third-party marketplace authors.
-- **Plugins evolve independently.** Once decoupled, a plugin can cut its own release
-  without gating on the kaizen core release cycle.
+- **No embedded plugins.** The binary ships no plugin code. Every plugin reaches
+  a user only through a marketplace install. This collapses the "embedded vs.
+  installed" duality and makes the marketplace path the only path.
+- **Installer owns first-run experience.** Packaging installers (brew, tarball,
+  etc.) are responsible for a working first-run kaizen: seeding the official
+  marketplace and pre-installing a default plugin set + harness. Out of scope
+  for this spec and for `kaizen-code`.
+- **The official marketplace is the reference implementation.** It validates
+  the Spec 1 marketplace format in production and provides a concrete example
+  for third-party marketplace authors.
+- **Plugins evolve independently.** Once decoupled, a plugin can cut its own
+  release without gating on the kaizen core release cycle. `minKaizenVersion`
+  on catalog entries keeps compatibility explicit.
+- **Spec 4 is a switch-flip, not a reimplementation.** The dynamic loader and
+  install machinery are owned by Spec 1's plan. This spec does two things only:
+  (a) extract the source to a new repo, (b) delete the embedding path from
+  `kaizen-code`.
 
 ---
 
@@ -47,34 +66,70 @@ of the marketplace format defined in Spec 1.
 
 ### In Scope
 
-- Proposal for the new `kaizen-plugins` repository structure.
-- Official marketplace catalog at `.kaizen/marketplace.json` in the new repo.
-- Changes to the kaizen build process to pull plugin sources from the new repo.
-- Migration guide for existing built-in plugins (relative imports → package imports).
-- Documentation updates (`docs/architecture.md`, `docs/plugin-loading.md`).
+- New `kaizen-sh/kaizen-plugins` repository and its initial layout.
+- Official marketplace catalog (`.kaizen/marketplace.json`) at the root of that
+  repo, following the Spec 1 `entries[]` format.
+- Migration of every plugin currently in `plugins/*` — including `core-secrets`
+  (new in Spec 2) — to the new repo with package imports (`kaizen/types`) in
+  place of relative imports.
+- Migration of harness files in `harnesses/*` to the new repo.
+- Removing the `plugins/` and `harnesses/` directories and all plugin-related
+  static imports from the `kaizen-code` repo.
+- Dev-time workflow: how contributors run kaizen from source against a local
+  marketplace (no special-case embedding for dev).
+- Test-fixture strategy: tiny inline fixture plugins for kaizen-code's own
+  unit tests; integration/e2e tests point at a real `kaizen-plugins` checkout.
+- Documentation updates (`docs/architecture.md`, `docs/plugin-loading.md`,
+  `docs/plugin-api.md`).
 
 ### Out of Scope
 
-- Changing the binary embedding strategy (plugins remain compiled in).
-- Moving `core-events`, `core-lifecycle`, etc. to fully independent repos — a single
+- The dynamic plugin loader itself (`src/core/plugin-loader.ts`,
+  `loadPluginFromInstallDir`) — owned by Spec 1's plan.
+- The marketplace install path and `pluginInstallDir`/`harnessInstallDir`
+  helpers — owned by Spec 1.
+- Installer / packaging work (pre-seeding the official marketplace, installing
+  a default plugin set, shipping a default harness on first run) — owned by
+  the installer, not kaizen-code.
+- Reshaping executor plugins to the Spec 2 `config.schema` + `config.secrets`
+  pattern — owned by Spec 2's plan Phase 9. This spec copies executors as-is;
+  Spec 2 reshapes them afterwards in the new repo.
+- npm publishing of plugins — catalog entries use `file` sources initially.
+  Switching to `npm` sources is future work, driven by the new repo's own CI.
+- Splitting first-party plugins into independent repos — a single
   `kaizen-plugins` monorepo is sufficient for v1.
-- CI/CD for publishing plugins to npm (left to the new repo's own setup).
-- Removing the `plugins/` directory from the main repo immediately — migration is
-  phased.
+- Plugin signing (Trust Model C) — future work.
+
+---
+
+## Prerequisites
+
+- **Spec 1 (marketplace) must be fully shipped.** Specifically, the spec-1 plan
+  must have delivered: marketplace add/update/install commands, the install
+  layout under `~/.kaizen/marketplaces/<id>/`, the `core/kaizen-config.ts`
+  path-owning module, the dynamic plugin loader (`loadPluginFromInstallDir`),
+  and the `src/cli.ts` wiring that loads plugins from installed marketplaces.
+  Without the loader in place, removing static imports breaks the binary.
+- **Spec 3 (scaffolder + standards) is recommended.** Migrated plugins should
+  pass `kaizen plugin validate`. If Spec 3 is not yet merged when Spec 4 lands,
+  any validator gaps are noted as follow-ups.
+- **Spec 2 (unified config + core-secrets) is optional.** If Spec 2 is merged
+  first, `core-secrets` is included in the initial migration list. If Spec 4
+  ships first, `core-secrets` is added to the repo later by Spec 2's plan.
 
 ---
 
 ## Target Repository: `kaizen-sh/kaizen-plugins`
 
-A new git repository following the conventional marketplace layout:
+A new git repository with the following layout:
 
 ```
 kaizen-plugins/
 ├── .kaizen/
-│   └── marketplace.json          ← official marketplace catalog
+│   └── marketplace.json           ← official marketplace catalog (Spec 1 format)
 ├── plugins/
 │   ├── core-events/
-│   │   ├── package.json          ← standalone: name "core-events", no relative imports
+│   │   ├── package.json
 │   │   ├── index.ts
 │   │   ├── index.test.ts
 │   │   └── README.md
@@ -86,15 +141,21 @@ kaizen-plugins/
 │   ├── core-executor-shell/
 │   ├── core-cli/
 │   ├── core-plugin-manager/
-│   └── kaizen-plugin-timestamps/
+│   ├── core-secrets/              ← new (Spec 2); added when Spec 2 lands
+│   └── timestamps/                ← renamed from kaizen-plugin-timestamps
 ├── harnesses/
 │   ├── core-anthropic.json
 │   ├── core-debug.json
 │   └── core-shell.json
+├── package.json                   ← workspace root
 └── README.md
 ```
 
 ### Official Marketplace Catalog (`.kaizen/marketplace.json`)
+
+Spec 1 catalog format: flat `entries[]` with `kind` tags; names unique across
+kinds; every version declares `minKaizenVersion` as a bare semver enforced
+install-time.
 
 ```json
 {
@@ -102,45 +163,83 @@ kaizen-plugins/
   "name": "kaizen-official",
   "description": "Official kaizen plugins and harnesses.",
   "url": "https://github.com/kaizen-sh/kaizen-plugins.git",
-  "plugins": [
+  "entries": [
     {
+      "kind": "plugin",
       "name": "core-events",
       "description": "Default event vocabulary for kaizen sessions.",
       "categories": ["core"],
       "versions": [
         {
-          "version": "2.0.0",
-          "source": { "type": "npm", "name": "kaizen-core-events", "version": "2.0.0" }
+          "version": "0.1.0",
+          "source": { "type": "file", "path": "plugins/core-events" },
+          "minKaizenVersion": "0.5.0"
         }
       ]
     },
     {
-      "name": "kaizen-plugin-timestamps",
+      "kind": "plugin",
+      "name": "timestamps",
       "description": "Prepends ISO timestamps to user messages and agent responses.",
       "categories": ["tool"],
       "versions": [
         {
           "version": "0.1.0",
-          "source": { "type": "file", "path": "plugins/kaizen-plugin-timestamps" }
+          "source": { "type": "file", "path": "plugins/timestamps" },
+          "minKaizenVersion": "0.5.0"
         }
       ]
-    }
-  ],
-  "harnesses": [
+    },
     {
+      "kind": "harness",
       "name": "core-anthropic",
       "description": "Default Anthropic LLM harness.",
       "categories": ["harness"],
       "versions": [
         {
           "version": "1.0.0",
-          "path": "harnesses/core-anthropic.json"
+          "path": "harnesses/core-anthropic.json",
+          "minKaizenVersion": "0.5.0"
         }
       ]
     }
   ]
 }
 ```
+
+Notes:
+- Names are unique across kinds — a plugin and a harness cannot share a name.
+- Catalog entry for the legacy `kaizen-plugin-timestamps` package is named
+  `timestamps`. Spec 1's resolution-time deprecation shim auto-rewrites bare
+  `kaizen-plugin-<name>` inputs to `<name>` against the `official` marketplace
+  for one release, then hard-errors.
+- Initial catalog uses `file` sources; entries live in the same repo. Switching
+  to `npm` sources is future work.
+
+---
+
+## Harness Files: Canonical Refs
+
+Spec 1 requires on-disk harness files to reference plugins with fully-qualified
+canonical refs (`<marketplace-id>/<name>@<version>`). Since every plugin is now
+marketplace-installed, harnesses in the official repo reference them
+accordingly:
+
+```json
+{
+  "plugins": [
+    "official/core-events@0.1.0",
+    "official/core-lifecycle@0.1.0",
+    "official/core-ui-terminal@0.1.0",
+    "official/core-executor-anthropic@0.1.0",
+    "official/core-cli@0.1.0",
+    "official/core-plugin-manager@0.1.0"
+  ]
+}
+```
+
+No bare-name refs in shipped harness files. Bare names are accepted only at CLI
+input; canonicalized before any file write.
 
 ---
 
@@ -153,119 +252,259 @@ Current plugins use relative imports to access core types:
 import type { KaizenPlugin } from "../../src/types/plugin.js";
 ```
 
-After decoupling, plugins import from the published kaizen package:
+After migration, plugins import from the `kaizen` package:
 
 ```typescript
-// After decoupling
+// After migration
 import type { KaizenPlugin } from "kaizen/types";
 ```
 
-This requires:
-1. `kaizen/types` export path declared in kaizen's `package.json` exports map.
-2. The `kaizen` package published to npm (or the new repo's plugins use `kaizen` as a
-   peer dependency resolved from the binary's install location).
+This requires `kaizen/types` to be declared in the kaizen package's `exports`
+map. Adding that export is part of this spec.
 
-**Package.json changes for each plugin:**
+Each plugin's `package.json` declares `kaizen` as a peer dependency:
+
 ```json
 {
-  "peerDependencies": {
-    "kaizen": "*"
-  }
+  "name": "<plugin-name>",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": { ".": "./index.ts" },
+  "keywords": ["kaizen-plugin"],
+  "peerDependencies": { "kaizen": "*" }
 }
 ```
 
+Cross-plugin imports (e.g. `core-lifecycle` importing `EVENTS` from
+`core-events`) become package imports (`import { EVENTS } from "core-events"`)
+and are listed as peer dependencies. At runtime these resolve through the
+loader's absolute-path import of the dependent plugin — not via `node_modules`.
+
 ---
 
-## Build Process Changes
+## Removing the Embedding Path in kaizen-code
 
-The kaizen binary currently embeds plugins via static imports in `src/cli.ts`:
+The binary currently embeds plugins via static imports in `src/cli.ts`:
 
 ```typescript
 import coreEvents from "core-events";
 import coreLifecycle from "core-lifecycle";
-// ...
+// …
+const plugins = [coreEvents, coreLifecycle, /* … */];
 ```
 
-After decoupling, these imports still work — the plugins are still npm packages,
-just sourced from a different repo. The build CI:
+After Spec 1's plan ships the dynamic loader, these static imports are
+redundant. This spec removes them and all fallback paths that referenced
+embedded plugins:
 
-1. Checks out `kaizen-sh/kaizen-plugins` (pinned to a tag or SHA).
-2. Runs `bun install` in each `plugins/<name>` directory (for any plugin-level deps).
-3. Runs `bun build --compile` on the main kaizen repo — the static imports resolve
-   from the checked-out plugin directories (via workspace or path overrides in
-   `package.json`).
+- Delete every `import <plugin> from "<plugin>"` line in `src/cli.ts`.
+- Delete any `const builtinPlugins = [...]` or equivalent hard-coded list.
+- Delete `plugins/` and `harnesses/` from the `kaizen-code` repo.
+- Remove `plugins/*` workspace entries from the root `package.json`.
+- Add the `kaizen/types` export path to `package.json` `exports`.
+- Remove any code path in the plugin resolver that distinguished "embedded"
+  from "installed" plugins — there is only one path now.
 
-**Option A (recommended): npm workspace.**
-The kaizen repo's `package.json` lists `kaizen-plugins` as a workspace or the plugins
-as local workspace packages. `bun install` at the repo root resolves them.
-
-**Option B: npm publish first.**
-Plugins are published to npm before the kaizen binary is built. The build pulls from
-the npm registry. Slower CI; stronger guarantee that the binary matches published npm.
-
-**Recommendation: Option A for development builds; Option B for release builds.**
+After this change, a fresh kaizen binary run against an empty `~/.kaizen/`
+produces a plain error ("no marketplaces configured" or "no harness
+installed") rather than silently booting a default plugin set. Providing a
+working first-run experience is the installer's job.
 
 ---
 
-## Phased Migration
+## Dev-Time Workflow
 
-### Phase 1 — New repo + catalog (no breakage)
+Running `kaizen-code` from source still needs plugins to load. With no
+embedding, dev mode goes through the same marketplace path as production.
 
-1. Create `kaizen-sh/kaizen-plugins` with the layout above.
-2. Copy plugin source from `plugins/*` in the main repo.
-3. Update relative imports to `kaizen/types`.
-4. Add `package.json` peer dependencies.
-5. Publish the `.kaizen/marketplace.json` catalog.
-6. The main repo's `plugins/` directory remains; both copies exist temporarily.
+### Recommended Contributor Setup
 
-### Phase 2 — Switch build to use new repo
-
-1. Update kaizen build CI to pull from `kaizen-sh/kaizen-plugins`.
-2. Verify binary still builds and all tests pass.
-3. Delete `plugins/` from the main kaizen repo.
-4. Update `docs/architecture.md` to reflect the new layout.
-
-### Phase 3 — Official marketplace declared
-
-1. `kaizen init --global` pre-adds the official marketplace:
-   ```json
-   { "id": "official", "url": "https://github.com/kaizen-sh/kaizen-plugins.git" }
+1. Clone `kaizen-sh/kaizen-plugins` as a sibling directory to `kaizen-code`.
+2. Point a local marketplace at the checkout:
    ```
-2. `kaizen marketplace list` shows the official marketplace on fresh installs.
-3. `kaizen install official/kaizen-plugin-timestamps` works.
+   kaizen marketplace add dev file://../kaizen-plugins
+   ```
+   Or seed `~/.kaizen/kaizen.json` with the entry manually.
+3. Install the plugins/harness you need:
+   ```
+   kaizen install dev/core-events
+   kaizen install dev/core-lifecycle
+   kaizen install dev/core-ui-terminal
+   kaizen install dev/core-executor-debug
+   kaizen harness install dev/core-debug
+   ```
+4. Run kaizen normally — plugins load from
+   `~/.kaizen/marketplaces/dev/plugins/<name>@<version>/`.
+
+A helper script in `kaizen-code` (`scripts/dev-setup.sh`) automates steps 1–3
+for contributors. It is convenience, not infrastructure: the mechanism is the
+standard marketplace path, not a dev-only code path in the binary.
+
+### No Dev-Only Code Paths
+
+`kaizen-code` does not special-case source-tree development. There is no
+`NODE_ENV=development` branch that re-enables embedding, no `--dev-plugins`
+flag that bypasses the loader, no workspace-resolution shortcut. Dev mode
+exercises the same install + load path as production, which is the point.
 
 ---
 
-## Documentation Updates
+## Test Fixtures
 
-- `docs/architecture.md` — update "Directory structure" to reference `kaizen-plugins`
-  repo; update plugin resolution order to mention official marketplace.
-- `docs/plugin-loading.md` — update "Development workflow" to reference the new repo.
-- `docs/plugin-api.md` — update import path examples to `kaizen/types`.
-- New `docs/contributing-plugins.md` — guide for contributing to `kaizen-plugins`.
+With plugins extracted, kaizen-code's tests can no longer import plugin
+implementations directly. Two test tiers:
+
+### Unit Tests (inline fixtures)
+
+Under `test/fixtures/plugins/*`, the kaizen-code repo ships tiny
+throwaway plugins used only by its own unit tests — minimal implementations
+that exercise harness loading, session wiring, event dispatch, etc. These
+fixtures are:
+
+- Loaded through the standard marketplace path via a test-only fixture
+  marketplace.
+- Never published; not part of any user-facing marketplace.
+- Intentionally minimal — they do not claim to represent real-world plugin
+  behavior.
+
+### Integration / E2E Tests
+
+Integration and end-to-end tests in `kaizen-code` check out the real
+`kaizen-sh/kaizen-plugins` repository (pinned to a tag or SHA) and run
+kaizen against it through the standard marketplace path. This is the tier
+that validates real-world plugin behavior.
+
+CI runs both tiers. Pinning strategy (tag vs. SHA vs. HEAD) is an
+implementation detail for the plan.
+
+---
+
+## Component Architecture
+
+| Component | Owner | Role |
+|---|---|---|
+| `src/cli.ts` static plugin imports | kaizen-code (removed here) | Deleted in this spec |
+| `src/core/plugin-loader.ts` | Spec 1 plan (already shipped) | Dynamic import from install dir |
+| `src/core/kaizen-config.ts` | Spec 1 (already shipped) | Owns `~/.kaizen/` path helpers |
+| `package.json#exports["./types"]` | kaizen-code (added here) | Public types entry for plugins |
+| `plugins/` directory | kaizen-code (removed here) | Deleted |
+| `harnesses/` directory | kaizen-code (removed here) | Deleted |
+| `kaizen-plugins` repository | new | First-party plugin source + catalog |
+| `.kaizen/marketplace.json` (in new repo) | new | Official catalog |
+| Pre-seeding official marketplace | installer (out of scope) | — |
+| First-run plugin/harness install | installer (out of scope) | — |
+
+---
+
+## Error Handling
+
+- **Binary runs with empty `~/.kaizen/`:** kaizen exits with a clear message
+  pointing at `kaizen marketplace add` and `kaizen install`. No silent
+  fallback to any default plugin set.
+- **Harness references a plugin not installed:** Spec 1's loader surfaces
+  "plugin `<ref>` not installed — run `kaizen install <ref>`". Unchanged.
+- **`minKaizenVersion` check fails at install:** Spec 1's install path raises
+  `KaizenVersionTooOldError`. Unchanged.
+- **Contributor runs kaizen from source with no dev marketplace configured:**
+  Same empty-`~/.kaizen/` error. The contributor guide surfaces
+  `scripts/dev-setup.sh`.
 
 ---
 
 ## Testing
 
 | Area | Approach |
-|------|----------|
-| Plugin import paths | Each plugin in new repo builds without errors |
-| Catalog validity | `kaizen marketplace validate .` passes on new repo |
-| Binary build | End-to-end: binary compiles, `kaizen run` starts, built-ins load |
-| Official marketplace | `kaizen marketplace add <url>` + `kaizen install official/timestamps` |
-| Backward compat | Existing harnesses with bare `core-events` etc. still resolve |
+|---|---|
+| Plugin builds in new repo | Each plugin's `bun test` passes after import migration |
+| Cross-plugin imports | `core-lifecycle` imports `EVENTS` from `core-events` via package import; resolves at runtime through the loader |
+| Catalog validity | `kaizen marketplace validate .` passes on `kaizen-plugins` repo |
+| Binary build | `bun build --compile` succeeds with no `plugins/` directory |
+| Empty first-run | Fresh binary against empty `~/.kaizen/` produces the documented error |
+| Dev-setup script | From a clean `kaizen-code` + sibling `kaizen-plugins` checkout, `scripts/dev-setup.sh` + `kaizen run` boots |
+| Unit tests with fixtures | Inline fixture plugins exercise harness/session/loader wiring |
+| Integration tests | Real `kaizen-plugins` checkout drives e2e scenarios |
+| Canonical refs in harnesses | Shipped harness files use `official/<name>@<version>` — no bare names |
+
+---
+
+## Migration
+
+### Phase 1 — Set up `kaizen-sh/kaizen-plugins`
+
+Create the repo with the layout above. Workspace `package.json` at the root.
+Initial empty `.kaizen/marketplace.json`. README stub.
+
+### Phase 2 — Migrate plugins
+
+Copy each plugin from `kaizen-code/plugins/*` to the new repo's
+`plugins/*`. Fix imports (`kaizen/types`, package imports across plugins).
+Add `package.json` peer deps. Ensure tests pass. Rename
+`kaizen-plugin-timestamps` → `timestamps`.
+
+Plugins to migrate:
+- `core-events`
+- `core-lifecycle`
+- `core-ui-terminal`
+- `core-cli`
+- `core-plugin-manager`
+- `core-executor-anthropic`
+- `core-executor-openai`
+- `core-executor-debug`
+- `core-executor-shell`
+- `timestamps` (was `kaizen-plugin-timestamps`)
+- `core-secrets` — only if Spec 2 is merged before this phase; otherwise
+  added by Spec 2's plan later.
+
+Executors are copied as-is; Spec 2's plan Phase 9 reshapes them to the
+`config.schema` + `config.secrets` pattern later.
+
+### Phase 3 — Migrate harnesses
+
+Copy harness JSON files. Rewrite plugin refs to canonical
+`official/<name>@<version>`.
+
+### Phase 4 — Write official catalog
+
+Populate `.kaizen/marketplace.json` with `entries[]` for every migrated
+plugin + harness. Every version declares `minKaizenVersion`. Run
+`kaizen marketplace validate .`.
+
+### Phase 5 — Add `kaizen/types` export in kaizen-code
+
+Declare the `./types` export in the root `package.json`. Verify a sample
+plugin in the new repo compiles against it.
+
+### Phase 6 — Remove embedding from kaizen-code
+
+- Delete every static plugin import in `src/cli.ts`.
+- Delete `plugins/` and `harnesses/` directories.
+- Remove `plugins/*` workspace entries from root `package.json`.
+- Remove any "embedded vs. installed" branch in the resolver.
+- Add inline test fixtures under `test/fixtures/plugins/*`.
+- Wire integration tests to a sibling `kaizen-plugins` checkout.
+- Add `scripts/dev-setup.sh` for contributors.
+
+### Phase 7 — Documentation
+
+- `docs/architecture.md` — remove "Directory structure: plugins/", add the
+  new repo + marketplace flow.
+- `docs/plugin-loading.md` — document marketplace-only loading; no
+  embedding.
+- `docs/plugin-api.md` — import examples use `kaizen/types`.
+- New `docs/contributing-plugins.md` — guide for contributing to
+  `kaizen-sh/kaizen-plugins`.
+- Update contributor README in kaizen-code with the dev-setup flow.
 
 ---
 
 ## Future Work
 
-- **Independent plugin releases.** Once decoupled, each plugin can have its own
-  semantic version and release cadence. npm publish automation via GitHub Actions in
-  the `kaizen-plugins` repo.
-- **Plugin signing (Trust Model C).** When publisher signing lands, the official
-  marketplace is the first candidate for signing — all `kaizen-sh` org plugins signed
-  with the org cert.
-- **Community plugins repo.** A separate `kaizen-sh/kaizen-community-plugins`
-  marketplace following the same format, for community-contributed plugins that meet
-  a quality bar but are not official.
+- **Independent plugin releases.** Per-plugin semver, npm publish automation
+  in the `kaizen-plugins` repo, catalog entries shift from `file` to `npm`
+  sources.
+- **Plugin signing (Trust Model C).** Official plugins signed with the
+  `kaizen-sh` org cert.
+- **Community plugins repo.** `kaizen-sh/kaizen-community-plugins`
+  marketplace with a quality bar but not "official".
+- **Retire the `kaizen-plugin-*` deprecation shim.** One release after Spec 1
+  ships it, remove the shim and require marketplace-qualified refs.

--- a/docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md
+++ b/docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md
@@ -1,0 +1,271 @@
+# Design: Built-in Plugins Repo Decoupling
+
+Date: 2026-04-18
+Status: APPROVED
+Related:
+- `docs/architecture.md` (current built-in plugin layout)
+- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — marketplace format this leverages)
+- `docs/plugin-loading.md` (binary loading internals)
+
+---
+
+## Problem Statement
+
+All built-in plugins (`core-events`, `core-lifecycle`, `core-ui-terminal`, etc.) live
+in the main kaizen monorepo under `plugins/`. This has several downsides:
+
+- Plugin authors and contributors must clone the entire kaizen repo to work on a plugin.
+- Plugin versioning is coupled to the kaizen release cycle — a fix to
+  `kaizen-plugin-timestamps` requires a kaizen release.
+- The official built-in plugins are a poor reference for third-party authors because
+  they depend on relative imports (`../../src/types/plugin.js`) that don't apply
+  to installed packages.
+- There is no "official marketplace" that third-party authors can reference as the
+  canonical `kaizen-plugin` collection.
+
+This design decouples the built-in plugins into a dedicated repository (or set of
+repositories) and establishes an official kaizen marketplace — the first instance
+of the marketplace format defined in Spec 1.
+
+---
+
+## Design Philosophy
+
+- **Keep binary startup unchanged.** The compiled binary still embeds the default
+  plugin stack. Users with no network access, no global npm install, and no
+  `kaizen.json` get a working kaizen. The decoupling is source-level; the
+  binary-level embedding is preserved.
+- **The official marketplace is the reference implementation.** It validates the
+  Spec 1 marketplace format in production and provides a concrete example for
+  third-party marketplace authors.
+- **Plugins evolve independently.** Once decoupled, a plugin can cut its own release
+  without gating on the kaizen core release cycle.
+
+---
+
+## Scope
+
+### In Scope
+
+- Proposal for the new `kaizen-plugins` repository structure.
+- Official marketplace catalog at `.kaizen/marketplace.json` in the new repo.
+- Changes to the kaizen build process to pull plugin sources from the new repo.
+- Migration guide for existing built-in plugins (relative imports → package imports).
+- Documentation updates (`docs/architecture.md`, `docs/plugin-loading.md`).
+
+### Out of Scope
+
+- Changing the binary embedding strategy (plugins remain compiled in).
+- Moving `core-events`, `core-lifecycle`, etc. to fully independent repos — a single
+  `kaizen-plugins` monorepo is sufficient for v1.
+- CI/CD for publishing plugins to npm (left to the new repo's own setup).
+- Removing the `plugins/` directory from the main repo immediately — migration is
+  phased.
+
+---
+
+## Target Repository: `kaizen-sh/kaizen-plugins`
+
+A new git repository following the conventional marketplace layout:
+
+```
+kaizen-plugins/
+├── .kaizen/
+│   └── marketplace.json          ← official marketplace catalog
+├── plugins/
+│   ├── core-events/
+│   │   ├── package.json          ← standalone: name "core-events", no relative imports
+│   │   ├── index.ts
+│   │   ├── index.test.ts
+│   │   └── README.md
+│   ├── core-lifecycle/
+│   ├── core-ui-terminal/
+│   ├── core-executor-anthropic/
+│   ├── core-executor-openai/
+│   ├── core-executor-debug/
+│   ├── core-executor-shell/
+│   ├── core-cli/
+│   ├── core-plugin-manager/
+│   └── kaizen-plugin-timestamps/
+├── harnesses/
+│   ├── core-anthropic.json
+│   ├── core-debug.json
+│   └── core-shell.json
+└── README.md
+```
+
+### Official Marketplace Catalog (`.kaizen/marketplace.json`)
+
+```json
+{
+  "version": "1.0.0",
+  "name": "kaizen-official",
+  "description": "Official kaizen plugins and harnesses.",
+  "url": "https://github.com/kaizen-sh/kaizen-plugins.git",
+  "plugins": [
+    {
+      "name": "core-events",
+      "description": "Default event vocabulary for kaizen sessions.",
+      "categories": ["core"],
+      "versions": [
+        {
+          "version": "2.0.0",
+          "source": { "type": "npm", "name": "kaizen-core-events", "version": "2.0.0" }
+        }
+      ]
+    },
+    {
+      "name": "kaizen-plugin-timestamps",
+      "description": "Prepends ISO timestamps to user messages and agent responses.",
+      "categories": ["tool"],
+      "versions": [
+        {
+          "version": "0.1.0",
+          "source": { "type": "file", "path": "plugins/kaizen-plugin-timestamps" }
+        }
+      ]
+    }
+  ],
+  "harnesses": [
+    {
+      "name": "core-anthropic",
+      "description": "Default Anthropic LLM harness.",
+      "categories": ["harness"],
+      "versions": [
+        {
+          "version": "1.0.0",
+          "path": "harnesses/core-anthropic.json"
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Plugin Migration: Relative Imports → Package Imports
+
+Current plugins use relative imports to access core types:
+
+```typescript
+// Current (in plugins/core-events/index.ts)
+import type { KaizenPlugin } from "../../src/types/plugin.js";
+```
+
+After decoupling, plugins import from the published kaizen package:
+
+```typescript
+// After decoupling
+import type { KaizenPlugin } from "kaizen/types";
+```
+
+This requires:
+1. `kaizen/types` export path declared in kaizen's `package.json` exports map.
+2. The `kaizen` package published to npm (or the new repo's plugins use `kaizen` as a
+   peer dependency resolved from the binary's install location).
+
+**Package.json changes for each plugin:**
+```json
+{
+  "peerDependencies": {
+    "kaizen": "*"
+  }
+}
+```
+
+---
+
+## Build Process Changes
+
+The kaizen binary currently embeds plugins via static imports in `src/cli.ts`:
+
+```typescript
+import coreEvents from "core-events";
+import coreLifecycle from "core-lifecycle";
+// ...
+```
+
+After decoupling, these imports still work — the plugins are still npm packages,
+just sourced from a different repo. The build CI:
+
+1. Checks out `kaizen-sh/kaizen-plugins` (pinned to a tag or SHA).
+2. Runs `bun install` in each `plugins/<name>` directory (for any plugin-level deps).
+3. Runs `bun build --compile` on the main kaizen repo — the static imports resolve
+   from the checked-out plugin directories (via workspace or path overrides in
+   `package.json`).
+
+**Option A (recommended): npm workspace.**
+The kaizen repo's `package.json` lists `kaizen-plugins` as a workspace or the plugins
+as local workspace packages. `bun install` at the repo root resolves them.
+
+**Option B: npm publish first.**
+Plugins are published to npm before the kaizen binary is built. The build pulls from
+the npm registry. Slower CI; stronger guarantee that the binary matches published npm.
+
+**Recommendation: Option A for development builds; Option B for release builds.**
+
+---
+
+## Phased Migration
+
+### Phase 1 — New repo + catalog (no breakage)
+
+1. Create `kaizen-sh/kaizen-plugins` with the layout above.
+2. Copy plugin source from `plugins/*` in the main repo.
+3. Update relative imports to `kaizen/types`.
+4. Add `package.json` peer dependencies.
+5. Publish the `.kaizen/marketplace.json` catalog.
+6. The main repo's `plugins/` directory remains; both copies exist temporarily.
+
+### Phase 2 — Switch build to use new repo
+
+1. Update kaizen build CI to pull from `kaizen-sh/kaizen-plugins`.
+2. Verify binary still builds and all tests pass.
+3. Delete `plugins/` from the main kaizen repo.
+4. Update `docs/architecture.md` to reflect the new layout.
+
+### Phase 3 — Official marketplace declared
+
+1. `kaizen init --global` pre-adds the official marketplace:
+   ```json
+   { "id": "official", "url": "https://github.com/kaizen-sh/kaizen-plugins.git" }
+   ```
+2. `kaizen marketplace list` shows the official marketplace on fresh installs.
+3. `kaizen install official/kaizen-plugin-timestamps` works.
+
+---
+
+## Documentation Updates
+
+- `docs/architecture.md` — update "Directory structure" to reference `kaizen-plugins`
+  repo; update plugin resolution order to mention official marketplace.
+- `docs/plugin-loading.md` — update "Development workflow" to reference the new repo.
+- `docs/plugin-api.md` — update import path examples to `kaizen/types`.
+- New `docs/contributing-plugins.md` — guide for contributing to `kaizen-plugins`.
+
+---
+
+## Testing
+
+| Area | Approach |
+|------|----------|
+| Plugin import paths | Each plugin in new repo builds without errors |
+| Catalog validity | `kaizen marketplace validate .` passes on new repo |
+| Binary build | End-to-end: binary compiles, `kaizen run` starts, built-ins load |
+| Official marketplace | `kaizen marketplace add <url>` + `kaizen install official/timestamps` |
+| Backward compat | Existing harnesses with bare `core-events` etc. still resolve |
+
+---
+
+## Future Work
+
+- **Independent plugin releases.** Once decoupled, each plugin can have its own
+  semantic version and release cadence. npm publish automation via GitHub Actions in
+  the `kaizen-plugins` repo.
+- **Plugin signing (Trust Model C).** When publisher signing lands, the official
+  marketplace is the first candidate for signing — all `kaizen-sh` org plugins signed
+  with the org cert.
+- **Community plugins repo.** A separate `kaizen-sh/kaizen-community-plugins`
+  marketplace following the same format, for community-contributed plugins that meet
+  a quality bar but are not official.

--- a/docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md
@@ -189,7 +189,17 @@ interface PluginVersionEntry {
   version: string;             // semver
   source: PluginSource;
   changelog?: string;
-  minKaizenVersion?: string;   // semver range
+  /**
+   * Minimum kaizen version required to install this plugin version. A bare
+   * semver (e.g. `"1.4.0"`), NOT a range — analogous to how a Kubernetes
+   * workload declares "needs k8s >= 1.30". Enforced at install-time: if
+   * `semver.gte(kaizenVersion, minKaizenVersion)` is false, `kaizen install`
+   * fails hard with a `KaizenVersionTooOldError`. Not re-checked at
+   * load-time — once installed, the plugin loads regardless of subsequent
+   * kaizen upgrades/downgrades (the lockfile is authoritative). There is
+   * no upper bound; plugins do not declare maximum-supported kaizen.
+   */
+  minKaizenVersion?: string;
 }
 
 interface HarnessVersionEntry {
@@ -609,6 +619,8 @@ verb for everything under `<id>/`.
 | Harness plugin entry is shorthand (not canonical) | Fatal: "harness plugin refs must be canonical `<marketplace>/<name>@<version>`. Run `kaizen install <name>` to canonicalize." |
 | Legacy `kaizen-plugin-*` bare-npm ref | Deprecation warning; auto-resolve against `official`. Hard error in v-next. |
 | Consent denied | Exit 1, no install |
+| `minKaizenVersion` unsatisfied at install | Fatal (`KaizenVersionTooOldError`): "<plugin>@<version> requires kaizen >= <min>; running <current>. Upgrade kaizen or pick an older plugin version."; exit 1 |
+| `minKaizenVersion` not a bare semver (e.g. a range like `^1.4.0`) | Fatal at `marketplace add` / `update`: "minKaizenVersion must be a bare semver, not a range."; exit 1 |
 | `--trust-lockfile` with missing lockfile entry | Fatal: "Plugin <name> not in lockfile. Run `kaizen install <ref>` first." |
 | Harness `marketplaces` entry clone fails during bootstrap, and a plugin ref needs it | Fatal: "cannot add marketplace <id> from <url>: <git error>"; bootstrap aborts |
 | Harness `marketplaces` entry clone fails, no plugin ref depends on it | Warning; bootstrap continues |

--- a/docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md
@@ -1,0 +1,432 @@
+# Design: Plugin Marketplace, Kaizen-Level Config & Install Rework
+
+Date: 2026-04-18
+Status: APPROVED
+Related:
+- `docs/architecture.md` (plugin resolution order, runtime layout)
+- `docs/plugin-security.md` (consent + lockfile — unchanged by this spec)
+- `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md` (Spec 2 — depends on this)
+- `docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md` (Spec 3 — depends on this)
+- `docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md` (Spec 4 — depends on this)
+
+---
+
+## Problem Statement
+
+Kaizen currently has no first-class mechanism for discovering, browsing, or sharing
+plugins and harnesses. Plugin "discovery" is `npm search kaizen-plugin`. Installation is
+a split between `kaizen install <name>` and `kaizen plugin install <pkg>` with subtly
+different behaviour. There is no portable harness format that can self-bootstrap — a
+shared `kaizen.json` only works if the recipient has already installed the right plugins.
+
+This design introduces:
+
+1. **Federated marketplaces** — any git repo or local directory containing
+   `.kaizen/marketplace.json` is a kaizen marketplace. No central registry required.
+2. **Polymorphic plugin refs** — a unified syntax for naming plugins across all ref
+   types (marketplace-qualified, npm, local path, URL).
+3. **Portable harnesses** — a harness file lists plugins by ref. `kaizen --harness
+   <url>` bootstraps missing plugins automatically. The file is all you need.
+4. **Kaizen-level config** — a new `~/.kaizen/kaizen.json` layer for global settings
+   (added marketplaces, defaults). Separate from per-project harness config.
+5. **Unified install CLI** — `kaizen install`, `kaizen uninstall`, `kaizen update`,
+   `kaizen marketplace *` replace the current fragmented surface.
+
+---
+
+## Design Philosophy
+
+- **Marketplace = discovery, not trust.** Adding a marketplace does not grant any
+  special trust to its plugins. Every plugin still goes through per-plugin UAC
+  (the security model from `docs/plugin-security.md` is unchanged).
+- **File as wire format.** A harness JSON is the portable artifact. Its URL is the
+  sharable link. No install step required to try a harness.
+- **Install vs ephemeral.** Installed plugins persist to `~/.kaizen/node_modules/`.
+  Ephemeral (from `--harness <url>`) fetches to `~/.kaizen/cache/` and can be GC'd.
+- **Ref syntax is obvious from shape.** `official/timestamps@1.2.3` is marketplace-
+  qualified. `./my-plugin` is local. `https://...` is a URL. No explicit scheme
+  prefix required for the common cases.
+- **Future-proof signing.** The catalog format reserves a `signature` field.
+  Publisher signing (trust model C) is deferred — see Future Work.
+
+---
+
+## Scope
+
+### In Scope
+
+- `marketplace.json` schema (the catalog format).
+- Kaizen-level config at `~/.kaizen/kaizen.json` (marketplaces array, defaults).
+- Plugin ref parser and resolver (all ref shapes → resolved install source).
+- `kaizen marketplace add|list|remove|update` commands.
+- `kaizen marketplace browse` (stub — lists catalog entries, no interactive TUI).
+- Revised `kaizen install <ref>` covering plugin and harness refs.
+- New `kaizen uninstall <ref>` and `kaizen update [<ref>]`.
+- Bootstrap-on-startup: `kaizen --harness <file|url|ref>` installs missing plugins.
+- Harness format extension: plugin entries accept any ref shape.
+- Backward compatibility: bare plugin names in existing harnesses treated as npm refs.
+- Cache directory (`~/.kaizen/cache/`) for ephemeral fetches.
+- Marketplace catalog cache (`~/.kaizen/marketplaces/<id>/marketplace.json`).
+- Lazy marketplace repo cloning: only clone full repo for `file`-source plugin installs.
+
+### Out of Scope (deferred)
+
+- Publisher signing / marketplace signature verification (Future Work section).
+- `kaizen marketplace browse` interactive TUI — stub only for v1.
+- Harness versioning / harness lock files.
+- Multi-version plugin side-by-side loading.
+- Marketplace publication workflow (`kaizen marketplace publish`).
+- Kaizen-level config beyond `marketplaces` and `defaults` (covered by Spec 2).
+
+---
+
+## Artifacts
+
+Four file types are defined or extended by this spec. All are JSON, all are portable
+by URL or filesystem path.
+
+### 1. Marketplace Catalog (`.kaizen/marketplace.json`)
+
+Lives at `.kaizen/marketplace.json` within a marketplace repo or directory.
+
+```typescript
+interface MarketplaceCatalog {
+  /** Catalog schema version. */
+  version: "1.0.0";
+  /** Human-readable name for the marketplace. */
+  name: string;
+  /** Short description. */
+  description?: string;
+  /** Canonical URL — the git remote or HTTPS URL users add via `kaizen marketplace add`. */
+  url: string;
+  /** Reserved for future publisher signing. */
+  signature?: string;
+  /** Plugin entries. */
+  plugins: MarketplacePluginEntry[];
+  /** Harness entries. */
+  harnesses: MarketplaceHarnessEntry[];
+}
+
+interface MarketplacePluginEntry {
+  /** Short name within this marketplace. kebab-case. */
+  name: string;
+  /** Human-readable description. */
+  description: string;
+  /** Category tags (e.g. "executor", "ui", "tool", "dev"). */
+  categories?: string[];
+  /** Published versions, newest first. */
+  versions: PluginVersionEntry[];
+}
+
+interface MarketplaceHarnessEntry {
+  /** Short name within this marketplace. */
+  name: string;
+  description: string;
+  categories?: string[];
+  versions: HarnessVersionEntry[];
+}
+
+interface PluginVersionEntry {
+  version: string;             // semver
+  source: PluginSource;
+  changelog?: string;
+  minKaizenVersion?: string;   // semver range
+}
+
+interface HarnessVersionEntry {
+  version: string;
+  /** Path (relative to marketplace root) or URL to the harness JSON file. */
+  path: string;
+  changelog?: string;
+}
+
+type PluginSource =
+  | { type: "npm";     name: string;  version: string }
+  | { type: "git";     url: string;   ref: string }
+  | { type: "tarball"; url: string;   sha256?: string }
+  | { type: "file";    path: string };  // relative to marketplace root
+```
+
+**`file` source resolution:** relative to the marketplace's root directory. For a
+git-backed marketplace this is the repo root (the clone dir). For a local filesystem
+marketplace this is the directory passed to `kaizen marketplace add`.
+
+### 2. Plugin Ref Syntax
+
+A plugin ref is a string that identifies a plugin (or harness). The form is inferred
+from its shape — no explicit scheme prefix required.
+
+| Form | Example | Resolves via |
+|------|---------|-------------|
+| Marketplace-qualified | `official/timestamps@1.2.3` | Catalog lookup |
+| Marketplace shorthand | `timestamps` or `timestamps@1.2.3` | First matching marketplace (prompt if ambiguous) |
+| Local path | `./my-plugin` or `/abs/path` | Filesystem |
+| URL | `https://example.com/plugin.tgz` | HTTP fetch |
+| npm package (legacy) | `kaizen-plugin-timestamps@1.2.3` | npm resolution |
+
+**Canonical form** (what gets written to harness files and the lockfile):
+`<marketplace-id>/<name>@<version>` for marketplace refs. Other forms are stored
+verbatim.
+
+**Ambiguity resolution:** if a shorthand name matches entries in multiple added
+marketplaces, `kaizen install` prompts the user to pick one. Non-interactive mode
+(`--non-interactive`) fails with an error.
+
+### 3. Harness File (extended)
+
+The existing `kaizen.json` harness format is extended: `plugins` entries now accept
+any ref shape. Existing bare names continue to work (treated as npm refs).
+
+```json
+{
+  "marketplaces": [
+    { "id": "official", "url": "https://github.com/kaizen-sh/marketplace.git" }
+  ],
+  "plugins": [
+    "official/timestamps@1.2.3",
+    "official/godot-tools@2.0.0",
+    "./local-dev-plugin",
+    "https://example.com/my-plugin.tgz",
+    "core-events"
+  ],
+  "core-executor-anthropic": {
+    "model": "claude-opus-4-6",
+    "api_key_env": "ANTHROPIC_API_KEY"
+  }
+}
+```
+
+The `marketplaces` section in a harness is **informational + bootstrap-enabling**:
+it tells `kaizen --harness <url>` which marketplaces to add (if not already added)
+so that marketplace-qualified refs in `plugins` can be resolved. Kaizen adds them
+temporarily for the bootstrap run; users must explicitly run `kaizen marketplace add`
+to persist them globally.
+
+### 4. Kaizen-Level Config (`~/.kaizen/kaizen.json`)
+
+New global config layer. Already partially exists (created by `kaizen init --global`);
+this spec extends its schema.
+
+```typescript
+interface KaizenGlobalConfig {
+  /** Added marketplaces. */
+  marketplaces?: MarketplaceRef[];
+  /** Default harness to run when no --harness flag or local .kaizen/kaizen.json. */
+  defaultHarness?: string;
+  /** Other future global settings. */
+  defaults?: Record<string, unknown>;
+}
+
+interface MarketplaceRef {
+  /** Short identifier used in plugin refs: `<id>/plugin@ver`. */
+  id: string;
+  /** Git URL or local directory path. */
+  url: string;
+  /** Timestamp of last successful `kaizen marketplace update`. */
+  updatedAt?: string;
+}
+```
+
+---
+
+## CLI Surface
+
+### `kaizen marketplace` subcommands
+
+```
+kaizen marketplace add <url> [--id <id>]
+```
+- `<url>`: git URL or local path. HTTPS GitHub URLs auto-detected.
+- `--id <id>`: override the marketplace identifier (default: derived from URL basename).
+- Fetches `.kaizen/marketplace.json` from the source (single-file fetch for git,
+  direct read for local). Validates schema. Writes to `~/.kaizen/marketplaces/<id>/`.
+- Updates `~/.kaizen/kaizen.json` `marketplaces` array.
+
+```
+kaizen marketplace list
+```
+Shows all added marketplaces: id, URL, plugin count, harness count, last updated.
+
+```
+kaizen marketplace remove <id>
+```
+Removes from global config and deletes cached catalog. Does not uninstall plugins.
+
+```
+kaizen marketplace update [<id>]
+```
+Re-fetches `.kaizen/marketplace.json` for one or all marketplaces.
+
+```
+kaizen marketplace browse [<id>]
+```
+Lists catalog entries. v1: tabular output to stdout. No interactive TUI.
+
+### `kaizen install <ref>`
+
+Unified install command. Accepts any ref shape. Replaces the split between
+`kaizen install <plugin>` (security flow) and `kaizen plugin install <pkg>` (npm-only).
+
+Flow:
+1. Parse ref → determine type.
+2. Resolve to a `PluginSource` (catalog lookup, or direct for path/URL/npm refs).
+3. Fetch manifest (read `KaizenPlugin` default export).
+4. Run consent flow (existing UAC — unchanged from `docs/plugin-security.md`).
+5. Install to `~/.kaizen/node_modules/` (npm) or appropriate location.
+6. Write lockfile entry.
+7. Add plugin name to `.kaizen/kaizen.json` `plugins` array (if project config exists).
+
+**Harness install:** `kaizen install harness:<ref>` fetches a harness JSON and writes
+it to `~/.kaizen/harnesses/<name>/kaizen.json`. The harness's plugins are NOT
+auto-installed — user runs `kaizen apply` separately, or uses `--harness` to bootstrap.
+
+### `kaizen uninstall <name>`
+
+Removes a plugin:
+1. Remove from `.kaizen/kaizen.json` `plugins` array.
+2. If `--purge`: npm uninstall from `~/.kaizen/node_modules/`, remove lockfile entry.
+3. Without `--purge`: removes from config only (plugin stays installed, lockfile entry
+   stays). Safe default — the plugin may be referenced by other harnesses.
+
+### `kaizen update [<ref>]`
+
+Updates one plugin (or all if no ref given):
+1. Resolve latest version from marketplace catalog (or npm dist-tag for npm refs).
+2. If version changed: re-run consent flow (grant changes require explicit re-consent;
+   same tier + same grants → silent update with new lockfile hash).
+3. Install new version.
+
+### `kaizen --harness <arg>` bootstrap
+
+`--harness` now accepts: file path, marketplace ref (`official/harness-name@ver`), or
+URL.
+
+Bootstrap flow for a harness with missing plugins:
+1. Fetch/read the harness JSON.
+2. If harness has a `marketplaces` section, register those marketplaces for this
+   session (without persisting to global config).
+3. For each plugin ref in `plugins`: check if installed. If not:
+   a. Resolve via ref resolver.
+   b. Fetch manifest.
+   c. Run consent flow (UAC per plugin). `--non-interactive --trust-lockfile` skips
+      UAC if a committed `kaizen.permissions.lock` covers the plugin.
+   d. Install (to `~/.kaizen/node_modules/` if interactive, to `~/.kaizen/cache/` if
+      ephemeral — see Ephemeral Cache).
+4. Run kaizen with the resolved plugin stack.
+
+**CI flow:**
+```bash
+kaizen --harness ./kaizen.json --trust-lockfile --non-interactive
+```
+Requires a committed `kaizen.permissions.lock` that covers all plugins. Fails fast
+if any plugin is missing from the lockfile.
+
+### Ephemeral Cache
+
+`~/.kaizen/cache/` holds fetched assets for `--harness <url>` runs that have not been
+explicitly installed. Subdirs by content hash. GC policy: entries older than 30 days
+with no recent access are candidates for removal. `kaizen cache clean [--all]` manual
+GC (future command, not part of this spec).
+
+---
+
+## Component Architecture
+
+### New modules
+
+**`src/core/marketplace.ts`**
+- `loadMarketplaceConfig(): KaizenGlobalConfig` — reads `~/.kaizen/kaizen.json`.
+- `saveMarketplaceConfig(cfg)` — writes global config.
+- `fetchCatalog(url): MarketplaceCatalog` — single-file fetch for git URLs (GitHub
+  raw API, or `git archive`); direct read for local paths. Validates against schema.
+- `getCachedCatalog(id): MarketplaceCatalog | null` — reads from
+  `~/.kaizen/marketplaces/<id>/marketplace.json`.
+- `writeCachedCatalog(id, catalog)` — persists fetched catalog.
+
+**`src/core/ref-resolver.ts`**
+- `parseRef(ref: string): ParsedRef` — determines ref type from shape.
+- `resolveRef(parsed: ParsedRef, marketplaces: MarketplaceRef[]): ResolvedSource` —
+  catalog lookup, npm resolution, or direct source.
+- `RefConflictError` — thrown when a shorthand ref matches multiple marketplaces.
+
+**`src/commands/marketplace.ts`**
+- Implements `add`, `list`, `remove`, `update`, `browse` subcommands.
+
+**`src/commands/install.ts`** (reworked)
+- Unified install using ref resolver. Replaces current `runInstall`.
+
+**`src/commands/uninstall.ts`** (new)
+**`src/commands/update.ts`** (new)
+
+### Modified modules
+
+**`src/cli.ts`**
+- Wire new `marketplace` subcommand.
+- Wire new `install` / `uninstall` / `update` top-level commands.
+- Extend `--harness` arg parsing to handle all ref shapes.
+- Bootstrap-on-startup logic.
+
+**`src/commands/manage.ts`**
+- `cmdPluginInstall` / `cmdPluginRemove` deprecated in favour of new commands.
+  Kept but print deprecation notice.
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Marketplace fetch fails (network error) | Error with URL + status; exit 1 |
+| Catalog schema invalid | Error listing validation failures; exit 1 |
+| Shorthand ref is ambiguous | Prompt to pick marketplace (interactive) or error (non-interactive) |
+| Plugin not found in any marketplace | Error "not found in any added marketplace. Run `kaizen marketplace list`." |
+| Consent denied | Exit 1, no install |
+| `--trust-lockfile` with missing lockfile entry | Fatal: "Plugin <name> not in lockfile. Run `kaizen install <ref>` first." |
+| Harness `marketplaces` ref fetch fails during bootstrap | Warning; bootstrap continues using already-added marketplaces |
+
+---
+
+## Testing
+
+| Area | Approach |
+|------|----------|
+| Ref parser | Unit tests for all forms: marketplace-qualified, shorthand, local, URL, npm, ambiguous |
+| Catalog schema | Valid / invalid JSON, missing required fields, unknown entry types |
+| `fetchCatalog` | Mock git raw API, local FS, network error |
+| Install pipeline | Integration test with a mock marketplace and all source types |
+| Harness bootstrap | Harness with missing plugins triggers consent + install; `--trust-lockfile` skips UAC |
+| Backward compat | Existing harness with bare npm names loads without modification |
+| CLI commands | `marketplace add/list/remove/update/browse` — functional tests with temp dirs |
+
+---
+
+## Migration
+
+- `kaizen install <plugin>` (current security-consent flow) is replaced by the new
+  unified `kaizen install`. Existing invocations continue to work; the ref `<plugin>`
+  is treated as an npm ref.
+- `kaizen plugin install <pkg>` emits a deprecation notice and delegates to `kaizen
+  install`.
+- `kaizen plugin remove <name>` delegates to `kaizen uninstall`.
+- Existing `kaizen.permissions.lock` files are unchanged.
+- Existing `~/.kaizen/kaizen.json` (if present) gains the `marketplaces` and
+  `defaults` fields lazily on next write. Old format is valid (fields are optional).
+
+---
+
+## Future Work
+
+- **Publisher signing (Trust Model C).** The `signature` field in `marketplace.json`
+  is reserved. Implementation: marketplace authors sign the catalog with a key;
+  `kaizen marketplace add --trust-key <key>` imports a public key; plugins from
+  signed marketplaces install without UAC for TRUSTED tier. Deferred — public
+  marketplaces require per-plugin UAC regardless of signing.
+- **`kaizen marketplace browse` TUI.** Interactive fuzzy-search browse + install in
+  the terminal. Deferred post-v1.
+- **Marketplace publishing workflow.** `kaizen marketplace publish` (or a separate CI
+  action) validates a marketplace repo, generates the catalog, and opens a PR.
+- **HTTP-hosted static marketplaces.** Support `https://host/` as a marketplace ref
+  (fetches `/.kaizen/marketplace.json`). Currently out of scope to avoid breaking
+  the "points at a directory, not a file" contract.
+- **Multi-version side-by-side.** Currently the install model assumes one version per
+  plugin name. Future: version-namespaced installs for testing.

--- a/docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md
@@ -1,11 +1,11 @@
 # Design: Plugin Marketplace, Kaizen-Level Config & Install Rework
 
 Date: 2026-04-18
-Status: APPROVED
+Status: DRAFT
 Related:
 - `docs/architecture.md` (plugin resolution order, runtime layout)
 - `docs/plugin-security.md` (consent + lockfile — unchanged by this spec)
-- `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md` (Spec 2 — depends on this)
+- `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md` (Spec 2 — consumes `kaizen-config.ts` module introduced here)
 - `docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md` (Spec 3 — depends on this)
 - `docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md` (Spec 4 — depends on this)
 
@@ -14,21 +14,23 @@ Related:
 ## Problem Statement
 
 Kaizen currently has no first-class mechanism for discovering, browsing, or sharing
-plugins and harnesses. Plugin "discovery" is `npm search kaizen-plugin`. Installation is
-a split between `kaizen install <name>` and `kaizen plugin install <pkg>` with subtly
+plugins and harnesses. Plugin "discovery" is `npm search kaizen-plugin`. Installation
+is split between `kaizen install <name>` and `kaizen plugin install <pkg>` with subtly
 different behaviour. There is no portable harness format that can self-bootstrap — a
 shared `kaizen.json` only works if the recipient has already installed the right plugins.
 
 This design introduces:
 
-1. **Federated marketplaces** — any git repo or local directory containing
-   `.kaizen/marketplace.json` is a kaizen marketplace. No central registry required.
-2. **Polymorphic plugin refs** — a unified syntax for naming plugins across all ref
-   types (marketplace-qualified, npm, local path, URL).
+1. **Federated marketplaces** — any git repo containing `.kaizen/marketplace.json` is
+   a kaizen marketplace. No central registry required.
+2. **Marketplace-scoped plugin refs** — a unified syntax for naming plugins
+   (marketplace-qualified or shorthand). Plugins are *always* resolved through a
+   marketplace.
 3. **Portable harnesses** — a harness file lists plugins by ref. `kaizen --harness
    <url>` bootstraps missing plugins automatically. The file is all you need.
-4. **Kaizen-level config** — a new `~/.kaizen/kaizen.json` layer for global settings
-   (added marketplaces, defaults). Separate from per-project harness config.
+4. **Kaizen-level config** — the existing `~/.kaizen/kaizen.json` layer gains a
+   `marketplaces` slice (and more via Spec 2). File I/O is owned by a new shared
+   `src/core/kaizen-config.ts` module.
 5. **Unified install CLI** — `kaizen install`, `kaizen uninstall`, `kaizen update`,
    `kaizen marketplace *` replace the current fragmented surface.
 
@@ -41,11 +43,42 @@ This design introduces:
   (the security model from `docs/plugin-security.md` is unchanged).
 - **File as wire format.** A harness JSON is the portable artifact. Its URL is the
   sharable link. No install step required to try a harness.
-- **Install vs ephemeral.** Installed plugins persist to `~/.kaizen/node_modules/`.
-  Ephemeral (from `--harness <url>`) fetches to `~/.kaizen/cache/` and can be GC'd.
-- **Ref syntax is obvious from shape.** `official/timestamps@1.2.3` is marketplace-
-  qualified. `./my-plugin` is local. `https://...` is a URL. No explicit scheme
-  prefix required for the common cases.
+- **One install path for everything.** There is no "ephemeral cache" vs "persistent
+  install" distinction. Every marketplace lives at `~/.kaizen/marketplaces/<id>/`;
+  every plugin's bits live at `~/.kaizen/marketplaces/<id>/plugins/<name>@<ver>/`;
+  every installed harness at `~/.kaizen/marketplaces/<id>/harnesses/<name>/`. The
+  bootstrap code path for `--harness` is the same `marketplace add` + `install`
+  logic users run interactively. If a harness references a new marketplace,
+  bootstrap adds it; the user sees it in `kaizen marketplace list` afterward and
+  can remove it with `kaizen marketplace remove <id>`.
+- **No `node_modules`.** Marketplace-installed plugins are loaded by absolute path
+  from `marketplaces/<id>/plugins/<name>@<ver>/`. Node's `node_modules` resolution
+  is not used for third-party plugins (builtins stay as workspace imports in the
+  kaizen repo itself).
+- **Refs are always marketplace-scoped.** `official/timestamps@1.2.3` is
+  marketplace-qualified; `timestamps` is shorthand (resolved across added
+  marketplaces). No URL, local-path, or bare-npm refs on the user surface — to ship
+  a plugin, ship a marketplace (even a one-entry marketplace).
+- **Marketplaces are git repos.** `kaizen marketplace add` shallow-clones.
+  `kaizen marketplace update` is `git pull`. Local-path marketplaces are symlinked
+  to an existing checkout (dev workflow). There is no alternate "HTTP static" or
+  "raw catalog file" fetch path.
+- **`official` marketplace is pre-seeded at install time.** Kaizen's installer
+  configures the `official` marketplace out of the box (analogous to how Claude
+  Code ships with its defaults). This spec assumes `official` is present on any
+  normally-installed kaizen; kaizen-code never auto-adds it at runtime. Installer
+  tooling is out of scope here — it is the installer's job to make the legacy
+  `kaizen-plugin-*` shim and the default `official/*` refs resolvable.
+- **Harnesses ship via marketplaces, too.** Just like plugins, the way to publish
+  a harness for others is to list it as a `harness` entry in a marketplace. Raw
+  URLs are not accepted on the user surface. Local file paths remain valid for
+  development/CI (analogous to local-path marketplaces).
+- **Catalogs index, they don't have to host.** A catalog entry points at source via
+  `file` (in-repo), `tarball` (URL), or `npm` (package). The same protocol supports
+  monorepo, federated-index, and single-plugin-marketplace patterns.
+- **Fail-safe silent updates.** A version bump with byte-equal canonical tier/grant
+  hash updates silently. Any change — even a field reorder — re-prompts. Impossible
+  to mis-classify a change as safe.
 - **Future-proof signing.** The catalog format reserves a `signature` field.
   Publisher signing (trust model C) is deferred — see Future Work.
 
@@ -55,39 +88,66 @@ This design introduces:
 
 ### In Scope
 
-- `marketplace.json` schema (the catalog format).
-- Kaizen-level config at `~/.kaizen/kaizen.json` (marketplaces array, defaults).
-- Plugin ref parser and resolver (all ref shapes → resolved install source).
+- `marketplace.json` schema (the catalog format) with a single `entries[]` list
+  tagged by `kind: "plugin" | "harness"`; names unique across all entries.
+- Kaizen-level config at `~/.kaizen/kaizen.json` with `marketplaces` array,
+  `marketplaceUpdateTTL`, and (for Spec 2) `defaults`. File I/O lives in
+  `src/core/kaizen-config.ts` (shared with Spec 2).
+- Plugin ref parser (marketplace-qualified and shorthand only) and resolver
+  (ref → catalog entry → `PluginSource`).
+- Marketplaces as git repos: `kaizen marketplace add <url>` runs
+  `git clone --depth=1` into `~/.kaizen/marketplaces/<id>/repo/`. Local paths are
+  symlinked (`~/.kaizen/marketplaces/<id>/repo/` → the working checkout).
 - `kaizen marketplace add|list|remove|update` commands.
-- `kaizen marketplace browse` (stub — lists catalog entries, no interactive TUI).
-- Revised `kaizen install <ref>` covering plugin and harness refs.
+- Background catalog refresh with configurable TTL (default 15 minutes = 900s);
+  first command in a session triggers a non-blocking `git fetch/pull` if stale.
+- `kaizen marketplace browse` (stub — tabular listing of catalog entries, no TUI).
+- Revised `kaizen install <ref>` (catalog lookup, dispatches by entry `kind`).
 - New `kaizen uninstall <ref>` and `kaizen update [<ref>]`.
-- Bootstrap-on-startup: `kaizen --harness <file|url|ref>` installs missing plugins.
-- Harness format extension: plugin entries accept any ref shape.
-- Backward compatibility: bare plugin names in existing harnesses treated as npm refs.
-- Cache directory (`~/.kaizen/cache/`) for ephemeral fetches.
-- Marketplace catalog cache (`~/.kaizen/marketplaces/<id>/marketplace.json`).
-- Lazy marketplace repo cloning: only clone full repo for `file`-source plugin installs.
+- Canonical tier/grant hash helper (`src/core/plugin-hash.ts`) for silent-update
+  eligibility.
+- Bootstrap-on-startup: `kaizen --harness <file|ref>` installs missing plugins.
+- Harness format extension: plugin entries are marketplace-qualified refs
+  (canonical form); shorthand is accepted only at CLI input and canonicalized on
+  write.
+- Backward compatibility: existing `kaizen-plugin-*` bare-npm refs trigger a
+  one-release deprecation shim that resolves them against the `official` marketplace.
+- Unified install tree under each marketplace:
+  `~/.kaizen/marketplaces/<id>/{repo,plugins/<name>@<ver>,harnesses/<name>}`.
+- Plugin loader change: marketplace-installed plugins are imported by absolute
+  path (`import(pluginInstallDir(id, name, ver))`). No reliance on
+  `~/.kaizen/node_modules/`.
+- `--trust-lockfile` and `--non-interactive` flags plumbed through the CLI parser.
 
 ### Out of Scope (deferred)
 
-- Publisher signing / marketplace signature verification (Future Work section).
+- Publisher signing / marketplace signature verification (Future Work).
 - `kaizen marketplace browse` interactive TUI — stub only for v1.
 - Harness versioning / harness lock files.
 - Multi-version plugin side-by-side loading.
 - Marketplace publication workflow (`kaizen marketplace publish`).
-- Kaizen-level config beyond `marketplaces` and `defaults` (covered by Spec 2).
+- Kaizen-level config beyond `marketplaces` and `marketplaceUpdateTTL` (covered by
+  Spec 2).
+- Non-git marketplace sources (HTTP static, raw catalog file).
+- Install-from-URL / install-from-local-path / install-from-bare-npm as user refs.
+- `--harness <url>`: raw URLs are rejected on the user surface. To share a harness,
+  publish it as a `harness` entry in a marketplace.
+- Installer tooling (pre-seeding the `official` marketplace on a fresh machine) —
+  owned by packaging/install docs, not by kaizen-code.
+- Batched bootstrap consent UX (per-plugin for v1).
+- Local-marketplace hot-reload (symlinking a plugin's source in `repo/` directly
+  into its `plugins/<name>@<ver>/` install slot). Copy-on-install for v1.
 
 ---
 
 ## Artifacts
 
-Four file types are defined or extended by this spec. All are JSON, all are portable
-by URL or filesystem path.
+Five artifact shapes are defined or extended by this spec. All are JSON, all are
+portable by URL or filesystem path.
 
 ### 1. Marketplace Catalog (`.kaizen/marketplace.json`)
 
-Lives at `.kaizen/marketplace.json` within a marketplace repo or directory.
+Lives at `.kaizen/marketplace.json` within a marketplace git repo.
 
 ```typescript
 interface MarketplaceCatalog {
@@ -97,29 +157,28 @@ interface MarketplaceCatalog {
   name: string;
   /** Short description. */
   description?: string;
-  /** Canonical URL — the git remote or HTTPS URL users add via `kaizen marketplace add`. */
+  /** Canonical git URL — the remote users add via `kaizen marketplace add`. */
   url: string;
   /** Reserved for future publisher signing. */
   signature?: string;
-  /** Plugin entries. */
-  plugins: MarketplacePluginEntry[];
-  /** Harness entries. */
-  harnesses: MarketplaceHarnessEntry[];
+  /** Flat list of entries; names unique across all entries. */
+  entries: MarketplaceEntry[];
 }
 
+type MarketplaceEntry = MarketplacePluginEntry | MarketplaceHarnessEntry;
+
 interface MarketplacePluginEntry {
-  /** Short name within this marketplace. kebab-case. */
+  kind: "plugin";
+  /** kebab-case; unique across all entries in this catalog. */
   name: string;
-  /** Human-readable description. */
   description: string;
-  /** Category tags (e.g. "executor", "ui", "tool", "dev"). */
   categories?: string[];
-  /** Published versions, newest first. */
   versions: PluginVersionEntry[];
 }
 
 interface MarketplaceHarnessEntry {
-  /** Short name within this marketplace. */
+  kind: "harness";
+  /** Unique across all entries in this catalog. */
   name: string;
   description: string;
   categories?: string[];
@@ -135,59 +194,87 @@ interface PluginVersionEntry {
 
 interface HarnessVersionEntry {
   version: string;
-  /** Path (relative to marketplace root) or URL to the harness JSON file. */
+  /** Path to the harness JSON file, relative to marketplace root. */
   path: string;
   changelog?: string;
 }
 
 type PluginSource =
   | { type: "npm";     name: string;  version: string }
-  | { type: "git";     url: string;   ref: string }
   | { type: "tarball"; url: string;   sha256?: string }
   | { type: "file";    path: string };  // relative to marketplace root
 ```
 
-**`file` source resolution:** relative to the marketplace's root directory. For a
-git-backed marketplace this is the repo root (the clone dir). For a local filesystem
-marketplace this is the directory passed to `kaizen marketplace add`.
+**Name uniqueness.** `name` must be unique across all entries — a plugin and a
+harness cannot share a name within a single catalog. Validated at `kaizen marketplace
+add` time (and on every `update`); collision is a fatal error.
 
-### 2. Plugin Ref Syntax
+**`file` source resolution.** Relative to the marketplace's **repo root** — on
+disk that is `~/.kaizen/marketplaces/<id>/repo/` (either the shallow clone or a
+symlink into a working checkout for local-dev marketplaces).
 
-A plugin ref is a string that identifies a plugin (or harness). The form is inferred
-from its shape — no explicit scheme prefix required.
+### 2. Marketplace Patterns
+
+The catalog is an index; plugin source can live inside or outside the marketplace
+repo. Three patterns emerge from the same protocol:
+
+| Pattern | Sources used | Fits |
+|---------|--------------|------|
+| Monorepo marketplace | `file` | 5–15 tightly coupled plugins (e.g. `kaizen-sh/kaizen-plugins`) |
+| Federated catalog | `tarball` / `npm` | Curated list; plugins live in author repos |
+| Single-plugin marketplace | `file` or `tarball` | Plugin author's own repo with a 1-entry catalog |
+
+A catalog may mix source types freely. Pattern choice is a marketplace author
+concern — it does not affect users or the wire protocol.
+
+### 3. Plugin Ref Syntax
+
+A plugin ref is a string that identifies a plugin or harness. Only two shapes are
+accepted.
 
 | Form | Example | Resolves via |
-|------|---------|-------------|
-| Marketplace-qualified | `official/timestamps@1.2.3` | Catalog lookup |
-| Marketplace shorthand | `timestamps` or `timestamps@1.2.3` | First matching marketplace (prompt if ambiguous) |
-| Local path | `./my-plugin` or `/abs/path` | Filesystem |
-| URL | `https://example.com/plugin.tgz` | HTTP fetch |
-| npm package (legacy) | `kaizen-plugin-timestamps@1.2.3` | npm resolution |
+|------|---------|--------------|
+| Marketplace-qualified | `official/timestamps@1.2.3` | Catalog lookup in `official` |
+| Shorthand             | `timestamps` or `timestamps@1.2.3` | First matching catalog (prompt if ambiguous) |
 
 **Canonical form** (what gets written to harness files and the lockfile):
-`<marketplace-id>/<name>@<version>` for marketplace refs. Other forms are stored
-verbatim.
+`<marketplace-id>/<name>@<version>`.
 
-**Ambiguity resolution:** if a shorthand name matches entries in multiple added
+**Ambiguity resolution.** If a shorthand name matches entries in multiple added
 marketplaces, `kaizen install` prompts the user to pick one. Non-interactive mode
-(`--non-interactive`) fails with an error.
+(`--non-interactive`) fails with a `RefConflictError`.
 
-### 3. Harness File (extended)
+**Dispatch by kind.** `kaizen install <ref>` looks the ref up in the catalog and
+dispatches based on the matching entry's `kind` — plugin or harness. No scheme
+prefix anywhere.
 
-The existing `kaizen.json` harness format is extended: `plugins` entries now accept
-any ref shape. Existing bare names continue to work (treated as npm refs).
+**Legacy shim.** Bare-npm refs matching `kaizen-plugin-*` are auto-resolved against
+the `official` marketplace with a deprecation notice. The shim ships for one
+release, then becomes a hard error.
+
+**Rejected shapes.** URL (`https://...`, `http://...`, `file://...`), local paths
+(`./foo`, `/abs/path`), scoped npm (`@scope/pkg`) are all rejected at parse time
+with a message pointing at `kaizen marketplace create` for the intended workflow.
+
+### 4. Harness File (extended)
+
+The existing `kaizen.json` harness format is extended: `plugins` entries **must be
+marketplace-qualified refs** in canonical `<marketplace-id>/<name>@<version>` form.
+Shorthand (`timestamps`, `timestamps@1.2.3`) is accepted only at CLI input (e.g.
+`kaizen install timestamps`); it is expanded to canonical form before being written
+to any harness file. This keeps shipped harnesses deterministic: the same
+`kaizen.json` bootstraps identically on any machine, regardless of which other
+marketplaces the recipient has added.
 
 ```json
 {
   "marketplaces": [
-    { "id": "official", "url": "https://github.com/kaizen-sh/marketplace.git" }
+    { "id": "official", "url": "https://github.com/kaizen-sh/kaizen-plugins.git" }
   ],
   "plugins": [
     "official/timestamps@1.2.3",
     "official/godot-tools@2.0.0",
-    "./local-dev-plugin",
-    "https://example.com/my-plugin.tgz",
-    "core-events"
+    "official/core-events@1.0.0"
   ],
   "core-executor-anthropic": {
     "model": "claude-opus-4-6",
@@ -197,24 +284,42 @@ any ref shape. Existing bare names continue to work (treated as npm refs).
 ```
 
 The `marketplaces` section in a harness is **informational + bootstrap-enabling**:
-it tells `kaizen --harness <url>` which marketplaces to add (if not already added)
-so that marketplace-qualified refs in `plugins` can be resolved. Kaizen adds them
-temporarily for the bootstrap run; users must explicitly run `kaizen marketplace add`
-to persist them globally.
+it tells `kaizen --harness <file|ref>` which marketplaces the harness expects. For
+any listed entry not already in `~/.kaizen/kaizen.json`, bootstrap runs the
+**same code path as `kaizen marketplace add`** — shallow-clone into
+`~/.kaizen/marketplaces/<id>/repo/` and append the entry to the global config.
+There is no separate "ephemeral" or "session-scoped" marketplace state. The user
+sees an explicit log line (`Adding marketplace <id> from <url>`) and can later
+remove with `kaizen marketplace remove <id>`. This keeps the mental model
+singular: every marketplace that resolves a ref is an installed, listed
+marketplace.
 
-### 4. Kaizen-Level Config (`~/.kaizen/kaizen.json`)
+### 5. Kaizen-Level Config (`~/.kaizen/kaizen.json`)
 
-New global config layer. Already partially exists (created by `kaizen init --global`);
-this spec extends its schema.
+Existing global config layer (already present; `kaizen init --global` creates it).
+This spec introduces the `marketplaces` and `marketplaceUpdateTTL` fields. Spec 2
+extends the same file further with `defaults` and per-plugin config slices.
+
+File **and directory** I/O is owned by a new shared module
+**`src/core/kaizen-config.ts`** — this spec's marketplace module and Spec 2's
+config module both consume it. The module owns the whole `~/.kaizen/` tree: it
+exposes path helpers (`kaizenHome()`, `marketplacesDir()`, `marketplaceDir(id)`,
+`marketplaceRepoDir(id)`, `pluginInstallDir(id, name, version)`,
+`harnessInstallDir(id, name)`), an `ensureKaizenHome()` bootstrap that creates
+`~/.kaizen/` and `~/.kaizen/marketplaces/` on first use, and the `load/save` pair
+for `~/.kaizen/kaizen.json` with atomic writes. No other module reads or writes
+`~/.kaizen/` directly.
 
 ```typescript
 interface KaizenGlobalConfig {
-  /** Added marketplaces. */
+  /** Added marketplaces (this spec). */
   marketplaces?: MarketplaceRef[];
   /** Default harness to run when no --harness flag or local .kaizen/kaizen.json. */
   defaultHarness?: string;
-  /** Other future global settings. */
+  /** Per-plugin default overrides (Spec 2). */
   defaults?: Record<string, unknown>;
+  /** Seconds between background marketplace refreshes; 0 disables. Default 900. */
+  marketplaceUpdateTTL?: number;
 }
 
 interface MarketplaceRef {
@@ -222,7 +327,7 @@ interface MarketplaceRef {
   id: string;
   /** Git URL or local directory path. */
   url: string;
-  /** Timestamp of last successful `kaizen marketplace update`. */
+  /** ISO-8601 timestamp of last successful pull (manual or background). */
   updatedAt?: string;
 }
 ```
@@ -236,11 +341,15 @@ interface MarketplaceRef {
 ```
 kaizen marketplace add <url> [--id <id>]
 ```
-- `<url>`: git URL or local path. HTTPS GitHub URLs auto-detected.
+- `<url>`: git URL, or local directory path for dev marketplaces.
 - `--id <id>`: override the marketplace identifier (default: derived from URL basename).
-- Fetches `.kaizen/marketplace.json` from the source (single-file fetch for git,
-  direct read for local). Validates schema. Writes to `~/.kaizen/marketplaces/<id>/`.
-- Updates `~/.kaizen/kaizen.json` `marketplaces` array.
+- Git URL: creates `~/.kaizen/marketplaces/<id>/` and runs
+  `git clone --depth=1 <url> ~/.kaizen/marketplaces/<id>/repo`.
+- Local path: creates `~/.kaizen/marketplaces/<id>/` and a symlink
+  `~/.kaizen/marketplaces/<id>/repo` → `<url>` so edits to the working checkout
+  appear immediately.
+- Reads `<id>/repo/.kaizen/marketplace.json`; validates schema and name uniqueness.
+- Updates `~/.kaizen/kaizen.json` `marketplaces` array via `kaizen-config.ts`.
 
 ```
 kaizen marketplace list
@@ -250,12 +359,19 @@ Shows all added marketplaces: id, URL, plugin count, harness count, last updated
 ```
 kaizen marketplace remove <id>
 ```
-Removes from global config and deletes cached catalog. Does not uninstall plugins.
+Removes the entry from global config and deletes the entire
+`~/.kaizen/marketplaces/<id>/` tree — repo, installed plugins, and installed
+harnesses from that marketplace all go. Lockfile entries for those plugins are
+left in place (in case another marketplace exposes the same plugin and the user
+re-installs later); `--purge-lockfile` removes them too.
 
 ```
 kaizen marketplace update [<id>]
 ```
-Re-fetches `.kaizen/marketplace.json` for one or all marketplaces.
+- Cloned marketplace: runs `git pull --depth=1 --ff-only` for one or all.
+- Symlinked (local) marketplace: no-op (the working checkout is authoritative).
+- Re-validates each catalog.
+- Also triggered in the background when `now - updatedAt > marketplaceUpdateTTL`.
 
 ```
 kaizen marketplace browse [<id>]
@@ -264,69 +380,109 @@ Lists catalog entries. v1: tabular output to stdout. No interactive TUI.
 
 ### `kaizen install <ref>`
 
-Unified install command. Accepts any ref shape. Replaces the split between
-`kaizen install <plugin>` (security flow) and `kaizen plugin install <pkg>` (npm-only).
+Unified install command. Accepts marketplace-qualified or shorthand refs. Replaces
+the split between `kaizen install <plugin>` (security flow) and `kaizen plugin
+install <pkg>` (npm-only).
 
 Flow:
-1. Parse ref → determine type.
-2. Resolve to a `PluginSource` (catalog lookup, or direct for path/URL/npm refs).
-3. Fetch manifest (read `KaizenPlugin` default export).
-4. Run consent flow (existing UAC — unchanged from `docs/plugin-security.md`).
-5. Install to `~/.kaizen/node_modules/` (npm) or appropriate location.
-6. Write lockfile entry.
-7. Add plugin name to `.kaizen/kaizen.json` `plugins` array (if project config exists).
-
-**Harness install:** `kaizen install harness:<ref>` fetches a harness JSON and writes
-it to `~/.kaizen/harnesses/<name>/kaizen.json`. The harness's plugins are NOT
-auto-installed — user runs `kaizen apply` separately, or uses `--harness` to bootstrap.
+1. Parse ref → `marketplace` or `shorthand`.
+2. Resolve against added marketplaces + cached catalogs → matching `MarketplaceEntry`.
+3. Dispatch by entry `kind`:
+   - **plugin**: fetch from `source` into
+     `~/.kaizen/marketplaces/<id>/plugins/<name>@<version>/`:
+     - `npm` source → `npm pack` + extract into the install dir (no global
+       `node_modules` involvement).
+     - `tarball` source → download + verify optional SHA-256 + extract.
+     - `file` source → copy from `<id>/repo/<path>` into the install dir. Always
+       a copy; symlink-based hot-reload is Future Work.
+     Then run consent flow (UAC — unchanged from `plugin-security.md`) and write
+     the lockfile entry (including canonical tier/grant hash).
+   - **harness**: read the harness file from `<id>/repo/<path>` and write it to
+     `~/.kaizen/marketplaces/<id>/harnesses/<name>/kaizen.json`. Harness plugins
+     are NOT auto-installed; user runs `kaizen apply` separately or uses
+     `--harness` to bootstrap.
+4. If a project harness exists and this is a plugin install: add canonical ref to
+   its `plugins` array.
 
 ### `kaizen uninstall <name>`
 
 Removes a plugin:
-1. Remove from `.kaizen/kaizen.json` `plugins` array.
-2. If `--purge`: npm uninstall from `~/.kaizen/node_modules/`, remove lockfile entry.
-3. Without `--purge`: removes from config only (plugin stays installed, lockfile entry
-   stays). Safe default — the plugin may be referenced by other harnesses.
+1. Remove from project harness `plugins` array (if present).
+2. If `--purge`: `rm -rf ~/.kaizen/marketplaces/<id>/plugins/<name>@<version>/`
+   and remove the lockfile entry.
+3. Without `--purge`: removes from config only (installed bits and lockfile entry
+   stay). Safe default — the plugin may be referenced by other harnesses.
 
 ### `kaizen update [<ref>]`
 
 Updates one plugin (or all if no ref given):
-1. Resolve latest version from marketplace catalog (or npm dist-tag for npm refs).
-2. If version changed: re-run consent flow (grant changes require explicit re-consent;
-   same tier + same grants → silent update with new lockfile hash).
-3. Install new version.
+1. Resolve latest version from marketplace catalog.
+2. Compute `canonicalTierGrantHash(manifest)` for the new version (helper in
+   `src/core/plugin-hash.ts`: sorted keys + sorted arrays + SHA-256 of
+   `{ tier, permissions }`).
+3. If hash matches stored lockfile hash → silent update (new source bits; bump
+   version; keep hash).
+4. If hash differs → full consent flow (UAC). Any diff in `tier` or `permissions`
+   — even a field reorder — re-prompts. Fail-safe bias.
 
 ### `kaizen --harness <arg>` bootstrap
 
-`--harness` now accepts: file path, marketplace ref (`official/harness-name@ver`), or
-URL.
+`--harness` accepts: local file path, or marketplace ref
+(`official/harness-name@ver`). Raw URLs are **rejected** with the same guidance
+as plugin refs — to ship a harness, publish it in a marketplace.
 
 Bootstrap flow for a harness with missing plugins:
 1. Fetch/read the harness JSON.
-2. If harness has a `marketplaces` section, register those marketplaces for this
-   session (without persisting to global config).
-3. For each plugin ref in `plugins`: check if installed. If not:
+2. For each entry in the harness's `marketplaces` section not already in
+   `~/.kaizen/kaizen.json`: run the same flow as `kaizen marketplace add`
+   (clone into `~/.kaizen/marketplaces/<id>/repo/`, append config entry, log
+   `Adding marketplace <id> from <url>`). Failure to clone is fatal if any plugin
+   ref depends on that marketplace; otherwise a warning.
+3. For each plugin ref in `plugins`: check `isInstalled(marketplaceId, name, version)`
+   (from `src/core/plugin-manager.ts`). If not:
    a. Resolve via ref resolver.
-   b. Fetch manifest.
-   c. Run consent flow (UAC per plugin). `--non-interactive --trust-lockfile` skips
+   b. Run consent flow (UAC per plugin). `--non-interactive --trust-lockfile` skips
       UAC if a committed `kaizen.permissions.lock` covers the plugin.
-   d. Install (to `~/.kaizen/node_modules/` if interactive, to `~/.kaizen/cache/` if
-      ephemeral — see Ephemeral Cache).
+   c. Install into `~/.kaizen/marketplaces/<id>/plugins/<name>@<version>/` (the
+      same install path as interactive `kaizen install`).
 4. Run kaizen with the resolved plugin stack.
 
+Consent prompts are per-plugin for v1 (one prompt per missing plugin). Batched
+summary UX is noted as Future Work.
+
 **CI flow:**
+
 ```bash
 kaizen --harness ./kaizen.json --trust-lockfile --non-interactive
 ```
+
 Requires a committed `kaizen.permissions.lock` that covers all plugins. Fails fast
 if any plugin is missing from the lockfile.
 
-### Ephemeral Cache
+### Install Layout (reference)
 
-`~/.kaizen/cache/` holds fetched assets for `--harness <url>` runs that have not been
-explicitly installed. Subdirs by content hash. GC policy: entries older than 30 days
-with no recent access are candidates for removal. `kaizen cache clean [--all]` manual
-GC (future command, not part of this spec).
+All marketplace state, installed plugins, and installed harnesses live under a
+single tree:
+
+```
+~/.kaizen/
+  kaizen.json                                              # global config
+  marketplaces/
+    <id>/
+      repo/                                                # shallow git clone or symlink
+        .kaizen/marketplace.json                           # catalog
+        …                                                  # marketplace repo contents
+      plugins/
+        <name>@<version>/                                  # installed plugin bits
+      harnesses/
+        <name>/
+          kaizen.json                                      # installed harness
+```
+
+There is no `~/.kaizen/cache/` and no `~/.kaizen/node_modules/`. Bootstrap-added
+marketplaces are indistinguishable on disk from manually-added ones and appear in
+`kaizen marketplace list`. `kaizen marketplace remove <id>` is the single cleanup
+verb for everything under `<id>/`.
 
 ---
 
@@ -334,41 +490,107 @@ GC (future command, not part of this spec).
 
 ### New modules
 
+**`src/core/kaizen-config.ts`** (shared with Spec 2) — owns the entire `~/.kaizen/` tree
+- `loadKaizenGlobalConfig(opts?): Promise<KaizenGlobalConfig>` — reads
+  `~/.kaizen/kaizen.json`. Returns `{}` if absent.
+- `saveKaizenGlobalConfig(cfg, opts?): Promise<void>` — atomic write via
+  `write-to-tmp + rename`.
+- `ensureKaizenHome(): Promise<void>` — creates `~/.kaizen/` and
+  `~/.kaizen/marketplaces/` on first use (idempotent). Per-marketplace subdirs
+  (`repo/`, `plugins/`, `harnesses/`) are created on demand by the marketplace /
+  install modules.
+- Path helpers (all return absolute paths; all hardcoded `~/.kaizen/` usage in
+  the codebase goes through these):
+  - `kaizenHome()`
+  - `marketplacesDir()`
+  - `marketplaceDir(id)`               → `<home>/marketplaces/<id>`
+  - `marketplaceRepoDir(id)`           → `<home>/marketplaces/<id>/repo`
+  - `pluginInstallDir(id, name, ver)`  → `<home>/marketplaces/<id>/plugins/<name>@<ver>`
+  - `harnessInstallDir(id, name)`      → `<home>/marketplaces/<id>/harnesses/<name>`
+- Owned by Spec 1; consumed by Spec 2 for its config slice and by this spec's
+  marketplace + install modules for on-disk paths. No other module touches
+  `~/.kaizen/` directly.
+
 **`src/core/marketplace.ts`**
-- `loadMarketplaceConfig(): KaizenGlobalConfig` — reads `~/.kaizen/kaizen.json`.
-- `saveMarketplaceConfig(cfg)` — writes global config.
-- `fetchCatalog(url): MarketplaceCatalog` — single-file fetch for git URLs (GitHub
-  raw API, or `git archive`); direct read for local paths. Validates against schema.
-- `getCachedCatalog(id): MarketplaceCatalog | null` — reads from
-  `~/.kaizen/marketplaces/<id>/marketplace.json`.
-- `writeCachedCatalog(id, catalog)` — persists fetched catalog.
+- `addMarketplace(url, id, opts?): Promise<void>` — the single entry point used
+  by both `kaizen marketplace add` and `--harness` bootstrap. Creates
+  `marketplaceDir(id)`, clones into `marketplaceRepoDir(id)` (or symlinks for
+  local paths), validates the catalog, appends to `kaizen.json` `marketplaces[]`.
+  Idempotent if the id is already added (no-op + optional `pullMarketplace`).
+- `pullMarketplace(id, opts?): Promise<void>` — `git pull --depth=1 --ff-only`
+  inside `marketplaceRepoDir(id)`; no-op on symlinks.
+- `readCatalog(id, opts?): Promise<MarketplaceCatalog>` — reads
+  `marketplaceRepoDir(id)/.kaizen/marketplace.json`. Validates.
+- `validateCatalog(catalog): void` — schema check + name-uniqueness.
+- `shouldRefresh(ref, ttlSeconds): boolean` — timestamp arithmetic.
+- `refreshInBackground(id, opts?): void` — fire-and-forget `pullMarketplace` +
+  `updatedAt` write.
+- (On-disk paths are resolved via `kaizen-config.ts` path helpers; this module
+  never hardcodes `~/.kaizen/` paths.)
+- **Concurrency:** concurrent refreshes across multiple kaizen processes are safe.
+  `git pull --ff-only` is idempotent and git's index lock serializes writes;
+  callers treat git as the arbiter and do not take an additional lock.
 
 **`src/core/ref-resolver.ts`**
-- `parseRef(ref: string): ParsedRef` — determines ref type from shape.
-- `resolveRef(parsed: ParsedRef, marketplaces: MarketplaceRef[]): ResolvedSource` —
-  catalog lookup, npm resolution, or direct source.
-- `RefConflictError` — thrown when a shorthand ref matches multiple marketplaces.
+- `parseRef(ref): ParsedRef` — determines `marketplace` vs `shorthand` from shape
+  (presence of `/`). Rejects URL / local / scoped-npm.
+- `resolveRef(parsed, catalogs): ResolvedEntry` — catalog lookup; throws
+  `RefConflictError` on ambiguous shorthand, `MarketplaceNotFoundError` /
+  `PluginNotFoundError` on misses.
+- `ResolvedEntry = { marketplaceId; entry; version; source? }` — `source` populated
+  for plugin entries.
 
-**`src/commands/marketplace.ts`**
-- Implements `add`, `list`, `remove`, `update`, `browse` subcommands.
+**`src/core/plugin-hash.ts`** (extend if present, else new)
+- `canonicalTierGrantHash(manifest): string` — SHA-256 of canonical serialization
+  of `{ tier, permissions }` (sorted keys + sorted arrays).
 
-**`src/commands/install.ts`** (reworked)
-- Unified install using ref resolver. Replaces current `runInstall`.
+**`src/core/plugin-installer.ts`** (new)
+- `installPlugin(id, name, version, source, opts?): Promise<void>` — materializes
+  plugin bits at `pluginInstallDir(id, name, version)`. Handles npm-pack-extract,
+  tarball-download-extract, and file-copy variants. Does not touch consent or the
+  lockfile — callers do that.
+- `installHarness(id, name, version, pathInRepo, opts?): Promise<void>` — copies
+  the harness JSON into `harnessInstallDir(id, name)/kaizen.json`.
 
-**`src/commands/uninstall.ts`** (new)
-**`src/commands/update.ts`** (new)
+**`src/core/plugin-loader.ts`** (new or extend the existing plugin loader)
+- `loadPluginFromInstallDir(id, name, version): Promise<KaizenPlugin>` —
+  resolves the absolute path via `pluginInstallDir(...)`, `import()`s it, and
+  returns the plugin default export. Marketplace-installed plugins are NOT
+  resolved through node `require`/`node_modules` lookup; only builtins (compiled
+  into the kaizen binary / workspace) are.
+
+**`src/core/bootstrap.ts`**
+- `bootstrapMissingPlugins(harnessConfig, opts): Promise<BootstrapReport>` —
+  adds any missing marketplaces (via `addMarketplace`), resolves + installs
+  missing plugins, returns summary.
+
+**`src/commands/marketplace.ts`** — `add`, `list`, `remove`, `update`, `browse`.
+
+**`src/commands/install.ts`** (reworked) — unified install using the ref resolver.
+
+**`src/commands/uninstall.ts`** (new).
+**`src/commands/update.ts`** (new).
 
 ### Modified modules
 
 **`src/cli.ts`**
-- Wire new `marketplace` subcommand.
-- Wire new `install` / `uninstall` / `update` top-level commands.
-- Extend `--harness` arg parsing to handle all ref shapes.
-- Bootstrap-on-startup logic.
+- Wire `marketplace` subcommand (inserted before any catch-all default branch).
+- Wire `install` / `uninstall` / `update` top-level commands.
+- Extend `--harness` arg parsing to handle file-path and marketplace-ref shapes
+  (raw URLs rejected at parse time).
+- Add `--trust-lockfile` and `--non-interactive` boolean flags.
+- First-invocation logic: for each added marketplace, `shouldRefresh() →
+  refreshInBackground()`.
+
+**`src/core/plugin-manager.ts`**
+- Export `isInstalled(marketplaceId: string, name: string, version: string): Promise<boolean>`
+  — checks `pluginInstallDir(...)` for a valid plugin. Replaces any prior
+  node_modules-presence check.
 
 **`src/commands/manage.ts`**
 - `cmdPluginInstall` / `cmdPluginRemove` deprecated in favour of new commands.
-  Kept but print deprecation notice.
+  Kept but print deprecation notice; `kaizen-plugin-*` bare-npm input auto-resolves
+  against `official`.
 
 ---
 
@@ -376,13 +598,22 @@ GC (future command, not part of this spec).
 
 | Scenario | Behaviour |
 |----------|-----------|
-| Marketplace fetch fails (network error) | Error with URL + status; exit 1 |
+| Marketplace clone fails (network / auth error) | Error with URL + git exit; exit 1 |
+| Local marketplace path does not exist | Fatal: "Path <p> not found"; exit 1 |
 | Catalog schema invalid | Error listing validation failures; exit 1 |
-| Shorthand ref is ambiguous | Prompt to pick marketplace (interactive) or error (non-interactive) |
-| Plugin not found in any marketplace | Error "not found in any added marketplace. Run `kaizen marketplace list`." |
+| Catalog entry name collision (plugin + harness share name) | Fatal at `marketplace add` / `update`; exit 1 |
+| Shorthand ref is ambiguous | Prompt to pick marketplace (interactive) or `RefConflictError` (non-interactive) |
+| Plugin not found in any marketplace | `PluginNotFoundError`: "not found in any added marketplace. Run `kaizen marketplace list`." |
+| Ref is URL / local path / scoped-npm | Fatal at parse: "refs must be marketplace-qualified or shorthand; see `kaizen marketplace create`." |
+| `--harness <url>` (raw URL) | Fatal at parse: "raw URL harnesses are not supported; publish the harness in a marketplace and use `--harness <id>/<name>@<ver>`." |
+| Harness plugin entry is shorthand (not canonical) | Fatal: "harness plugin refs must be canonical `<marketplace>/<name>@<version>`. Run `kaizen install <name>` to canonicalize." |
+| Legacy `kaizen-plugin-*` bare-npm ref | Deprecation warning; auto-resolve against `official`. Hard error in v-next. |
 | Consent denied | Exit 1, no install |
 | `--trust-lockfile` with missing lockfile entry | Fatal: "Plugin <name> not in lockfile. Run `kaizen install <ref>` first." |
-| Harness `marketplaces` ref fetch fails during bootstrap | Warning; bootstrap continues using already-added marketplaces |
+| Harness `marketplaces` entry clone fails during bootstrap, and a plugin ref needs it | Fatal: "cannot add marketplace <id> from <url>: <git error>"; bootstrap aborts |
+| Harness `marketplaces` entry clone fails, no plugin ref depends on it | Warning; bootstrap continues |
+| `pullMarketplace` on symlinked marketplace | No-op (by design) |
+| Background refresh failure | Logged, non-fatal; next foreground command retries |
 
 ---
 
@@ -390,43 +621,60 @@ GC (future command, not part of this spec).
 
 | Area | Approach |
 |------|----------|
-| Ref parser | Unit tests for all forms: marketplace-qualified, shorthand, local, URL, npm, ambiguous |
-| Catalog schema | Valid / invalid JSON, missing required fields, unknown entry types |
-| `fetchCatalog` | Mock git raw API, local FS, network error |
-| Install pipeline | Integration test with a mock marketplace and all source types |
-| Harness bootstrap | Harness with missing plugins triggers consent + install; `--trust-lockfile` skips UAC |
-| Backward compat | Existing harness with bare npm names loads without modification |
-| CLI commands | `marketplace add/list/remove/update/browse` — functional tests with temp dirs |
+| Ref parser | Unit tests: marketplace-qualified, shorthand with/without version, legacy `kaizen-plugin-*`, ambiguous shorthand. Rejection cases: URL, local path, scoped-npm. |
+| Catalog schema | Valid / invalid JSON, missing required fields, unknown `kind`, name collision across kinds. |
+| `addMarketplace` / `pullMarketplace` | Use temp-dir git-repo fixtures (real git subprocess); test clone into `<id>/repo/`, pull, symlink-case no-op, idempotent re-add, failure. |
+| Install layout | Each source type (`npm`, `tarball`, `file`) lands plugin bits at `marketplaces/<id>/plugins/<name>@<version>/`; harness install lands at `marketplaces/<id>/harnesses/<name>/kaizen.json`. |
+| `marketplace remove` | Deletes the entire `<id>/` subtree; installed plugins and harnesses from that marketplace vanish; lockfile entries preserved (unless `--purge-lockfile`). |
+| Absolute-path plugin loader | `loadPluginFromInstallDir` imports by absolute path; no `node_modules` fallback. |
+| Install pipeline | Integration test with a fixture local git marketplace covering all three source types (`file`, `tarball`, `npm`). |
+| Harness bootstrap | Harness with missing plugins triggers consent + install; `--trust-lockfile --non-interactive` skips UAC when lockfile covers; fails fast when it doesn't. |
+| Canonical tier/grant hash | Reordered keys / reordered arrays → same hash. Any value change → different hash. Tier change → different hash. |
+| Silent vs prompting update | Hash equal → no prompt, version bump only. Hash diff → consent flow fires. |
+| Backward compat | Existing harness with bare `kaizen-plugin-*` names loads with deprecation warning and resolves. |
+| CLI commands | `marketplace add/list/remove/update/browse` — functional tests with temp dirs. |
+| Background refresh | Expired TTL → async pull fires; unexpired → no-op. Failed pull is non-fatal. |
 
 ---
 
 ## Migration
 
-- `kaizen install <plugin>` (current security-consent flow) is replaced by the new
-  unified `kaizen install`. Existing invocations continue to work; the ref `<plugin>`
-  is treated as an npm ref.
-- `kaizen plugin install <pkg>` emits a deprecation notice and delegates to `kaizen
-  install`.
+Kaizen has no external adopters yet, so there is **no on-disk migration**. Users
+who have run pre-release versions can `rm -rf ~/.kaizen` and re-install cleanly
+against the new layout. No migrator tooling is shipped.
+
+CLI-surface compat:
+
+- `kaizen install <plugin>` (current security-consent flow) is replaced by the
+  new unified `kaizen install`. Bare `kaizen-plugin-*` names continue to work for
+  one release with a deprecation warning, auto-resolved against `official`.
+- `kaizen install https://...`, `kaizen install ./path`, and scoped-npm refs now
+  error at parse time with guidance pointing at `kaizen marketplace create`.
+- `kaizen plugin install <pkg>` emits a deprecation notice and delegates to
+  `kaizen install`.
 - `kaizen plugin remove <name>` delegates to `kaizen uninstall`.
-- Existing `kaizen.permissions.lock` files are unchanged.
-- Existing `~/.kaizen/kaizen.json` (if present) gains the `marketplaces` and
-  `defaults` fields lazily on next write. Old format is valid (fields are optional).
+- `kaizen.permissions.lock` schema gains the canonical tier/grant hash for new
+  entries; no rewrite of pre-existing files needed (kaizen is pre-adoption).
 
 ---
 
 ## Future Work
 
-- **Publisher signing (Trust Model C).** The `signature` field in `marketplace.json`
-  is reserved. Implementation: marketplace authors sign the catalog with a key;
-  `kaizen marketplace add --trust-key <key>` imports a public key; plugins from
-  signed marketplaces install without UAC for TRUSTED tier. Deferred — public
-  marketplaces require per-plugin UAC regardless of signing.
+- **Publisher signing (Trust Model C).** The `signature` field in
+  `marketplace.json` is reserved. Implementation: marketplace authors sign the
+  catalog with a key; `kaizen marketplace add --trust-key <key>` imports a public
+  key; plugins from signed marketplaces install without UAC for TRUSTED tier.
+  Deferred — public marketplaces require per-plugin UAC regardless of signing.
+- **Batched bootstrap consent.** `--harness` with many missing plugins currently
+  prompts per plugin. A batched "12 plugins to add: 3 TRUSTED / 7 SCOPED / 2
+  UNSCOPED — approve all TRUSTED? [y/N]" UX is a post-v1 refactor.
 - **`kaizen marketplace browse` TUI.** Interactive fuzzy-search browse + install in
   the terminal. Deferred post-v1.
-- **Marketplace publishing workflow.** `kaizen marketplace publish` (or a separate CI
-  action) validates a marketplace repo, generates the catalog, and opens a PR.
-- **HTTP-hosted static marketplaces.** Support `https://host/` as a marketplace ref
-  (fetches `/.kaizen/marketplace.json`). Currently out of scope to avoid breaking
-  the "points at a directory, not a file" contract.
-- **Multi-version side-by-side.** Currently the install model assumes one version per
-  plugin name. Future: version-namespaced installs for testing.
+- **Marketplace publishing workflow.** `kaizen marketplace publish` (or a separate
+  CI action) validates a marketplace repo, generates the catalog, and opens a PR.
+- **Multi-version side-by-side.** Currently the install model assumes one version
+  per plugin name. Future: version-namespaced installs for testing.
+- **Local-marketplace hot-reload.** `file`-source installs from a symlinked
+  marketplace could symlink `<id>/plugins/<name>@<ver>/` directly to the source
+  in `<id>/repo/<path>/` instead of copying, so edits to plugin source reflect
+  without reinstall.

--- a/docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md
+++ b/docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md
@@ -1,0 +1,527 @@
+# Design: Plugin & Marketplace Scaffolders + Coding Standards
+
+Date: 2026-04-18
+Status: APPROVED
+Related:
+- `docs/plugin-api.md` (the authoring reference this spec extends)
+- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — marketplace format)
+- `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md` (Spec 2 — config schema)
+
+---
+
+## Problem Statement
+
+Authoring a kaizen plugin today is Wild West. There is no scaffolder, no enforced
+structure, no standards document, no linter, and no test template. New authors read
+`docs/plugin-api.md`, copy an existing plugin, and hope they don't miss something.
+Common failure modes:
+
+- Wrong `package.json` (missing `exports`, wrong `type`).
+- Missing `apiVersion` or wrong format.
+- No tests.
+- No README.
+- Permissions not declared (defaults to `trusted` silently when the plugin actually
+  needs `scoped`).
+- Config accessed raw without a schema declaration (pre-Spec 2).
+- Publishing to npm without the `kaizen-plugin` keyword.
+
+Marketplace authoring is even more undefined — there is no tooling to create or
+validate a `.kaizen/marketplace.json`.
+
+This design introduces:
+
+1. **`kaizen plugin create <path>`** — interactive plugin scaffolder.
+2. **`kaizen marketplace create <path>`** — marketplace scaffolder.
+3. **`kaizen plugin validate [<path>]`** — lint + standards check for plugins.
+4. **`kaizen marketplace validate [<path>]`** — validate a marketplace catalog.
+5. **`docs/plugin-standards.md`** — the canonical coding standards document.
+
+---
+
+## Design Philosophy
+
+- **Scaffolded output must pass `validate` immediately.** A freshly scaffolded plugin
+  or marketplace runs `kaizen plugin validate` / `kaizen marketplace validate` with
+  zero errors. It also runs `bun test` and passes.
+- **`create` is opinionated, `validate` is the law.** The scaffolder picks sensible
+  defaults; authors can deviate. The validator enforces what's actually required.
+- **Standards are checkable.** Every rule in `docs/plugin-standards.md` maps to a
+  `validate` check. If it can't be checked, it doesn't belong in standards; it
+  belongs in guidelines.
+
+---
+
+## Scope
+
+### In Scope
+
+- `kaizen plugin create <path>` interactive scaffolder (TypeScript output).
+- `kaizen marketplace create <path>` scaffolder.
+- `kaizen plugin validate [<path>]` — static + structural checks.
+- `kaizen marketplace validate [<path>]` — catalog schema + entry checks.
+- `docs/plugin-standards.md` — coding standards.
+- Test template using `bun:test`.
+- README template.
+
+### Out of Scope
+
+- `kaizen plugin publish` — publishing workflow (future).
+- `kaizen plugin build` — tarball packaging (future).
+- JavaScript (non-TypeScript) scaffolding — TypeScript only for v1.
+- IDE extension / language-server integration.
+- Automatic migration of existing plugins to standards (manual with guidance).
+
+---
+
+## `kaizen plugin create <path>`
+
+Interactive scaffolder that creates a new plugin directory at `<path>`.
+
+### Prompts
+
+```
+Plugin name: (kebab-case, e.g. my-plugin)
+Description: (one line)
+Permission tier: [trusted / scoped / unscoped]  (default: trusted)
+  (if scoped) Grant types needed: [fs / net / env / exec / events] (multi-select)
+Capabilities provided: (space-separated, e.g. core-lifecycle:executor.send)
+Capabilities consumed: (space-separated, e.g. core-events:service)
+Declare config schema? [y/N]
+  (if y) Config keys: (name:type pairs, e.g. api_key:string timeout_ms:number)
+  (if y) Required keys: (subset of above)
+  (if y) Secret keys: (subset of above, for env var resolution)
+```
+
+All prompts have defaults and can be skipped (enter = accept default). Non-interactive
+mode (`--defaults`) accepts all defaults silently and uses `<path>` basename as name.
+
+### Generated files
+
+```
+<path>/
+├── package.json
+├── tsconfig.json
+├── index.ts
+├── index.test.ts
+├── README.md
+└── .kaizen/
+    └── .gitkeep
+```
+
+#### `package.json`
+```json
+{
+  "name": "<name>",
+  "version": "0.1.0",
+  "description": "<description>",
+  "type": "module",
+  "exports": { ".": "./index.ts" },
+  "keywords": ["kaizen-plugin"],
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.4.0"
+  }
+}
+```
+
+Key rules enforced:
+- `"type": "module"` — ESM required.
+- `"exports": { ".": "./index.ts" }` — kaizen uses `exports`, not `main`.
+- `"keywords": ["kaizen-plugin"]` — required for npm discovery.
+
+#### `tsconfig.json`
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+#### `index.ts`
+
+Generated from the prompt answers. Example for a scoped plugin with env grant:
+
+```typescript
+import type { KaizenPlugin } from "kaizen/types";
+
+const plugin: KaizenPlugin = {
+  name: "my-plugin",
+  apiVersion: "2.0.0",
+  permissions: {
+    tier: "scoped",
+    env: ["MY_API_KEY"],
+  },
+  capabilities: {
+    consumes: ["core-events:service"],
+  },
+  config: {
+    schema: {
+      type: "object",
+      properties: {
+        api_key: { type: "string", description: "API key." },
+      },
+      required: ["api_key"],
+    },
+    defaults: {},
+    secrets: ["api_key"],
+  },
+
+  async setup(ctx) {
+    // TODO: register tools, subscribe to events.
+    ctx.log("my-plugin setup complete");
+  },
+};
+
+export default plugin;
+```
+
+#### `index.test.ts`
+
+```typescript
+import { describe, it, expect, mock } from "bun:test";
+import plugin from "./index.ts";
+
+const makeCtx = () => ({
+  log: mock(() => {}),
+  config: {},
+  registerTool: mock(() => {}),
+  on: mock(() => {}),
+  defineEvent: mock(() => {}),
+  emit: mock(async () => []),
+  secrets: { get: mock(() => undefined) },
+  // Add other ctx fields as needed.
+} as any);
+
+describe("my-plugin", () => {
+  it("has correct metadata", () => {
+    expect(plugin.name).toBe("my-plugin");
+    expect(plugin.apiVersion).toBe("2.0.0");
+  });
+
+  it("setup runs without error", async () => {
+    const ctx = makeCtx();
+    await plugin.setup(ctx);
+    expect(ctx.log).toHaveBeenCalled();
+  });
+});
+```
+
+#### `README.md`
+
+```markdown
+# my-plugin
+
+> One-line description.
+
+A kaizen plugin that does X.
+
+## Installation
+
+\`\`\`bash
+kaizen install my-plugin
+\`\`\`
+
+## Configuration
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| api_key | string | yes | API key (env var name). |
+
+Add to your harness:
+
+\`\`\`json
+{
+  "plugins": ["my-plugin"],
+  "my-plugin": {
+    "api_key": "MY_API_KEY_ENV_VAR"
+  }
+}
+\`\`\`
+
+## Permissions
+
+Tier: **scoped** — requires `env: ["MY_API_KEY"]`.
+
+## Development
+
+\`\`\`bash
+bun test
+kaizen plugin validate .
+kaizen plugin dev --observe --harness core-debug .
+\`\`\`
+```
+
+---
+
+## `kaizen marketplace create <path>`
+
+Creates a new marketplace directory at `<path>`.
+
+### Prompts
+
+```
+Marketplace name: (e.g. my-org-plugins)
+Description: (one line)
+Marketplace URL: (git URL or leave blank for local-only)
+```
+
+### Generated files
+
+```
+<path>/
+├── .kaizen/
+│   └── marketplace.json
+├── plugins/
+│   └── .gitkeep
+├── harnesses/
+│   └── .gitkeep
+└── README.md
+```
+
+#### `.kaizen/marketplace.json`
+
+```json
+{
+  "version": "1.0.0",
+  "name": "my-org-plugins",
+  "description": "Kaizen plugins for my-org.",
+  "url": "https://github.com/my-org/kaizen-plugins.git",
+  "plugins": [],
+  "harnesses": []
+}
+```
+
+#### `README.md`
+
+Template explaining the marketplace structure, how to add plugins, and how users add
+the marketplace with `kaizen marketplace add`.
+
+---
+
+## `kaizen plugin validate [<path>]`
+
+Validates a plugin at `<path>` (defaults to current directory).
+
+### Checks
+
+**Structural (always run):**
+
+| Rule | Check |
+|------|-------|
+| `package.json` exists | File present |
+| `name` is kebab-case | Regex: `^[a-z][a-z0-9-]*$` |
+| `"type": "module"` | Field equals `"module"` |
+| `exports["."]` present | Field present |
+| `"kaizen-plugin"` keyword | `keywords` array includes it |
+| Default export exists | Can statically detect a default export |
+| `plugin.name` matches `package.json` name | Loaded name equals package name |
+| `plugin.apiVersion` present and semver | Matches semver pattern |
+| `permissions.tier` declared | Field present |
+| SCOPED: at least one grant | At least one grant key populated |
+| `capabilities` field present | Field present |
+| Tests present | `index.test.ts` (or `*.test.ts`) exists |
+| README present | `README.md` exists |
+
+**Schema checks (run if `config.schema` declared):**
+
+| Rule | Check |
+|------|-------|
+| Schema is valid JSON Schema | ajv compile succeeds |
+| `secrets` keys are in schema | Each secret key appears in `schema.properties` |
+| `secrets` keys are in `permissions.env` | Cross-check with permissions |
+
+**Import scan (static analysis):**
+
+| Rule | Check |
+|------|-------|
+| TRUSTED/SCOPED: no `node:fs` direct import | AST scan for forbidden imports |
+| TRUSTED/SCOPED: no `node:child_process` import | AST scan |
+| TRUSTED/SCOPED: no `node:worker_threads` import | AST scan |
+
+The import scan is best-effort (static only). The runtime enforcer is the
+authoritative gate; validate is an early-warning signal.
+
+**Output:**
+
+```
+kaizen plugin validate ./my-plugin
+
+  ✓ package.json present
+  ✓ name is kebab-case: my-plugin
+  ✓ type: module
+  ✓ exports["."] present
+  ✓ keywords: kaizen-plugin present
+  ✓ apiVersion: 2.0.0
+  ✓ permissions.tier: scoped
+  ✓ config.schema valid
+  ✗ config secrets key "api_key" not in permissions.env
+  ✓ tests present: index.test.ts
+  ✓ README.md present
+
+1 error found. Fix errors before publishing.
+```
+
+Exit 0 if no errors, exit 1 if errors, exit 0 with warnings if only warnings.
+
+---
+
+## `kaizen marketplace validate [<path>]`
+
+Validates a marketplace directory at `<path>` (defaults to current directory).
+
+### Checks
+
+| Rule | Check |
+|------|-------|
+| `.kaizen/marketplace.json` exists | File present |
+| Schema version is `"1.0.0"` | Field equals expected |
+| `name` present | Non-empty string |
+| `url` present | Non-empty string |
+| `plugins` is array | Type check |
+| `harnesses` is array | Type check |
+| Each plugin entry has `name`, `description`, `versions[]` | Field checks |
+| Each harness entry has `name`, `description`, `versions[]` | Field checks |
+| `file` source paths exist relative to root | `existsSync` check |
+
+---
+
+## `docs/plugin-standards.md`
+
+The canonical coding standards document. Every rule is checkable by `kaizen plugin
+validate` unless explicitly marked `[guideline]`.
+
+### Outline
+
+```
+# Kaizen Plugin Coding Standards
+
+## 1. Package Structure
+   - Required: package.json with type:module, exports["."], kaizen-plugin keyword
+   - Required: index.ts (or index.js for compiled) as default export entrypoint
+   - Required: tests (index.test.ts minimum)
+   - Required: README.md
+   - Guideline: CHANGELOG.md for published plugins
+
+## 2. Plugin Manifest
+   - Required: name (kebab-case, matches package.json)
+   - Required: apiVersion "2.0.0" (or current major)
+   - Required: permissions.tier declared
+   - Required: capabilities field (empty object acceptable)
+   - Guideline: config.schema for any configurable plugin
+
+## 3. Permission Tier Selection
+   - Default to trusted. Escalate only when you hit a real need.
+   - Use observe mode to determine actual grants needed.
+   - UNSCOPED requires justification in README.
+
+## 4. Capability Naming
+   - Format: <owner-plugin>:<local-name>
+   - Use existing capabilities where possible (do not re-declare core-events:service)
+   - Local names: dot-separated, kebab segments (e.g. ui.input, lifecycle.drive)
+
+## 5. Configuration
+   - Declare config.schema for any configurable behaviour
+   - Use config.secrets for env var references (not api_key_env pattern)
+   - Provide defaults for optional keys
+   - Document all config keys in README
+
+## 6. Testing
+   - Each plugin must have at least one test that calls setup()
+   - Use bun:test as the test framework
+   - Mock ctx using the makeCtx() pattern from the scaffold template
+   - Tests must pass with `bun test` from the plugin directory
+
+## 7. Error Handling
+   - setup() should not throw unless the plugin cannot function at all
+   - Tool handlers should return { ok: false, error: "..." } rather than throw
+   - Log warnings with ctx.log(); reserve throws for unrecoverable states
+
+## 8. Event Handling
+   - Define custom events with ctx.defineEvent() before emitting
+   - Document emitted events in README
+   - Declare events.subscribe grant for cross-plugin subscriptions
+
+## 9. Publishing
+   - Keyword kaizen-plugin required for npm discovery
+   - README must include: installation, configuration table, permissions section
+   - Pin or document minimum kaizen version if using recent API features
+   - Marketplace submission: open a PR to the target marketplace repo adding an
+     entry to .kaizen/marketplace.json
+
+## 10. API Version Pinning
+   - Set apiVersion to the current core API major: "2.0.0"
+   - Core warns (but loads) if major version mismatches
+   - Breaking changes in core increment the major; plugins must update
+```
+
+---
+
+## Component Architecture
+
+### New: `src/commands/plugin-create.ts`
+
+Interactive scaffolder. Depends on `prompts` (or Bun's built-in readline) for
+interactive input. Emits files via `fs.writeFileSync`.
+
+### New: `src/commands/marketplace-create.ts`
+
+Marketplace scaffolder. Same approach.
+
+### New: `src/commands/plugin-validate.ts`
+
+Static + structural validation. AST scanning via Bun's built-in `Bun.Transpiler`
+or TypeScript compiler API. ajv for schema validation.
+
+### New: `src/commands/marketplace-validate.ts`
+
+Catalog validation.
+
+### Modified: `src/cli.ts`
+
+Wire new subcommands:
+- `kaizen plugin create <path>`
+- `kaizen plugin validate [<path>]`
+- `kaizen marketplace create <path>`
+- `kaizen marketplace validate [<path>]`
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| `<path>` already exists (create) | Error: "Directory already exists. Use an empty path." |
+| Prompt input is invalid | Re-prompt with error message |
+| `--defaults` mode, name conflicts with existing npm package | Warning only; author decides |
+| `validate` path not found | Error: "No plugin found at <path>." |
+| `validate` import scan parse error | Warning: "Could not parse <file> for import scan." (non-fatal) |
+
+---
+
+## Testing
+
+| Area | Approach |
+|------|----------|
+| Scaffolder output | Scaffolded plugin: `bun test` passes, `kaizen plugin validate .` passes |
+| Marketplace scaffolder | Scaffolded marketplace: `kaizen marketplace validate .` passes |
+| `validate` rules | One test per rule: passing case + failing case |
+| Import scan | Static scan detects `import fs from "node:fs"` in TRUSTED plugin |
+| Non-interactive mode | `--defaults` generates valid plugin with no prompts |
+
+---
+
+## Future Work
+
+- **`kaizen plugin build`** — package plugin into a distributable tarball (`.tgz`),
+  optionally signed, ready for a marketplace `file` or `tarball` source entry.
+- **`kaizen plugin publish`** — open a PR to a target marketplace adding the entry.
+- **JavaScript scaffolding** — for authors who prefer not to use TypeScript.
+- **Custom templates** — `kaizen plugin create --template <url>` for org-specific
+  boilerplate.
+- **IDE integration** — JSON Schema for `kaizen.json` harness files to enable
+  autocompletion in VS Code and other editors.

--- a/docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md
+++ b/docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md
@@ -1,11 +1,12 @@
 # Design: Plugin & Marketplace Scaffolders + Coding Standards
 
 Date: 2026-04-18
-Status: APPROVED
+Status: DRAFT
 Related:
 - `docs/plugin-api.md` (the authoring reference this spec extends)
-- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — marketplace format)
-- `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md` (Spec 2 — config schema)
+- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — marketplace `entries[]` catalog shape; canonical refs; install layout)
+- `docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md` (Spec 2 — `config.schema`, `ctx.secrets.get`, `core-secrets:provider` capability)
+- `docs/superpowers/specs/2026-04-18-builtin-plugins-repo-decoupling-design.md` (Spec 4 — depends on scaffolded plugins passing `kaizen plugin validate`)
 
 ---
 
@@ -23,6 +24,8 @@ Common failure modes:
 - Permissions not declared (defaults to `trusted` silently when the plugin actually
   needs `scoped`).
 - Config accessed raw without a schema declaration (pre-Spec 2).
+- Secrets read directly from `process.env` via the `api_key_env` indirection
+  rather than the `ctx.secrets` provider pipeline (pre-Spec 2).
 - Publishing to npm without the `kaizen-plugin` keyword.
 
 Marketplace authoring is even more undefined — there is no tooling to create or
@@ -89,7 +92,8 @@ Capabilities consumed: (space-separated, e.g. core-events:service)
 Declare config schema? [y/N]
   (if y) Config keys: (name:type pairs, e.g. api_key:string timeout_ms:number)
   (if y) Required keys: (subset of above)
-  (if y) Secret keys: (subset of above, for env var resolution)
+  (if y) Secret keys: (subset of above; resolved via the core-secrets:provider
+                       capability, default provider is `kaizen` — OS keychain)
 ```
 
 All prompts have defaults and can be skipped (enter = accept default). Non-interactive
@@ -144,7 +148,10 @@ Key rules enforced:
 
 #### `index.ts`
 
-Generated from the prompt answers. Example for a scoped plugin with env grant:
+Generated from the prompt answers. Example for a scoped plugin that declares a
+secret. Note: selecting any secret keys causes the scaffolder to emit an explicit
+`consumes: ["core-secrets:provider"]` entry (it is implicit per Spec 2, but
+surfacing it in the template is a documentation win).
 
 ```typescript
 import type { KaizenPlugin } from "kaizen/types";
@@ -154,31 +161,41 @@ const plugin: KaizenPlugin = {
   apiVersion: "2.0.0",
   permissions: {
     tier: "scoped",
-    env: ["MY_API_KEY"],
+    net: ["api.example.com"],
   },
   capabilities: {
-    consumes: ["core-events:service"],
+    consumes: ["core-events:service", "core-secrets:provider"],
   },
   config: {
     schema: {
       type: "object",
       properties: {
-        api_key: { type: "string", description: "API key." },
+        api_key:    { type: "string", description: "API key." },
+        timeout_ms: { type: "number", description: "Request timeout in ms." },
       },
       required: ["api_key"],
     },
-    defaults: {},
+    defaults: {
+      timeout_ms: 5000,
+    },
     secrets: ["api_key"],
   },
 
   async setup(ctx) {
+    const apiKey = await ctx.secrets.get("api_key");
+    ctx.log(`my-plugin setup complete (timeout=${ctx.config.timeout_ms}ms)`);
     // TODO: register tools, subscribe to events.
-    ctx.log("my-plugin setup complete");
   },
 };
 
 export default plugin;
 ```
+
+**Import path.** The template uses `"kaizen/types"`, which resolves after Spec 4
+(built-in plugin repo decoupling) lands and plugins live outside the main
+kaizen repo. Scaffolding a new plugin *inside* the main kaizen repo's
+`plugins/` tree pre-Spec-4 is not a supported workflow — authors should
+scaffold into a standalone directory.
 
 #### `index.test.ts`
 
@@ -186,15 +203,22 @@ export default plugin;
 import { describe, it, expect, mock } from "bun:test";
 import plugin from "./index.ts";
 
-const makeCtx = () => ({
+const makeCtx = (overrides: Record<string, unknown> = {}) => ({
   log: mock(() => {}),
-  config: {},
+  // Validated + merged non-secret config. Fill in defaults matching the schema
+  // so setup() sees realistic values.
+  config: { timeout_ms: 5000 },
   registerTool: mock(() => {}),
   on: mock(() => {}),
   defineEvent: mock(() => {}),
   emit: mock(async () => []),
-  secrets: { get: mock(() => undefined) },
-  // Add other ctx fields as needed.
+  // Secrets are async and provider-backed. Tests stub per-key values.
+  secrets: {
+    get: mock(async (_key: string): Promise<string | undefined> => undefined),
+    refresh: mock(async (_key: string): Promise<string | undefined> => undefined),
+  },
+  capabilities: { register: mock(() => {}) },
+  ...overrides,
 } as any);
 
 describe("my-plugin", () => {
@@ -204,7 +228,12 @@ describe("my-plugin", () => {
   });
 
   it("setup runs without error", async () => {
-    const ctx = makeCtx();
+    const ctx = makeCtx({
+      secrets: {
+        get: mock(async (key: string) => (key === "api_key" ? "test-key" : undefined)),
+        refresh: mock(async () => undefined),
+      },
+    });
     await plugin.setup(ctx);
     expect(ctx.log).toHaveBeenCalled();
   });
@@ -223,29 +252,55 @@ A kaizen plugin that does X.
 ## Installation
 
 \`\`\`bash
-kaizen install my-plugin
+kaizen install my-org/my-plugin
 \`\`\`
+
+`my-org/my-plugin` is a marketplace-qualified ref (see
+`docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md`). Shorthand
+(`kaizen install my-plugin`) is accepted at the CLI and canonicalized before
+being written into harness files.
 
 ## Configuration
 
-| Key | Type | Required | Description |
-|-----|------|----------|-------------|
-| api_key | string | yes | API key (env var name). |
+| Key | Type | Required | Secret | Description |
+|-----|------|----------|--------|-------------|
+| api_key    | string | yes | yes | Provider-backed API key. |
+| timeout_ms | number | no  | no  | Request timeout in ms. |
 
-Add to your harness:
+Add to your harness. Plugin entries in shipped harnesses must be canonical
+`<marketplace>/<name>@<version>`. The `my-plugin` block keys config values;
+secret values are references (the actual secret lives in the OS keychain or
+another registered provider — see Spec 2 on unified config + secrets):
 
 \`\`\`json
 {
-  "plugins": ["my-plugin"],
+  "plugins": ["my-org/my-plugin@0.1.0"],
   "my-plugin": {
-    "api_key": "MY_API_KEY_ENV_VAR"
+    "api_key": "my-plugin-prod",
+    "timeout_ms": 3000
   }
 }
 \`\`\`
 
+The bare-string secret (`"my-plugin-prod"`) targets the default provider
+(`kaizen`, the OS keychain). To target a different provider, use the
+structured form:
+
+\`\`\`json
+"api_key": { "provider": "doppler", "ref": "MY_PLUGIN_API_KEY" }
+\`\`\`
+
+Store the secret value interactively:
+
+\`\`\`bash
+kaizen config set-secret my-plugin api_key
+\`\`\`
+
 ## Permissions
 
-Tier: **scoped** — requires `env: ["MY_API_KEY"]`.
+Tier: **scoped** — declare `net: [...]` / `fs: [...]` grants as needed.
+Secrets do NOT require an `env` grant in the permissions block — they resolve
+through the `core-secrets:provider` capability pipeline.
 
 ## Development
 
@@ -285,14 +340,17 @@ Marketplace URL: (git URL or leave blank for local-only)
 
 #### `.kaizen/marketplace.json`
 
+Matches the `entries[]` catalog shape from Spec 1. Plugin and harness entries
+share a single list and are distinguished by `kind`; names must be unique
+across all entries.
+
 ```json
 {
   "version": "1.0.0",
   "name": "my-org-plugins",
   "description": "Kaizen plugins for my-org.",
   "url": "https://github.com/my-org/kaizen-plugins.git",
-  "plugins": [],
-  "harnesses": []
+  "entries": []
 }
 ```
 
@@ -333,7 +391,14 @@ Validates a plugin at `<path>` (defaults to current directory).
 |------|-------|
 | Schema is valid JSON Schema | ajv compile succeeds |
 | `secrets` keys are in schema | Each secret key appears in `schema.properties` |
-| `secrets` keys are in `permissions.env` | Cross-check with permissions |
+| Implicit `core-secrets:provider` dep | If `config.secrets` non-empty, `capabilities.consumes` either lists `core-secrets:provider` explicitly OR validator emits an informational note that the dep is implicit per Spec 2 (not a failure). |
+
+**Note on provider existence.** `kaizen plugin validate` does NOT check that
+any `StructuredSecretRef.provider` named in a harness resolves to a registered
+`core-secrets:provider`. That check happens at `kaizen install <ref>`
+(install-time) and `kaizen run` (load-time) where the provider registry is
+live. Static `plugin validate` operates on a plugin in isolation, without a
+harness or provider set, so it cannot and must not enforce it.
 
 **Import scan (static analysis):**
 
@@ -359,7 +424,8 @@ kaizen plugin validate ./my-plugin
   ✓ apiVersion: 2.0.0
   ✓ permissions.tier: scoped
   ✓ config.schema valid
-  ✗ config secrets key "api_key" not in permissions.env
+  ✗ config secrets key "api_key" not declared in config.schema.properties
+  ℹ config.secrets is non-empty; core-secrets:provider dependency is implicit
   ✓ tests present: index.test.ts
   ✓ README.md present
 
@@ -382,11 +448,17 @@ Validates a marketplace directory at `<path>` (defaults to current directory).
 | Schema version is `"1.0.0"` | Field equals expected |
 | `name` present | Non-empty string |
 | `url` present | Non-empty string |
-| `plugins` is array | Type check |
-| `harnesses` is array | Type check |
-| Each plugin entry has `name`, `description`, `versions[]` | Field checks |
-| Each harness entry has `name`, `description`, `versions[]` | Field checks |
-| `file` source paths exist relative to root | `existsSync` check |
+| `entries` is array | Type check (rejects legacy `plugins`/`harnesses` arrays with a migration error) |
+| Each entry has `kind` | `kind ∈ {"plugin", "harness"}` |
+| Entry `name` is kebab-case | Regex `^[a-z][a-z0-9-]*$` |
+| Names unique across all entries | Cross-kind uniqueness (a plugin and a harness cannot share a name) |
+| Each entry has `description`, `versions[]` | Non-empty array |
+| Each version has `version` (semver) | Semver parse |
+| Plugin version has valid `source` | Tagged union by `source.type`: `npm` requires `name`+`version`; `tarball` requires `url` (optional `sha256`); `file` requires `path` |
+| Harness version has `path` | Non-empty string |
+| `file` source `path` exists | `existsSync(join(dir, source.path))` relative to marketplace root |
+| Harness `path` exists | `existsSync(join(dir, version.path))` |
+| `minKaizenVersion` parses | Optional; if present, must be a valid semver range |
 
 ---
 
@@ -413,6 +485,9 @@ validate` unless explicitly marked `[guideline]`.
    - Required: permissions.tier declared
    - Required: capabilities field (empty object acceptable)
    - Guideline: config.schema for any configurable plugin
+   - Guideline: if config.secrets is non-empty, explicitly list
+     "core-secrets:provider" in capabilities.consumes (it is implicit, but
+     listing it aids discoverability)
 
 ## 3. Permission Tier Selection
    - Default to trusted. Escalate only when you hit a real need.
@@ -426,9 +501,12 @@ validate` unless explicitly marked `[guideline]`.
 
 ## 5. Configuration
    - Declare config.schema for any configurable behaviour
-   - Use config.secrets for env var references (not api_key_env pattern)
-   - Provide defaults for optional keys
-   - Document all config keys in README
+   - Use config.secrets to declare secret keys; access via ctx.secrets.get()
+     (not the legacy api_key_env / process.env pattern)
+   - Secret values are harness-level references resolved via a
+     core-secrets:provider (default: `kaizen`, the OS keychain)
+   - Provide defaults for optional non-secret keys
+   - Document all config keys in README (including which are secrets)
 
 ## 6. Testing
    - Each plugin must have at least one test that calls setup()
@@ -510,8 +588,34 @@ Wire new subcommands:
 | Scaffolder output | Scaffolded plugin: `bun test` passes, `kaizen plugin validate .` passes |
 | Marketplace scaffolder | Scaffolded marketplace: `kaizen marketplace validate .` passes |
 | `validate` rules | One test per rule: passing case + failing case |
+| Catalog shape | Legacy `{ plugins, harnesses }` catalog rejected with migration error; `entries[]` + `kind` accepted |
+| Cross-kind name uniqueness | Plugin and harness with same `name` in one catalog → fatal |
+| Secrets rule | `config.secrets: ["api_key"]` without `api_key` in `schema.properties` → fail |
+| Secrets/permissions decoupling | `config.secrets` with NO `permissions.env` grant → pass (no cross-check) |
+| Implicit provider dep | `config.secrets` non-empty with `core-secrets:provider` absent from `consumes` → informational note, not fail |
 | Import scan | Static scan detects `import fs from "node:fs"` in TRUSTED plugin |
 | Non-interactive mode | `--defaults` generates valid plugin with no prompts |
+| Scaffolded secrets test | `makeCtx()` exposes async `ctx.secrets.get/refresh`; sample plugin setup resolves the secret |
+
+---
+
+## Migration
+
+Kaizen is pre-adoption; there is no on-disk migration of existing plugins. Any
+author who scaffolded a plugin against prior drafts of this spec should:
+
+1. Update generated `index.ts` to remove the `env: [<SECRET_ENV_VAR>]`
+   permission grant *for the secret alone* (env grants for real non-secret
+   env reads still apply) and switch secret access to `ctx.secrets.get("...")`.
+2. Update harness config: replace `"api_key": "MY_API_KEY_ENV_VAR"` with either
+   a bare-string ref (`"my-plugin-prod"`, default provider `kaizen`) or the
+   structured form `{ "provider": "...", "ref": "..." }`.
+3. If scaffolded a marketplace with the old `{ plugins, harnesses }` shape,
+   convert to `entries[]` with `kind` tags. `kaizen marketplace validate`
+   emits a migration error pointing at this step.
+
+Existing built-in plugins migrate as part of Spec 4 (repo decoupling) and
+Spec 2 (Phase 9); this spec's scaffolder only affects newly-created plugins.
 
 ---
 
@@ -525,3 +629,10 @@ Wire new subcommands:
   boilerplate.
 - **IDE integration** — JSON Schema for `kaizen.json` harness files to enable
   autocompletion in VS Code and other editors.
+- **Env-var collision warning** — validate emits a warning when two config
+  keys uppercase-collapse to the same `KAIZEN_<PLUGIN>_<KEY>` env var.
+- **In-tree scaffolding mode** — `--in-tree` flag that generates with
+  relative imports for authors working inside a kaizen monorepo checkout
+  (pre-Spec-4 workflow).
+- **Harness scaffolder** (`kaizen harness create`) — scaffolds a harness JSON
+  with canonical refs pre-populated from added marketplaces.

--- a/docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md
+++ b/docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md
@@ -458,7 +458,7 @@ Validates a marketplace directory at `<path>` (defaults to current directory).
 | Harness version has `path` | Non-empty string |
 | `file` source `path` exists | `existsSync(join(dir, source.path))` relative to marketplace root |
 | Harness `path` exists | `existsSync(join(dir, version.path))` |
-| `minKaizenVersion` parses | Optional; if present, must be a valid semver range |
+| `minKaizenVersion` parses | Optional; if present, must be a bare semver (NOT a range — analogous to k8s ">= 1.30") |
 
 ---
 

--- a/docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md
+++ b/docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md
@@ -1,0 +1,344 @@
+# Design: Unified Plugin Configuration
+
+Date: 2026-04-18
+Status: APPROVED
+Related:
+- `docs/plugin-api.md` (current `ctx.config` usage — this spec replaces that section)
+- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — install lifecycle hooks)
+- `docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md` (Spec 3 — scaffolded plugins use this config pattern)
+
+---
+
+## Problem Statement
+
+Plugin config today is a raw `Record<string, unknown>` pulled from the plugin's
+namespace in `kaizen.json`. There is no schema, no validation, no discoverability,
+and no standard way to declare which values are secrets. Authors write patterns like:
+
+```typescript
+const key = process.env[ctx.config["api_key_env"] as string];
+const timeout = ctx.config["timeout_ms"] as number ?? 5000;
+```
+
+This is brittle (wrong key = silent `undefined`), unvalidated (wrong type at runtime),
+and undiscoverable (no way to know what a plugin needs without reading its source).
+
+This design adds:
+
+1. **Declared config schema** on the plugin export (JSON Schema + defaults).
+2. **Validation at load time** — misconfigured plugins fail fast with clear errors.
+3. **Typed `ctx.config`** — the context surface returns a validated, typed object.
+4. **Secrets declaration** — `config.secrets` marks which keys are env-var names,
+   eliminating the `api_key_env` indirection pattern.
+5. **Merge precedence** — a defined order: plugin defaults → kaizen-level defaults →
+   harness config → env overrides.
+6. **`kaizen config` CLI** — inspect and override config from the command line.
+
+---
+
+## Design Philosophy
+
+- **Fail at load, not at call time.** A plugin whose required config is missing should
+  die at startup, not when the first user message hits a code path that reads config.
+- **Schema as documentation.** A plugin's `config.schema` is human-readable. `kaizen
+  config show <plugin>` surfaces it. Third-party tooling (IDEs, harness authors) can
+  validate harness files before running.
+- **No new dependency.** ajv is already in the project (used for tool parameter
+  validation). Config schema validation reuses it.
+- **Backward compatible.** Plugins that don't declare a schema continue to work.
+  `ctx.config` stays available as a raw object for legacy access.
+
+---
+
+## Scope
+
+### In Scope
+
+- `config` field on `KaizenPlugin` export: `schema`, `defaults`, `secrets`.
+- Config merge pipeline: defaults → kaizen-level → harness → env.
+- `ctx.config` typed access (replaces current raw `Record<string, unknown>`).
+- `ctx.secrets.get(key)` integration with declared secrets.
+- Validation at plugin load time.
+- `kaizen config show [<plugin>]` — display effective merged config + schema.
+- `kaizen config get <plugin>.<path>` — read a single value.
+- `kaizen config set <plugin>.<path> <value>` — write to project harness config.
+- Core wiring in `src/core/context.ts` and `src/core/loader.ts`.
+
+### Out of Scope
+
+- Config encryption at rest (secrets are still env var names; actual values come from
+  the environment, not kaizen storage).
+- Per-user config override layer (beyond the env-var layer already present).
+- IDE schema integration / JSON Schema Language Server support (future).
+- Harness-level config validation CLI (future).
+
+---
+
+## Plugin Config Declaration
+
+Plugins declare config on their default export alongside `name`, `apiVersion`, etc.:
+
+```typescript
+import type { KaizenPlugin } from "kaizen/types";
+
+const plugin: KaizenPlugin = {
+  name: "my-plugin",
+  apiVersion: "2.0.0",
+  permissions: { tier: "scoped", env: ["MY_API_KEY"] },
+  capabilities: { consumes: ["core-events:service"] },
+
+  config: {
+    schema: {
+      type: "object",
+      properties: {
+        api_key:    { type: "string", description: "API key for the service." },
+        timeout_ms: { type: "number", description: "Request timeout in milliseconds." },
+        base_url:   { type: "string", description: "Service base URL." },
+      },
+      required: ["api_key"],
+    },
+    defaults: {
+      timeout_ms: 5000,
+      base_url: "https://api.example.com",
+    },
+    secrets: ["api_key"],  // these values are env var names resolved at runtime
+  },
+
+  async setup(ctx) {
+    const cfg = ctx.config;            // typed as Record<string, unknown> (v1)
+    const key = cfg.api_key as string; // resolved from env — not the raw key name
+    const timeout = cfg.timeout_ms as number;
+    ctx.log(`connecting to ${cfg.base_url} with timeout ${timeout}ms`);
+  },
+};
+```
+
+### The `config` field
+
+```typescript
+interface PluginConfigDeclaration {
+  /**
+   * JSON Schema (draft-07) describing valid config. `type: "object"` is assumed
+   * if omitted. Core validates the merged config against this schema at load time.
+   */
+  schema?: JSONSchema;
+  /**
+   * Default values merged before harness config. Plugin-level defaults have lowest
+   * precedence.
+   */
+  defaults?: Record<string, unknown>;
+  /**
+   * Keys whose values are environment variable NAMES. When core resolves config,
+   * it replaces the value of a secrets key with `process.env[value]`.
+   * Requires the key to appear in `permissions.env`.
+   */
+  secrets?: string[];
+}
+```
+
+### Secrets resolution
+
+The `secrets` array names config keys whose values are environment variable names,
+not literal values. Core resolves them during the merge pipeline:
+
+```json
+// In kaizen.json harness:
+{ "my-plugin": { "api_key": "MY_API_KEY" } }
+```
+
+```typescript
+// ctx.config.api_key === process.env["MY_API_KEY"]  (the actual key value)
+```
+
+This eliminates the `api_key_env` indirection. The plugin author no longer needs
+to write `process.env[ctx.config["api_key_env"] as string]`.
+
+If the env var is missing and `api_key` is in `required`, load fails with:
+`"my-plugin: required config key 'api_key' is missing. Set env var MY_API_KEY."`.
+
+---
+
+## Merge Precedence
+
+Config is built right-to-left (right wins):
+
+```
+plugin.config.defaults
+  ← ~/.kaizen/kaizen.json defaults.<plugin-name>
+    ← <harness>/kaizen.json <plugin-name>
+      ← env vars (secrets resolution)
+```
+
+**Plugin defaults** are the lowest priority. Authors use them for safe fallback values.
+
+**Kaizen-level defaults** (in `~/.kaizen/kaizen.json` under a `defaults` key) let users
+set personal overrides that apply across all harnesses. Example: a personal
+`anthropic.api_key_env` preference.
+
+**Harness config** is the main per-project config (today's `kaizen.json`). This is
+what harness authors ship.
+
+**Env vars** (secrets resolution) are the highest priority. An env var in the shell
+always overrides the harness-specified value.
+
+---
+
+## Validation
+
+Validation runs in `src/core/loader.ts` after merging config, before calling
+`plugin.setup(ctx)`.
+
+Steps:
+1. Build merged config (defaults → kaizen-level → harness → secrets).
+2. Validate against `plugin.config.schema` using ajv.
+3. If invalid: fatal error with the plugin name, the failing path, and the schema
+   constraint. Example:
+   ```
+   Error: my-plugin config invalid:
+     - /timeout_ms: must be number (got string "5000")
+     - /api_key: required
+   ```
+4. Pass the validated, merged config to `createPluginContext`.
+
+Plugins without `config.schema` skip validation. Their `ctx.config` is the raw
+merged object from the harness (today's behaviour).
+
+---
+
+## `ctx.config` Surface
+
+`ctx.config` returns the validated, merged config object. Type is
+`Record<string, unknown>` at runtime (typed via schema at declaration time; a future
+spec may add TypeScript-level generics).
+
+Secrets keys in `ctx.config` return the **resolved env var value**, not the env var
+name. The raw name is not exposed.
+
+```typescript
+// plugin declares: secrets: ["api_key"]
+// harness has:     "my-plugin": { "api_key": "MY_API_KEY" }
+// shell has:       MY_API_KEY=abc123
+
+ctx.config.api_key  // → "abc123"
+```
+
+`ctx.secrets.get(key)` remains available as an explicit alternative. It is equivalent
+to reading `ctx.config[key]` for a key in `secrets`.
+
+---
+
+## CLI: `kaizen config`
+
+### `kaizen config show [<plugin>]`
+
+Prints the effective merged config for all plugins (or one). Shows:
+- Each key with its resolved value (secrets values are redacted: `***`).
+- The source of each value: `[default]`, `[global]`, `[harness]`, `[env]`.
+- The plugin's declared schema (if any) as a compact table.
+
+Example output:
+```
+my-plugin config:
+  api_key      ***           [env MY_API_KEY]
+  timeout_ms   5000          [default]
+  base_url     https://...   [harness]
+
+Schema:
+  api_key    string   required   "API key for the service."
+  timeout_ms number   optional   "Request timeout in milliseconds."
+  base_url   string   optional   "Service base URL."
+```
+
+### `kaizen config get <plugin>.<path>`
+
+Prints the resolved value at the dotted path. Secrets are redacted.
+Exit 1 if plugin or path not found.
+
+### `kaizen config set <plugin>.<path> <value>`
+
+Writes the value to the project's `.kaizen/kaizen.json` under the plugin's namespace.
+Validates the new value against the plugin's schema (if available).
+Fails if the plugin is not in the current harness.
+
+---
+
+## Component Architecture
+
+### Modified: `src/types/plugin.ts`
+
+Add `PluginConfigDeclaration` interface and `config?: PluginConfigDeclaration` field
+to `KaizenPlugin`.
+
+### Modified: `src/core/loader.ts`
+
+Add `mergePluginConfig(plugin, globalConfig, harnessConfig): Record<string, unknown>`
+and `validatePluginConfig(plugin, merged): void`.
+
+### Modified: `src/core/context.ts`
+
+`createPluginContext` receives pre-validated merged config and exposes it as
+`ctx.config`. Secrets keys return resolved env values.
+
+### New: `src/core/config-validator.ts`
+
+Wraps ajv instance (reuse the one from `tool-registry.ts` or instantiate separately).
+Exports `validateConfig(schema, data): ValidationError[]`.
+
+### New: `src/commands/config.ts`
+
+Implements `show`, `get`, `set` subcommands.
+
+### Modified: `src/cli.ts`
+
+Wire `kaizen config` subcommand.
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Required config key missing | Fatal at startup: "Plugin <n>: required config key '<k>' missing." |
+| Config value wrong type | Fatal at startup: lists all ajv errors |
+| Secrets key env var missing (required) | Fatal at startup: "Set env var <VAR_NAME>" |
+| Secrets key env var missing (optional) | Config key resolves to `undefined`; plugin handles |
+| Schema itself invalid JSON Schema | Fatal at startup: "Plugin <n>: config.schema is not a valid JSON Schema" |
+| `kaizen config set` with invalid value | Error; does not write. Shows schema constraint. |
+
+---
+
+## Testing
+
+| Area | Approach |
+|------|----------|
+| Merge pipeline | Unit tests for all four layers; secrets resolution; right-wins order |
+| Validation | Valid config, missing required, wrong type, nested path errors |
+| Secrets | Env var present, missing required, missing optional |
+| `ctx.config` access | Resolved values match expectations; secrets redacted in `show` |
+| CLI `show` | Snapshot test for output format |
+| CLI `get` | Found, not found, nested path |
+| CLI `set` | Writes to correct config file; validates before write |
+| Backward compat | Plugin without `config` field loads unchanged |
+
+---
+
+## Migration
+
+- **Existing plugins** that read `ctx.config["api_key_env"]` then call
+  `process.env[...]` continue to work. No breaking change.
+- **Recommended migration** for existing built-in plugins: add `config.schema`,
+  `config.defaults`, and `config.secrets` to their exports. Update `setup()` to use
+  `ctx.config.api_key` directly.
+- Migration guide added to `docs/plugin-api.md`.
+
+---
+
+## Future Work
+
+- TypeScript-level typed `ctx.config`: `ctx.config<MyConfigType>()` with compile-time
+  safety derived from the declared schema. Requires codegen or TypeScript declaration
+  augmentation — deferred for complexity.
+- Harness validation CLI: `kaizen validate` checks harness config against all loaded
+  plugins' schemas before running. Useful for CI.
+- IDE schema integration: emit a JSON Schema for each plugin's config namespace, wire
+  into a VS Code extension for `kaizen.json` autocompletion.

--- a/docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md
+++ b/docs/superpowers/specs/2026-04-18-unified-plugin-config-design.md
@@ -1,11 +1,12 @@
-# Design: Unified Plugin Configuration
+# Design: Unified Plugin Configuration & Pluggable Secrets
 
 Date: 2026-04-18
-Status: APPROVED
+Status: DRAFT
 Related:
 - `docs/plugin-api.md` (current `ctx.config` usage — this spec replaces that section)
-- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — install lifecycle hooks)
+- `docs/superpowers/specs/2026-04-18-plugin-marketplace-design.md` (Spec 1 — consumes `kaizen-config.ts` module; marketplace-qualified refs)
 - `docs/superpowers/specs/2026-04-18-plugin-scaffolder-standards-design.md` (Spec 3 — scaffolded plugins use this config pattern)
+- `docs/superpowers/specs/2026-04-17-capability-registry-design.md` (capability ordering for secret providers)
 
 ---
 
@@ -23,30 +24,60 @@ const timeout = ctx.config["timeout_ms"] as number ?? 5000;
 This is brittle (wrong key = silent `undefined`), unvalidated (wrong type at runtime),
 and undiscoverable (no way to know what a plugin needs without reading its source).
 
+Secrets are a second-class concern. Plugins read `process.env` directly. There is no
+OS-portable secret store, no way to swap in Doppler/Vault, and no mechanism for
+runtime secret fetches when an LLM navigates into a code path the author didn't
+anticipate.
+
 This design adds:
 
 1. **Declared config schema** on the plugin export (JSON Schema + defaults).
-2. **Validation at load time** — misconfigured plugins fail fast with clear errors.
-3. **Typed `ctx.config`** — the context surface returns a validated, typed object.
-4. **Secrets declaration** — `config.secrets` marks which keys are env-var names,
-   eliminating the `api_key_env` indirection pattern.
-5. **Merge precedence** — a defined order: plugin defaults → kaizen-level defaults →
-   harness config → env overrides.
-6. **`kaizen config` CLI** — inspect and override config from the command line.
+2. **Validation at install + load time** — shape errors fail fast with clear messages.
+3. **Typed `ctx.config`** — the context surface returns a validated object containing
+   non-secret values only.
+4. **Structured secret references** — `{ provider, ref }` in harness config; bare
+   string is shorthand for the default provider.
+5. **Pluggable secret providers** — the `core-secrets:provider` capability lets any
+   plugin supply secrets. Default `core-secrets` plugin uses OS keychain (macOS
+   Keychain, Windows Credential Manager, Linux libsecret / file fallback). Doppler,
+   Vault, etc. ship as replacement plugins.
+6. **Lazy async `ctx.secrets.get(key)`** — declared secrets pre-fetched in
+   background at setup; undeclared secrets resolvable mid-workflow for LLM-driven
+   paths.
+7. **Merge precedence** — a defined order: plugin defaults → kaizen-level defaults
+   → harness config → env overrides.
+8. **`kaizen config` CLI** — inspect, override, and set secrets from the command
+   line.
 
 ---
 
 ## Design Philosophy
 
-- **Fail at load, not at call time.** A plugin whose required config is missing should
-  die at startup, not when the first user message hits a code path that reads config.
+- **Fail at install or load, not at call time.** A misconfigured plugin dies at
+  startup, not when the first user message hits a code path that reads config.
+  Schema-shape errors are catchable at `kaizen install`; secret value resolution is
+  deferred to runtime.
 - **Schema as documentation.** A plugin's `config.schema` is human-readable. `kaizen
-  config show <plugin>` surfaces it. Third-party tooling (IDEs, harness authors) can
-  validate harness files before running.
-- **No new dependency.** ajv is already in the project (used for tool parameter
-  validation). Config schema validation reuses it.
-- **Backward compatible.** Plugins that don't declare a schema continue to work.
-  `ctx.config` stays available as a raw object for legacy access.
+  config show <plugin>` surfaces it. Third-party tooling validates harness files
+  before running.
+- **Non-secret config never leaks to env.** Kaizen stores non-secret config in its
+  own files. It does not export plugin config as env vars the way Claude Code does
+  (`CLAUDE_PLUGIN_OPTION_*`). Env vars may *override* config values when set, but
+  kaizen never writes them.
+- **Secrets are pluggable at runtime.** Providers are plain kaizen plugins declaring
+  the `core-secrets:provider` capability. The capability-registry ordering
+  guarantees any consumer loads after its provider. Providers that need network
+  I/O (Doppler, Vault) get to stay live for the whole session.
+- **OS-portable defaults.** The built-in `core-secrets` provider uses the native
+  OS secret store on macOS, Windows, and Linux, with an encrypted-file fallback for
+  headless environments. No reliance on user-managed env vars.
+- **Authority lives with the provider.** Kaizen does not duplicate a provider's
+  access-control rules. If Doppler rejects a secret lookup, kaizen surfaces the
+  error; it does not pre-filter keys.
+- **No new dependency.** ajv is already in the project (tool parameter validation).
+  Config schema validation reuses it.
+- **Backward compatible.** Plugins that don't declare `config` continue to work.
+  `ctx.config` stays available as a raw `Record<string, unknown>` for legacy access.
 
 ---
 
@@ -55,22 +86,39 @@ This design adds:
 ### In Scope
 
 - `config` field on `KaizenPlugin` export: `schema`, `defaults`, `secrets`.
-- Config merge pipeline: defaults → kaizen-level → harness → env.
-- `ctx.config` typed access (replaces current raw `Record<string, unknown>`).
-- `ctx.secrets.get(key)` integration with declared secrets.
-- Validation at plugin load time.
-- `kaizen config show [<plugin>]` — display effective merged config + schema.
-- `kaizen config get <plugin>.<path>` — read a single value.
-- `kaizen config set <plugin>.<path> <value>` — write to project harness config.
-- Core wiring in `src/core/context.ts` and `src/core/loader.ts`.
+- Config merge pipeline: plugin defaults → kaizen-level defaults → harness → env.
+- Env override convention: `KAIZEN_<PLUGIN>_<KEY>` (uppercased, underscored),
+  plus optional per-key `envOverride` escape hatch.
+- `ctx.config` typed access — contains validated non-secret config values only.
+- `ctx.secrets.get(key): Promise<string | undefined>` — async, provider-backed;
+  declared secrets pre-fetched at setup.
+- Structured secret reference format in harness config: `{ provider, ref }`; bare
+  string = default provider.
+- `core-secrets:provider` capability (registered in Spec's capability registry).
+- `core-secrets` built-in plugin: OS keychain on macOS / Windows / Linux, file
+  fallback at `~/.kaizen/.credentials.json` (chmod 600).
+- Install-time validation: schema shape, non-secret required keys, registered
+  provider existence for every declared secret ref.
+- Load-time validation: same schema check post-merge; secret values resolved
+  lazily (first `ctx.secrets.get(key)` call, with background pre-fetch).
+- `kaizen config show [<plugin>]` — effective merged config + schema.
+- `kaizen config get <plugin> <path>` — read a single value.
+- `kaizen config set <plugin> <path> <value>` — write to project harness config.
+- `kaizen config set-secret <plugin> <key>` — interactive prompt, writes via the
+  default provider (OS keychain).
+- Core wiring: `src/core/context.ts`, `src/core/loader.ts`, new
+  `src/core/config-validator.ts`, `src/core/config-merge.ts`, `src/core/secrets.ts`,
+  `src/core/secret-providers/*`.
 
 ### Out of Scope
 
-- Config encryption at rest (secrets are still env var names; actual values come from
-  the environment, not kaizen storage).
-- Per-user config override layer (beyond the env-var layer already present).
-- IDE schema integration / JSON Schema Language Server support (future).
-- Harness-level config validation CLI (future).
+- Non-default secret providers (Doppler, Vault, AWS Secrets Manager). These ship
+  as separate plugins authored by the community or kaizen-sh.
+- Kaizen-side secret access-control (globs, allowlists). Providers own auth.
+- Per-user overlay config file beyond the env-var layer.
+- IDE schema integration / JSON Schema Language Server support.
+- Harness-level config validation CLI (`kaizen validate`) — future.
+- TypeScript-typed `ctx.config<T>()` with compile-time guarantees — future.
 
 ---
 
@@ -82,33 +130,32 @@ Plugins declare config on their default export alongside `name`, `apiVersion`, e
 import type { KaizenPlugin } from "kaizen/types";
 
 const plugin: KaizenPlugin = {
-  name: "my-plugin",
+  name: "stripe-billing",
   apiVersion: "2.0.0",
-  permissions: { tier: "scoped", env: ["MY_API_KEY"] },
-  capabilities: { consumes: ["core-events:service"] },
+  permissions: { tier: "scoped", net: ["api.stripe.com"] },
+  capabilities: { consumes: ["core-events:service", "core-secrets:provider"] },
 
   config: {
     schema: {
       type: "object",
       properties: {
-        api_key:    { type: "string", description: "API key for the service." },
-        timeout_ms: { type: "number", description: "Request timeout in milliseconds." },
-        base_url:   { type: "string", description: "Service base URL." },
+        api_key:    { type: "string", description: "Stripe secret key." },
+        timeout_ms: { type: "number", description: "Request timeout in ms." },
+        base_url:   { type: "string", description: "API base URL." },
       },
       required: ["api_key"],
     },
     defaults: {
       timeout_ms: 5000,
-      base_url: "https://api.example.com",
+      base_url: "https://api.stripe.com",
     },
-    secrets: ["api_key"],  // these values are env var names resolved at runtime
+    secrets: ["api_key"],
   },
 
   async setup(ctx) {
-    const cfg = ctx.config;            // typed as Record<string, unknown> (v1)
-    const key = cfg.api_key as string; // resolved from env — not the raw key name
-    const timeout = cfg.timeout_ms as number;
-    ctx.log(`connecting to ${cfg.base_url} with timeout ${timeout}ms`);
+    const apiKey = await ctx.secrets.get("api_key");
+    ctx.log(`stripe: timeout=${ctx.config.timeout_ms}ms base=${ctx.config.base_url}`);
+    // ...
   },
 };
 ```
@@ -118,147 +165,350 @@ const plugin: KaizenPlugin = {
 ```typescript
 interface PluginConfigDeclaration {
   /**
-   * JSON Schema (draft-07) describing valid config. `type: "object"` is assumed
-   * if omitted. Core validates the merged config against this schema at load time.
+   * JSON Schema (draft-07) describing valid config. `type: "object"` is assumed at
+   * the root. Validates the merged, non-secret config at install and load time.
    */
   schema?: JSONSchema;
   /**
-   * Default values merged before harness config. Plugin-level defaults have lowest
-   * precedence.
+   * Default values. Lowest-precedence layer in the merge pipeline.
    */
   defaults?: Record<string, unknown>;
   /**
-   * Keys whose values are environment variable NAMES. When core resolves config,
-   * it replaces the value of a secrets key with `process.env[value]`.
-   * Requires the key to appear in `permissions.env`.
+   * Config keys whose values are secret references (not plain data). Core does NOT
+   * expose these on `ctx.config`; they are accessed exclusively through
+   * `ctx.secrets.get(key)`.
+   *
+   * A plugin that declares any secret automatically gains an implicit
+   * `consumes: ["core-secrets:provider"]` capability dependency (the
+   * capability-registry orders secret providers before consumers).
    */
   secrets?: string[];
 }
 ```
 
-### Secrets resolution
+### Config keying in harness files
 
-The `secrets` array names config keys whose values are environment variable names,
-not literal values. Core resolves them during the merge pipeline:
+Harness `kaizen.json` keys plugin config by the plugin's **declared `name`**. When
+two loaded plugins share a name (e.g. shadowing from different marketplaces), the
+full marketplace-qualified ref (e.g. `official/stripe-billing`) is accepted as the
+config key and resolves unambiguously. Shorthand is canonicalized to the qualified
+ref on write (via `kaizen config set`) when disambiguation is needed.
+
+Name collision without an explicit qualified config key is a fatal load-time error
+with guidance to qualify in the harness.
+
+---
+
+## Secret References
+
+Secret values live outside the harness. The harness stores *how to fetch* the value:
 
 ```json
-// In kaizen.json harness:
-{ "my-plugin": { "api_key": "MY_API_KEY" } }
+{
+  "stripe-billing": {
+    "api_key": { "provider": "kaizen", "ref": "stripe-prod" },
+    "timeout_ms": 3000
+  }
+}
 ```
+
+### Reference shape
 
 ```typescript
-// ctx.config.api_key === process.env["MY_API_KEY"]  (the actual key value)
+interface StructuredSecretRef {
+  /** Registered provider name (capability slot). `kaizen` = default provider. */
+  provider: string;
+  /** Provider-specific identifier (env var name, keychain item, Doppler key, ...). */
+  ref: string;
+  /** Optional override: read env var first, use its value if set. */
+  envOverride?: string;
+}
+
+type SecretRef = string | StructuredSecretRef;
 ```
 
-This eliminates the `api_key_env` indirection. The plugin author no longer needs
-to write `process.env[ctx.config["api_key_env"] as string]`.
+Bare string shorthand:
+```json
+"api_key": "stripe-prod"
+```
+is equivalent to:
+```json
+"api_key": { "provider": "kaizen", "ref": "stripe-prod" }
+```
 
-If the env var is missing and `api_key` is in `required`, load fails with:
-`"my-plugin: required config key 'api_key' is missing. Set env var MY_API_KEY."`.
+### Provider naming
+
+Providers register under a **name**, not a URI scheme. The default `core-secrets`
+plugin registers under `kaizen`. A Doppler plugin registers under `doppler`. Name
+collisions (two installed providers claiming the same name) are a fatal load-time
+error.
+
+### Env override
+
+For every secret key, core checks env overrides in this order before calling the
+provider:
+
+1. If `envOverride` is set on the ref and `process.env[envOverride]` is defined —
+   use it.
+2. If `process.env["KAIZEN_<PLUGIN>_<KEY>"]` is defined (uppercased,
+   non-alphanumeric → `_`) — use it.
+3. Otherwise, call the provider: `provider.get(ref)`.
+
+The fixed `KAIZEN_<PLUGIN>_<KEY>` convention means any secret (or non-secret
+config value; see below) can be overridden in CI without harness changes. The
+`envOverride` field exists for CI systems that already export secrets under
+pre-existing names (e.g. `STRIPE_KEY`) and don't want to rename.
+
+### Non-secret env overrides
+
+Non-secret config values are overridden by the same
+`KAIZEN_<PLUGIN>_<KEY>` convention but with no `envOverride` escape hatch
+(since there is no structured form to attach it to). Env values are parsed as
+strings unless the schema's type is `number` or `boolean`, in which case core
+coerces.
+
+---
+
+## Secret Provider Capability
+
+`core-secrets:provider` is a capability (per
+`2026-04-17-capability-registry-design.md`). Providers declare:
+
+```typescript
+capabilities: {
+  provides: [
+    { kind: "core-secrets:provider", name: "kaizen" }
+  ],
+},
+```
+
+The `name` field distinguishes providers. Consumers never pick a provider by id;
+they reference it by name from harness config.
+
+### Provider interface
+
+```typescript
+interface SecretProvider {
+  /** Unique provider name (must match the `name` in the capability declaration). */
+  readonly name: string;
+
+  /**
+   * Fetch a secret by provider-specific ref.
+   * Returns `undefined` if the ref is unknown (not an error — core decides what to
+   * do based on whether the key is required).
+   * Throws on auth/transport failure.
+   */
+  get(ref: string): Promise<string | undefined>;
+
+  /**
+   * Optional: write a secret. Invoked by `kaizen config set-secret` when this
+   * provider is the target. Read-only providers (Doppler, Vault) omit this.
+   */
+  set?(ref: string, value: string): Promise<void>;
+
+  /**
+   * Optional: warm the provider's cache for a known list of refs. Called once at
+   * setup time with all declared secrets that target this provider.
+   */
+  prefetch?(refs: string[]): Promise<void>;
+}
+```
+
+Providers register themselves during `setup()` via the capability registry API:
+
+```typescript
+ctx.capabilities.register("core-secrets:provider", myProvider);
+```
+
+### Default provider: `core-secrets`
+
+Ships as a built-in plugin. Registers under the name `kaizen`. Storage:
+
+- **macOS:** Keychain via the `security` CLI (or a binding if we pick one).
+- **Windows:** Credential Manager via `wincred` / PowerShell.
+- **Linux:** libsecret via `secret-tool`.
+- **Fallback (any OS):** `~/.kaizen/.credentials.json`, chmod 600, JSON object
+  `{ "<ref>": "<value>" }`. Used when OS store is unavailable or `KAIZEN_SECRETS_BACKEND=file`.
+
+Implements `get`, `set`, and `prefetch` (trivial — keychain reads are cheap, but
+prefetch is still useful as a "surface auth errors early" hook).
+
+The `core-secrets` plugin is distributed alongside kaizen built-ins and installed
+by default. Users replace it by installing a different provider plugin and
+removing or shadowing `core-secrets`.
+
+### Dependency ordering
+
+Any plugin that declares `config.secrets` gains an implicit
+`consumes: ["core-secrets:provider"]` dependency. The capability-registry orders
+all provider plugins before any consumer. If no provider registers the `name` a
+ref targets, that consumer fails to load with a clear error.
 
 ---
 
 ## Merge Precedence
 
-Config is built right-to-left (right wins):
+Non-secret config is built right-to-left (right wins):
 
 ```
 plugin.config.defaults
-  ← ~/.kaizen/kaizen.json defaults.<plugin-name>
-    ← <harness>/kaizen.json <plugin-name>
-      ← env vars (secrets resolution)
+  ← ~/.kaizen/kaizen.json defaults[<plugin>]
+    ← <harness>/kaizen.json [<plugin>]
+      ← env overrides (KAIZEN_<PLUGIN>_<KEY>)
 ```
 
-**Plugin defaults** are the lowest priority. Authors use them for safe fallback values.
+Merge is **shallow per top-level key** (matching Claude Code's `pluginConfigs`
+semantics). A harness that overrides `retry: { max: 5 }` on a plugin whose default
+is `retry: { max: 3, delay: 100 }` replaces the entire `retry` object. Document
+this prominently in `docs/plugin-api.md` and surface it in `kaizen config show`
+output.
 
-**Kaizen-level defaults** (in `~/.kaizen/kaizen.json` under a `defaults` key) let users
-set personal overrides that apply across all harnesses. Example: a personal
-`anthropic.api_key_env` preference.
-
-**Harness config** is the main per-project config (today's `kaizen.json`). This is
-what harness authors ship.
-
-**Env vars** (secrets resolution) are the highest priority. An env var in the shell
-always overrides the harness-specified value.
+Secrets do not participate in this merge. Only the *reference* for a given secret
+key participates (same shallow-replace semantics as other keys); resolution
+happens via the provider.
 
 ---
 
 ## Validation
 
-Validation runs in `src/core/loader.ts` after merging config, before calling
-`plugin.setup(ctx)`.
+Runs in two phases.
 
-Steps:
-1. Build merged config (defaults → kaizen-level → harness → secrets).
-2. Validate against `plugin.config.schema` using ajv.
-3. If invalid: fatal error with the plugin name, the failing path, and the schema
-   constraint. Example:
-   ```
-   Error: my-plugin config invalid:
-     - /timeout_ms: must be number (got string "5000")
-     - /api_key: required
-   ```
-4. Pass the validated, merged config to `createPluginContext`.
+### Install-time (`kaizen install <ref>`)
 
-Plugins without `config.schema` skip validation. Their `ctx.config` is the raw
-merged object from the harness (today's behaviour).
+After fetching plugin bits and before writing to the lockfile:
+
+1. Parse `config.schema`. Invalid JSON Schema → fatal.
+2. Merge plugin defaults + kaizen-level defaults + harness config (if a project
+   harness is active).
+3. Validate merged config against schema. **Secrets keys** (those declared in
+   `config.secrets`) are stripped before validation — their *refs* are validated
+   structurally only (must be a string or `{ provider, ref }`), not against the
+   schema's type.
+4. For each declared secret, check the referenced `provider` is a registered
+   capability name. Fatal if unknown (with guidance: "install a plugin that
+   provides this provider, or change the ref").
+5. Do NOT attempt to fetch secret values. The install machine may lack auth; CI
+   is a legitimate reason for values to be absent at install time.
+
+### Load-time (`kaizen run`)
+
+1. Repeat the merge + schema validation (harness or env vars may have changed).
+2. For each declared secret, background-prefetch via `provider.prefetch?.(refs)`.
+   Failures are logged but non-fatal — the actual `get(key)` call surfaces the
+   error to the plugin.
+3. Call `plugin.setup(ctx)`. `ctx.config` contains only non-secret values;
+   `ctx.secrets.get(key)` is the only access path for declared secrets.
+
+### Error format
+
+```
+Error: my-plugin config invalid:
+  - /timeout_ms: must be number (got string "5000")
+  - /api_key: references provider 'doppler' but no plugin provides it.
+    Install a provider: kaizen install doppler-secrets
+    Or change the ref: kaizen config set my-plugin api_key '{"provider":"kaizen","ref":"..."}'
+```
 
 ---
 
-## `ctx.config` Surface
+## `ctx.config` and `ctx.secrets` Surface
 
-`ctx.config` returns the validated, merged config object. Type is
-`Record<string, unknown>` at runtime (typed via schema at declaration time; a future
-spec may add TypeScript-level generics).
+### `ctx.config`
 
-Secrets keys in `ctx.config` return the **resolved env var value**, not the env var
-name. The raw name is not exposed.
+Returns the validated, merged, **non-secret** config object. Type:
+`Record<string, unknown>` at runtime. Secret keys are absent — accessing
+`ctx.config.api_key` when `api_key` is declared in `config.secrets` returns
+`undefined`.
 
 ```typescript
-// plugin declares: secrets: ["api_key"]
-// harness has:     "my-plugin": { "api_key": "MY_API_KEY" }
-// shell has:       MY_API_KEY=abc123
-
-ctx.config.api_key  // → "abc123"
+ctx.config.timeout_ms  // → 5000
+ctx.config.base_url    // → "https://api.stripe.com"
+ctx.config.api_key     // → undefined (declared secret)
 ```
 
-`ctx.secrets.get(key)` remains available as an explicit alternative. It is equivalent
-to reading `ctx.config[key]` for a key in `secrets`.
+### `ctx.secrets.get(key)`
+
+```typescript
+get(key: string): Promise<string | undefined>
+```
+
+Resolves a secret. If `key` is declared in `config.secrets`, core uses the
+harness's ref for that key (pre-fetched at setup for fast first access). If `key`
+is undeclared, core treats it as a ref against the default provider — useful for
+LLM-driven flows where the plugin author can't know secret names upfront:
+
+```typescript
+// Declared — fast, uses harness ref, honors envOverride
+const stripe = await ctx.secrets.get("api_key");
+
+// Undeclared — live provider lookup, no env override convention
+const other = await ctx.secrets.get("random-runtime-key");
+```
+
+Provider errors propagate. Missing values (provider returned `undefined`) return
+`undefined` — the caller decides whether that's fatal.
+
+### `ctx.secrets.refresh(key)`
+
+```typescript
+refresh(key: string): Promise<string | undefined>
+```
+
+Forces a re-fetch, bypassing any cache. Intended for long-running plugins whose
+secrets rotate.
 
 ---
 
 ## CLI: `kaizen config`
 
+Space-separated arguments (no dot-notation) to avoid collisions with
+marketplace-qualified refs and dotted config paths.
+
 ### `kaizen config show [<plugin>]`
 
 Prints the effective merged config for all plugins (or one). Shows:
-- Each key with its resolved value (secrets values are redacted: `***`).
-- The source of each value: `[default]`, `[global]`, `[harness]`, `[env]`.
-- The plugin's declared schema (if any) as a compact table.
 
-Example output:
+- Each non-secret key with its resolved value and source annotation (`[default]`,
+  `[global]`, `[harness]`, `[env KAIZEN_X_Y]`).
+- Each secret key with provider/ref (value redacted as `***`).
+- The plugin's declared schema as a compact table.
+- A footnote if shallow-merge replaced a nested object (heuristic: any top-level
+  key whose value is an object present in both defaults and harness).
+
+Example:
 ```
-my-plugin config:
-  api_key      ***           [env MY_API_KEY]
-  timeout_ms   5000          [default]
-  base_url     https://...   [harness]
+stripe-billing:
+  timeout_ms  5000                     [default]
+  base_url    https://api.stripe.com   [default]
+  api_key     *** (provider: kaizen, ref: stripe-prod)  [harness]
 
 Schema:
-  api_key    string   required   "API key for the service."
-  timeout_ms number   optional   "Request timeout in milliseconds."
-  base_url   string   optional   "Service base URL."
+  api_key     string   required   "Stripe secret key."
+  timeout_ms  number   optional   "Request timeout in ms."
+  base_url    string   optional   "API base URL."
 ```
 
-### `kaizen config get <plugin>.<path>`
+### `kaizen config get <plugin> <path>`
 
-Prints the resolved value at the dotted path. Secrets are redacted.
-Exit 1 if plugin or path not found.
+Prints the resolved value at the dotted path. Secrets redacted unless `--reveal`
+is passed. Exit 1 if plugin or path not found.
 
-### `kaizen config set <plugin>.<path> <value>`
+### `kaizen config set <plugin> <path> <value>`
 
-Writes the value to the project's `.kaizen/kaizen.json` under the plugin's namespace.
-Validates the new value against the plugin's schema (if available).
-Fails if the plugin is not in the current harness.
+Writes the value to the project's `.kaizen/kaizen.json` under the plugin's
+namespace. Validates the new value against the schema. Fails if the plugin is not
+in the current harness. `--global` writes to `~/.kaizen/kaizen.json` `defaults[<plugin>]`
+instead.
+
+### `kaizen config set-secret <plugin> <key>`
+
+Interactive prompt (value never echoed). Writes via the default provider's `set()`
+method. Refuses if the default provider doesn't implement `set` (e.g. the user
+has swapped in a read-only provider like Doppler). Stores the ref in the harness
+(or `--global` for kaizen-level defaults) as `{ provider: "kaizen", ref: "<chosen-ref>" }`.
+
+`--provider <name>` targets a specific non-default provider that implements `set`.
+Rare; mostly unused.
 
 ---
 
@@ -266,44 +516,88 @@ Fails if the plugin is not in the current harness.
 
 ### Modified: `src/types/plugin.ts`
 
-Add `PluginConfigDeclaration` interface and `config?: PluginConfigDeclaration` field
-to `KaizenPlugin`.
+Add `PluginConfigDeclaration`, `SecretRef`, `StructuredSecretRef` interfaces. Add
+`config?: PluginConfigDeclaration` field to `KaizenPlugin`.
 
 ### Modified: `src/core/loader.ts`
 
 Add `mergePluginConfig(plugin, globalConfig, harnessConfig): Record<string, unknown>`
-and `validatePluginConfig(plugin, merged): void`.
+and `validatePluginConfig(plugin, merged): void`. Wire install-time and load-time
+validation phases described above.
 
 ### Modified: `src/core/context.ts`
 
-`createPluginContext` receives pre-validated merged config and exposes it as
-`ctx.config`. Secrets keys return resolved env values.
-
-### New: `src/core/config-validator.ts`
-
-Wraps ajv instance (reuse the one from `tool-registry.ts` or instantiate separately).
-Exports `validateConfig(schema, data): ValidationError[]`.
-
-### New: `src/commands/config.ts`
-
-Implements `show`, `get`, `set` subcommands.
+`createPluginContext` receives pre-validated merged config. Exposes `ctx.config`
+(non-secrets only) and `ctx.secrets` (from new `src/core/secrets.ts`).
 
 ### Modified: `src/cli.ts`
 
-Wire `kaizen config` subcommand.
+Wire `kaizen config` subcommand with `show`, `get`, `set`, `set-secret`.
+
+### Modified: `src/commands/install.ts`
+
+Add install-time config validation step (post-lockfile-write would be too late —
+wire before lockfile write).
+
+### New: `src/core/config-validator.ts`
+
+Wraps ajv instance (reuse from `tool-registry.ts` or instantiate separately).
+Exports `validateConfig(schema, data): ValidationError[]` and
+`validateSchemaItself(schema): boolean`.
+
+### New: `src/core/config-merge.ts`
+
+Exports `mergePluginConfig`, `applyEnvOverrides(pluginName, merged, schema)`,
+`separateSecrets(merged, secretKeys): { config, secretRefs }`.
+
+### New: `src/core/secrets.ts`
+
+`SecretsRegistry` — tracks registered providers by name. Instantiated once per
+kaizen run.
+- `register(name, provider)` — called by provider plugins during `setup()`.
+- `resolve(pluginName, key, ref): Promise<string | undefined>` — the env-override
+  + provider-call pipeline.
+- `prefetch(pluginName, secrets, refs)` — called by loader once per plugin.
+- `createSecretsContext(pluginName, declaredRefs)` — returns the `ctx.secrets`
+  handle bound to a specific plugin.
+
+### New: `src/core/secret-providers/` (types only here; implementations in `plugins/core-secrets/`)
+
+`SecretProvider` interface export. Canonical location for third-party providers
+to import from.
+
+### New: `plugins/core-secrets/`
+
+Built-in plugin. Implements the default `kaizen` provider:
+- `plugins/core-secrets/index.ts` — plugin entry; registers the provider.
+- `plugins/core-secrets/keychain-macos.ts` — `security` CLI wrapper.
+- `plugins/core-secrets/keychain-windows.ts` — PowerShell `CredentialManager` wrapper.
+- `plugins/core-secrets/keychain-linux.ts` — `secret-tool` wrapper.
+- `plugins/core-secrets/file-fallback.ts` — `~/.kaizen/.credentials.json` (chmod 600).
+- `plugins/core-secrets/detect.ts` — picks backend at startup (OS + availability).
+
+### New: `src/commands/config.ts`
+
+Implements `show`, `get`, `set`, `set-secret` subcommands.
 
 ---
 
 ## Error Handling
 
-| Scenario | Behaviour |
-|----------|-----------|
-| Required config key missing | Fatal at startup: "Plugin <n>: required config key '<k>' missing." |
-| Config value wrong type | Fatal at startup: lists all ajv errors |
-| Secrets key env var missing (required) | Fatal at startup: "Set env var <VAR_NAME>" |
-| Secrets key env var missing (optional) | Config key resolves to `undefined`; plugin handles |
-| Schema itself invalid JSON Schema | Fatal at startup: "Plugin <n>: config.schema is not a valid JSON Schema" |
-| `kaizen config set` with invalid value | Error; does not write. Shows schema constraint. |
+| Scenario | Phase | Behaviour |
+|----------|-------|-----------|
+| Required non-secret config key missing | install + load | Fatal with key name |
+| Config value wrong type | install + load | Fatal; lists all ajv errors |
+| Schema itself invalid JSON Schema | install + load | Fatal with plugin name |
+| Declared secret ref targets unknown provider | install + load | Fatal; suggests `kaizen install <provider>` or ref change |
+| Declared secret ref is not a string or `{ provider, ref }` object | install + load | Fatal with plugin + key |
+| `provider.get(ref)` throws (auth, network) | runtime | Propagates to plugin via `ctx.secrets.get` |
+| `provider.get(ref)` returns `undefined` for declared-required secret | runtime (first access) | Plugin-author choice — core returns `undefined` |
+| `provider.prefetch(refs)` fails | runtime (setup) | Logged, non-fatal; later `get` surfaces real error |
+| Two providers register under the same name | runtime (setup) | Fatal at second registration |
+| Two loaded plugins share `name` without qualified harness key | load | Fatal; asks user to qualify |
+| `kaizen config set` with invalid value | CLI | Error; does not write |
+| `kaizen config set-secret` on read-only default provider | CLI | Error with provider name and guidance |
 
 ---
 
@@ -311,34 +605,57 @@ Wire `kaizen config` subcommand.
 
 | Area | Approach |
 |------|----------|
-| Merge pipeline | Unit tests for all four layers; secrets resolution; right-wins order |
-| Validation | Valid config, missing required, wrong type, nested path errors |
-| Secrets | Env var present, missing required, missing optional |
-| `ctx.config` access | Resolved values match expectations; secrets redacted in `show` |
-| CLI `show` | Snapshot test for output format |
-| CLI `get` | Found, not found, nested path |
-| CLI `set` | Writes to correct config file; validates before write |
-| Backward compat | Plugin without `config` field loads unchanged |
+| Merge pipeline | Unit: four-layer order; shallow replace; env override precedence |
+| Env override convention | Unit: `KAIZEN_<PLUGIN>_<KEY>` coercion for number / boolean / string; `envOverride` escape hatch |
+| Schema validation | Valid, missing required, wrong type, nested-path errors, invalid-schema |
+| Install-time validation | Plugin with bad schema rejected at `kaizen install`; plugin with missing required key rejected; secret pointing at unknown provider rejected |
+| Secret references | Bare string = default provider; structured form parsed; unknown provider → fatal |
+| Provider registry | Two-provider name collision → fatal; ordering via capability-registry covered separately |
+| `ctx.secrets.get` declared | Pre-fetched; env override wins; provider returns value |
+| `ctx.secrets.get` undeclared | Live provider lookup; no env override convention |
+| `ctx.secrets.refresh` | Bypasses cache; re-calls provider |
+| `core-secrets` macOS | Integration test gated on platform; writes + reads a test item; cleans up |
+| `core-secrets` Linux | Same, via `secret-tool`; skipped if libsecret absent |
+| `core-secrets` file fallback | Forced via `KAIZEN_SECRETS_BACKEND=file`; writes JSON at chmod 600 |
+| CLI `show` | Snapshot test; secrets redacted; shallow-merge footnote fires correctly |
+| CLI `get` | Found, not found; `--reveal` surfaces secret |
+| CLI `set` | Writes correct file; validates before write; `--global` path |
+| CLI `set-secret` | Prompts; writes via provider; refuses when provider is read-only |
+| Backward compat | Plugin without `config` field loads unchanged; `ctx.config` is raw harness config |
+| Built-in migration | Updated `core-executor-*` plugins pass schema validation |
 
 ---
 
 ## Migration
 
 - **Existing plugins** that read `ctx.config["api_key_env"]` then call
-  `process.env[...]` continue to work. No breaking change.
-- **Recommended migration** for existing built-in plugins: add `config.schema`,
-  `config.defaults`, and `config.secrets` to their exports. Update `setup()` to use
-  `ctx.config.api_key` directly.
-- Migration guide added to `docs/plugin-api.md`.
+  `process.env[...]` continue to work — they never declared `config.secrets` so
+  kaizen doesn't intercept. Recommended migration: add `config.schema`,
+  `config.defaults`, `config.secrets`; access via `ctx.secrets.get("api_key")`.
+- **Built-in plugins** (executor-anthropic, executor-openai, etc.) migrate in
+  Phase 9 of the plan. Each gains `config.secrets: ["api_key"]`; the old
+  `api_key_env` indirection is removed.
+- **Migration guide** added to `docs/plugin-api.md` covering both the config
+  schema pattern and the secret-reference shape.
 
 ---
 
 ## Future Work
 
-- TypeScript-level typed `ctx.config`: `ctx.config<MyConfigType>()` with compile-time
-  safety derived from the declared schema. Requires codegen or TypeScript declaration
-  augmentation — deferred for complexity.
-- Harness validation CLI: `kaizen validate` checks harness config against all loaded
-  plugins' schemas before running. Useful for CI.
-- IDE schema integration: emit a JSON Schema for each plugin's config namespace, wire
-  into a VS Code extension for `kaizen.json` autocompletion.
+- **Non-default providers.** Doppler, Vault, AWS Secrets Manager, 1Password
+  Connect. Each is an independent plugin that declares
+  `provides: [{ kind: "core-secrets:provider", name: "<name>" }]` and implements
+  `SecretProvider`. Out of scope for this spec — the capability and interface are
+  the extension point.
+- **Typed `ctx.config<T>()`** with compile-time safety derived from the declared
+  schema. Requires codegen or declaration augmentation.
+- **Harness validation CLI** (`kaizen validate`): check harness config against
+  all loaded plugins' schemas without running. CI-friendly.
+- **IDE schema integration**: emit per-plugin JSON Schema for harness
+  autocompletion in VS Code.
+- **Secret rotation notifications.** Providers could emit an event when a secret
+  changes (`core-secrets:rotated`); plugins listen and call `refresh`.
+- **Deep-merge opt-in.** A `mergeStrategy: "deep" | "shallow"` field on
+  `config.schema` for plugins with nested defaults that want deep-merge semantics.
+- **Dotted `kaizen config` paths.** If nested access becomes common, reintroduce
+  dotted paths with explicit separator escaping.


### PR DESCRIPTION
## Summary

This PR contains the output of a plugin tooling brainstorm session covering what's needed to make plugins first-class citizens in kaizen. Four design specs and four matching implementation plans are included.

### Specs

- **`2026-04-18-plugin-marketplace-design.md`** — Federated marketplace catalogs (`.kaizen/marketplace.json`), polymorphic plugin refs (`official/timestamps@1.2.3`, local path, URL, npm), kaizen-level global config (`~/.kaizen/kaizen.json`), portable harness bootstrap (`kaizen --harness <url>` auto-installs missing plugins), unified `kaizen install/uninstall/update` CLI, `kaizen marketplace add|list|remove|update|browse`.

- **`2026-04-18-unified-plugin-config-design.md`** — Declared `config.schema` (JSON Schema) on plugin exports, validated typed `ctx.config`, secrets resolution (eliminates `api_key_env` indirection pattern), merge pipeline (plugin defaults → global → harness → env), `kaizen config show|get|set` CLI.

- **`2026-04-18-plugin-scaffolder-standards-design.md`** — `kaizen plugin create <path>` and `kaizen marketplace create <path>` interactive scaffolders, `kaizen plugin validate` and `kaizen marketplace validate` linters, `docs/plugin-standards.md` coding standards document. Scaffolded output passes validate and `bun test` out of the box.

- **`2026-04-18-builtin-plugins-repo-decoupling-design.md`** — Proposal for `kaizen-sh/kaizen-plugins` repo following the conventional marketplace layout (`plugins/`, `harnesses/`, `.kaizen/marketplace.json`), official marketplace catalog, phased migration from `plugins/*` in this monorepo, build process updates, pre-populated official marketplace on `kaizen init --global`.

### Plans

Each spec has a matching implementation plan with phased, checkbox-style tasks ready for agentic execution via `superpowers:executing-plans` or `superpowers:subagent-driven-development`.

### Key design decisions

- Marketplace = discovery only, not trust. Per-plugin UAC retained for all marketplaces (publisher signing deferred as future work).
- Marketplace ref: `<marketplace-id>/<name>@<version>` canonical form; shape-inferred (no explicit scheme prefix needed).
- Marketplace catalog lives at `.kaizen/marketplace.json` in the repo/directory root — consistent with kaizen's existing `.kaizen/` convention and Claude Code's `.claude/` pattern.
- Conventional layout: `plugins/` and `harnesses/` subfolders inside a marketplace repo.
- Lazy fetch: `kaizen marketplace add` fetches only the catalog file; full repo clone only happens when installing a `file`-source plugin.
- Harness files are self-contained portable artifacts — embedding marketplace refs so `kaizen --harness <url>` works in CI without prior setup.
- URL drift accepted for raw URL refs; versioned marketplace refs are integrity-anchored by the catalog.

### Ordering

These should be implemented in order: Spec 1 → Spec 2 → Spec 3 → Spec 4 (Spec 4 depends on Spec 1's marketplace format existing).

https://claude.ai/code/session_01AwSNWNg5Bfrfnx1TzGvMow