### PR TITLE
feat: plugin & marketplace scaffolders + coding standards (Spec 3/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Review and paste into your plugin's default export.
 
 ### Commands reference
 
+**Plugin authoring:**
+- `kaizen plugin create <path>` — scaffold a new plugin at `<path>` (interactive, or `--defaults` for non-interactive).
+- `kaizen plugin validate [<path>]` — check a plugin directory for compliance (package.json, manifest shape, test file, README). Defaults to `.` if `<path>` is omitted.
+
 **Plugin management:**
 - `kaizen install <plugin>` — resolve, read manifest, run consent flow, write lockfile.
 - `kaizen plugin consent <plugin>` — re-run consent (after version bump or drift).
@@ -85,6 +89,10 @@ Review and paste into your plugin's default export.
 ### Marketplace & plugin management
 
 ```bash
+# Marketplace authoring
+kaizen marketplace create <path>            # Scaffold a new marketplace at <path> (--defaults for non-interactive)
+kaizen marketplace validate [<path>]        # Check marketplace structure (defaults to .)
+
 # Marketplace management
 kaizen marketplace add <url> [--id <id>]   # Register a git-backed marketplace
 kaizen marketplace list                     # List registered marketplaces

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -6,6 +6,49 @@ A kaizen plugin is an npm package that exports a `KaizenPlugin` as its default
 export. Plugins register tools, subscribe to lifecycle events, and optionally
 provide capability roles (executor, UI, lifecycle).
 
+## Creating a plugin
+
+The fastest way to start is the scaffolder:
+
+```bash
+kaizen plugin create ./my-plugin
+```
+
+This runs an interactive prompt and writes all required files under `./my-plugin`.
+Use `--defaults` to skip prompts and accept generated defaults:
+
+```bash
+kaizen plugin create --defaults ./my-plugin
+```
+
+The scaffolder creates:
+- `package.json` — `type: "module"`, `keywords: ["kaizen-plugin"]`, correct `exports`
+- `tsconfig.json` — strict ESNext config
+- `index.ts` — minimal `KaizenPlugin` default export
+- `index.test.ts` — bun:test stubs for metadata and setup smoke-test
+- `README.md` — placeholder docs
+- `.kaizen/.gitkeep` — directory for runtime state and proposed-permissions output
+
+See [`docs/plugin-standards.md`](./plugin-standards.md) for the full coding
+standards that `kaizen plugin validate` enforces.
+
+### Checking compliance
+
+```bash
+kaizen plugin validate [<path>]
+```
+
+Runs structural checks on the plugin directory: `package.json` shape, manifest
+loadability, import scan for flagged modules, presence of a test file and
+`README.md`. Defaults to `.` when `<path>` is omitted. Returns exit code 0 when
+all checks pass (warnings are non-blocking), 1 when any check fails.
+
+> **Note:** `kaizen plugin validate` loads your plugin's entry file at check
+> time. If your plugin imports `kaizen/types` or other workspace packages that
+> are not yet installed locally, the manifest-loadable check will fail. Run
+> `bun install` (or `npm install`) in the plugin directory first, or install the
+> `kaizen` package as a dev dependency.
+
 ## Minimal plugin
 
 ```typescript

--- a/docs/plugin-standards.md
+++ b/docs/plugin-standards.md
@@ -1,0 +1,346 @@
+# Plugin Coding Standards
+
+*Read when: you are writing a kaizen plugin and need to understand required practices and guidelines.*
+
+This document is the canonical reference for kaizen plugin authors. Every rule is marked as `[required]` (enforced by `kaizen plugin validate`) or `[guideline]` (informational, recommended).
+
+---
+
+## 1. Package Structure
+
+### Files and directories
+
+- [required] **`package.json`** with `"type": "module"` (ESM-only)
+- [required] **`exports["."]: "./index.ts"`** or appropriate entry point
+- [required] **`"kaizen-plugin"` keyword** in package.json
+- [required] **`index.ts`** at the package root that exports the plugin (`export default const plugin: KaizenPlugin = { ... }`)
+- [required] **Test suite** — at least one test file (e.g., `index.test.ts`) using `bun:test`
+- [required] **`README.md`** at the package root documenting install, configuration, and permissions
+- [guideline] **`CHANGELOG.md`** tracking version history and breaking changes
+
+### Example package.json
+
+```json
+{
+  "name": "kaizen-plugin-my-tool",
+  "type": "module",
+  "version": "1.0.0",
+  "exports": { ".": "./index.ts" },
+  "keywords": ["kaizen-plugin"],
+  "devDependencies": { "bun": "latest", "@types/bun": "latest" }
+}
+```
+
+---
+
+## 2. Plugin Manifest
+
+### Required fields
+
+- [required] **`name`** in the KaizenPlugin: kebab-case, matches the package.json name (minus the `kaizen-plugin-` prefix) and the config key in `kaizen.json`
+- [required] **`apiVersion`** set to `"2.0.0"` or appropriate major.minor.patch; core warns but loads if major version differs from PLUGIN_API_VERSION
+- [required] **`permissions.tier`** explicitly declared (choose one: `"trusted"`, `"scoped"`, `"unscoped"`); defaults to `"trusted"` if omitted, but explicit declaration is required
+- [required] **`capabilities`** field present in the manifest (may be empty object `{}` if the plugin declares no capabilities)
+
+### Optional fields
+
+- [guideline] **`config.schema`** — if your plugin is configurable, declare a JSON schema describing configuration keys
+- [guideline] **`capabilities.consumes` includes `"core-secrets:provider"`** — if your plugin declares `config.secrets`, explicitly list this capability in `capabilities.consumes` to aid discoverability (it is implicitly required, but listing it makes the dependency explicit)
+
+### Example manifest
+
+```typescript
+const plugin: KaizenPlugin = {
+  name: "my-tool",
+  apiVersion: "2.0.0",
+  capabilities: {
+    provides: ["my-tool:handler"],
+    consumes: ["core-secrets:provider"]
+  },
+  permissions: {
+    tier: "trusted"
+  },
+  config: {
+    schema: {
+      type: "object",
+      properties: {
+        apiKey: { type: "string" }
+      }
+    },
+    secrets: ["apiKey"]
+  },
+  async setup(ctx) {
+    // initialization
+  }
+};
+```
+
+---
+
+## 3. Permission Tier Selection
+
+### Tier guidelines
+
+- [required] Choose one: `"trusted"`, `"scoped"`, or `"unscoped"`
+- [guideline] Default to `"trusted"` — no filesystem, network, or env access unless declared
+- [guideline] Use `"scoped"` when the plugin needs specific, auditable access (e.g., read from workspace `.kaizen/` directory, connect to a specific API)
+- [guideline] Reserve `"unscoped"` for plugins that genuinely need unrestricted access; document justification in `README.md`
+
+### Declaring scoped permissions
+
+```typescript
+permissions: {
+  tier: "scoped",
+  fs: {
+    read: [".kaizen/config.json"],
+    write: [".kaizen/state/**"]
+  },
+  net: {
+    connect: ["api.example.com:443"]
+  }
+}
+```
+
+---
+
+## 4. Capability Naming
+
+### Format and conventions
+
+- [required] Capability names follow the format `<owner-plugin>:<local-name>`
+- [required] `<owner-plugin>` is the kebab-case plugin name (e.g., `my-tool`, `core-lifecycle`)
+- [required] `<local-name>` uses dot-separated kebab-case for nested concepts (e.g., `tool.handler`, `events.before-turn`)
+- [required] Use existing capabilities from core or other plugins when available; do not duplicate
+- [guideline] Document each provided capability with a `defineCapability()` call that includes a human-readable description
+
+### Example
+
+```typescript
+async setup(ctx) {
+  ctx.defineCapability("my-tool:event-handler", {
+    cardinality: "many",
+    description: "Allows other plugins to hook into my-tool's event lifecycle"
+  });
+
+  // Consuming a capability
+}
+```
+
+---
+
+## 5. Configuration
+
+### Schema and defaults
+
+- [required] If your plugin is configurable, declare `config.schema` using JSON Schema (subset)
+- [required] Use `config.schema` for validation; call `validateSchemaItself(schema)` in tests
+- [required] Provide `config.defaults` for optional non-secret keys so users are not required to set them
+
+### Secrets
+
+- [required] For sensitive values (API keys, passwords, tokens), declare them in `config.secrets: ["key1", "key2"]`
+- [required] Access secrets only via `await ctx.secrets.get("key")` — never use legacy `process.env` or `api_key_env`
+- [required] Secrets must be listed in `config.secrets` array; they are not part of schema
+- [required] Document all config keys (both schema and secrets) in your `README.md`, including whether each is a secret and its purpose
+
+### Example
+
+```typescript
+config: {
+  schema: {
+    type: "object",
+    properties: {
+      endpoint: { type: "string" },
+      timeout: { type: "number", default: 30000 }
+    },
+    required: ["endpoint"]
+  },
+  defaults: {
+    timeout: 30000
+  },
+  secrets: ["apiToken"]
+}
+```
+
+In `setup()`:
+
+```typescript
+async setup(ctx) {
+  const endpoint = ctx.config.endpoint as string;
+  const apiToken = await ctx.secrets.get("apiToken");
+  
+  if (!apiToken) {
+    throw new Error("apiToken secret is required");
+  }
+}
+```
+
+---
+
+## 6. Testing
+
+### Test requirements
+
+- [required] At least one test file using `bun:test`
+- [required] Every test must call `setup(ctx)` and execute at least one meaningful action
+- [required] Use the `makeCtx()` pattern (or equivalent) to create a mock `PluginContext` for testing
+- [required] Tests pass with `bun test` with no failures
+
+### Example test
+
+```typescript
+import { test, expect } from "bun:test";
+import plugin from "./index";
+
+function makeCtx() {
+  return {
+    config: {},
+    log: (msg: string) => console.log(`[test] ${msg}`),
+    secrets: { get: async () => undefined },
+    registerTool: () => {},
+    defineCapability: () => {},
+    defineEvent: () => {},
+    on: () => {},
+    emit: async () => [],
+    // ... other context methods as needed
+  };
+}
+
+test("plugin initializes without error", async () => {
+  const ctx = makeCtx();
+  await expect(plugin.setup(ctx)).resolves.toBeUndefined();
+});
+```
+
+---
+
+## 7. Error Handling
+
+### Setup phase
+
+- [required] `setup()` should not throw unless the error is unrecoverable (missing required secret, invalid configuration, incompatible API version)
+- [guideline] Use `ctx.log()` to warn about non-fatal issues (e.g., "Feature X disabled because secret Y is not set")
+
+### Tool execution
+
+- [required] Tool handlers (via `execute()`) must return `{ ok: false, error: "..." }` for errors instead of throwing
+- [required] Core wraps tool exceptions; returning `ToolResult` with `ok: false` is the standard error path
+
+### Event handlers
+
+- [guideline] If an event handler throws, core logs the error and continues with the next handler; do not rely on exception propagation
+
+### Example
+
+```typescript
+const tool: ToolDefinition = {
+  name: "fetch-data",
+  description: "Fetch data from API",
+  parameters: { type: "object" },
+  async execute(args) {
+    try {
+      const response = await fetch("https://api.example.com/data");
+      if (!response.ok) {
+        return { ok: false, error: `API error: ${response.statusText}` };
+      }
+      return { ok: true, data: await response.json() };
+    } catch (err) {
+      return { ok: false, error: `Network error: ${err instanceof Error ? err.message : String(err)}` };
+    }
+  }
+};
+```
+
+---
+
+## 8. Event Handling
+
+### Event declaration and subscription
+
+- [required] Call `ctx.defineEvent(name)` before emitting any event to declare its type
+- [required] Document all events your plugin emits (in README and inline code comments)
+- [required] For cross-plugin event subscriptions, declare `permissions.events.subscribe` with the event patterns you consume
+
+### Example
+
+```typescript
+async setup(ctx) {
+  // Declare events this plugin will emit
+  ctx.defineEvent("my-tool:task-started");
+  ctx.defineEvent("my-tool:task-completed");
+
+  // Subscribe to events from other plugins
+  ctx.on("core-lifecycle:tool:before", async (payload) => {
+    ctx.log(`Tool execution starting: ${payload?.name}`);
+  });
+
+  // Later, emit an event
+  await ctx.emit("my-tool:task-started", { taskId: "123" });
+}
+```
+
+### Permissions for subscriptions
+
+```typescript
+permissions: {
+  tier: "scoped",
+  events: {
+    subscribe: ["core-lifecycle:tool:before", "core-lifecycle:tool:after"]
+  }
+}
+```
+
+---
+
+## 9. Publishing
+
+### Pre-publication checklist
+
+- [required] **`kaizen-plugin` keyword** in package.json
+- [required] **`README.md`** includes:
+  - Installation instructions (how to add to `kaizen.json`)
+  - Configuration section (all schema keys, all secrets)
+  - Permissions section (list permission tier and any scoped grants)
+  - Any required capabilities and what they do
+- [required] Pin or document the **minimum kaizen version** (e.g., "Requires kaizen >= 2.0.0") in README or `package.json` (`minKaizenVersion` field if available)
+- [guideline] Version your plugin following semver; document breaking changes in `CHANGELOG.md`
+
+### Marketplace submission
+
+To list your plugin in the marketplace:
+- Create a PR to `.kaizen/marketplace.json` in the kaizen repository
+- Include your plugin's metadata: name, description, version, source (npm package, tarball, or local path)
+- Link to or provide the version's changelog
+
+---
+
+## 10. API Version Pinning
+
+### Version field
+
+- [required] Set `apiVersion` to the current major version (e.g., `"2.0.0"`)
+- [guideline] Understand that core warns but still loads plugins if their `apiVersion` major version differs from `PLUGIN_API_VERSION`
+- [guideline] Breaking changes in the core plugin API increment the major version; minor updates are backward-compatible within the same major
+
+### Example
+
+```typescript
+const plugin: KaizenPlugin = {
+  name: "my-tool",
+  apiVersion: "2.0.0", // matches current PLUGIN_API_VERSION = "2"
+  // ...
+};
+```
+
+---
+
+## Validation with `kaizen plugin validate`
+
+Run `kaizen plugin validate <path-to-plugin>` to check:
+- All `[required]` rules are met
+- Plugin loads without errors
+- Schema is valid (via `validateSchemaItself()`)
+- Tests pass (`bun test`)
+- Capabilities are properly formatted and declared
+
+Guidelines are not enforced by validation but should be followed for consistency and maintainability.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -220,6 +220,20 @@ if (subcommand === "marketplace") {
   const idIdx = rest.indexOf("--id");
   const id = idIdx >= 0 ? rest[idIdx + 1] : undefined;
 
+  if (sub === "create") {
+    const { runMarketplaceCreate } = await import("./commands/marketplace-create.js");
+    const targetPath = rawArgs[2] ?? ".";
+    const code = await runMarketplaceCreate(targetPath, { defaults: rawArgs.includes("--defaults") });
+    process.exit(code);
+  }
+
+  if (sub === "validate") {
+    const { runMarketplaceValidate } = await import("./commands/marketplace-validate.js");
+    const targetPath = rawArgs[2] ?? ".";
+    const code = await runMarketplaceValidate(targetPath);
+    process.exit(code);
+  }
+
   let code = 0;
   switch (sub) {
     case "add": {
@@ -248,7 +262,7 @@ if (subcommand === "marketplace") {
       break;
     }
     default:
-      console.error("Usage: kaizen marketplace {add|list|remove|update|browse} [args]");
+      console.error("Usage: kaizen marketplace {add|list|remove|update|browse|create|validate} [args]");
       code = 2;
   }
   process.exit(code);
@@ -356,6 +370,20 @@ if (subcommand === "plugin") {
     process.exit(code);
   }
 
+  if (pluginSub === "create") {
+    const { runPluginCreate } = await import("./commands/plugin-create.js");
+    const targetPath = name ?? ".";
+    const code = await runPluginCreate(targetPath, { defaults: rest.includes("--defaults") });
+    process.exit(code);
+  }
+
+  if (pluginSub === "validate") {
+    const { runPluginValidate } = await import("./commands/plugin-validate.js");
+    const targetPath = name ?? ".";
+    const code = await runPluginValidate(targetPath);
+    process.exit(code);
+  }
+
   switch (pluginSub) {
     case "install":
       cmdPluginInstall(rawArgs[2]);
@@ -367,7 +395,7 @@ if (subcommand === "plugin") {
       cmdPluginList(builtins);
       break;
     default:
-      console.error("Usage: kaizen plugin {install|remove|list|consent|review|audit|dev} [args]");
+      console.error("Usage: kaizen plugin {install|remove|list|consent|review|audit|dev|create|validate} [args]");
       process.exit(1);
   }
   process.exit(0);

--- a/src/commands/integration.test.ts
+++ b/src/commands/integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Integration tests: full scaffold → validate workflows.
+ *
+ * Plugin validate: checkManifest will fail because the scaffolded index.ts
+ * imports "kaizen/types", which is not resolvable in a bare temp dir.
+ * That's expected — the manifest check requires `kaizen` to be installed.
+ * The structural checks (package.json, README, test file) should still pass.
+ *
+ * Marketplace validate: no dynamic imports, so full workflow passes cleanly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runPluginCreate } from "./plugin-create.js";
+import { runMarketplaceCreate } from "./marketplace-create.js";
+import { runMarketplaceValidate } from "./marketplace-validate.js";
+import {
+  checkPackageJson,
+  checkFilesPresent,
+  type ValidationResult,
+} from "./plugin-validate.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "kaizen-integration-"));
+}
+
+// ─── Test 1: Full plugin scaffold workflow ────────────────────────────────────
+
+describe("integration: plugin scaffold", () => {
+  let tmpBase: string;
+  let pluginDir: string;
+
+  beforeEach(() => {
+    tmpBase = makeTmpDir();
+    pluginDir = join(tmpBase, "my-integration-plugin");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("runPluginCreate returns 0 and all 6 files exist", async () => {
+    const code = await runPluginCreate(pluginDir, { defaults: true });
+    expect(code).toBe(0);
+
+    expect(existsSync(join(pluginDir, "package.json"))).toBe(true);
+    expect(existsSync(join(pluginDir, "tsconfig.json"))).toBe(true);
+    expect(existsSync(join(pluginDir, "index.ts"))).toBe(true);
+    expect(existsSync(join(pluginDir, "index.test.ts"))).toBe(true);
+    expect(existsSync(join(pluginDir, "README.md"))).toBe(true);
+    expect(existsSync(join(pluginDir, ".kaizen", ".gitkeep"))).toBe(true);
+  });
+
+  it("scaffolded package.json passes checkPackageJson", async () => {
+    await runPluginCreate(pluginDir, { defaults: true });
+
+    const results = await checkPackageJson(pluginDir);
+    const failures = results.filter((r: ValidationResult) => r.status === "fail");
+    expect(failures).toHaveLength(0);
+  });
+
+  it("scaffolded plugin dir passes checkFilesPresent", async () => {
+    await runPluginCreate(pluginDir, { defaults: true });
+
+    const results = await checkFilesPresent(pluginDir);
+    const failures = results.filter((r: ValidationResult) => r.status === "fail");
+    expect(failures).toHaveLength(0);
+  });
+
+  it("scaffolded package.json has correct content (type:module, keywords, exports)", async () => {
+    await runPluginCreate(pluginDir, { defaults: true });
+
+    const pkg = JSON.parse(
+      readFileSync(join(pluginDir, "package.json"), "utf8"),
+    ) as Record<string, unknown>;
+
+    expect(pkg.type).toBe("module");
+    expect(pkg.keywords).toContain("kaizen-plugin");
+    expect((pkg.exports as Record<string, unknown>)["."]).toBe("./index.ts");
+    expect(typeof pkg.version).toBe("string");
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("checkManifest fail is isolated to manifest-loadable rule (kaizen/types not installed)", async () => {
+    // The scaffolded index.ts imports "kaizen/types" which won't resolve in a
+    // bare temp dir. We confirm the failure message references the import
+    // rather than a structural problem (missing exports, wrong shape, etc.).
+    await runPluginCreate(pluginDir, { defaults: true });
+
+    const pkg = JSON.parse(
+      readFileSync(join(pluginDir, "package.json"), "utf8"),
+    ) as Record<string, unknown>;
+
+    const { checkManifest } = await import("./plugin-validate.js");
+    const results = await checkManifest(pluginDir, pkg);
+    const failures = results.filter((r: ValidationResult) => r.status === "fail");
+
+    // There should be exactly one failure, and it must be the loadable rule.
+    // (If kaizen/types somehow resolved, this plugin would load cleanly — that's fine too.)
+    if (failures.length > 0) {
+      expect(failures).toHaveLength(1);
+      const f = failures[0] as ValidationResult;
+      expect(f.rule).toBe("plugin manifest loadable");
+      expect(f.message).toMatch(/kaizen\/types|Cannot find|ERR_MODULE_NOT_FOUND/i);
+    }
+    // If failures.length === 0 then the package resolved (e.g. in CI with kaizen installed) — pass.
+  });
+});
+
+// ─── Test 2: Full marketplace scaffold → validate workflow ────────────────────
+
+describe("integration: marketplace scaffold → validate", () => {
+  let tmpBase: string;
+  let marketDir: string;
+
+  beforeEach(() => {
+    tmpBase = makeTmpDir();
+    marketDir = join(tmpBase, "my-integration-market");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("runMarketplaceCreate → runMarketplaceValidate exits 0", async () => {
+    const createCode = await runMarketplaceCreate(marketDir, { defaults: true });
+    expect(createCode).toBe(0);
+
+    const validateCode = await runMarketplaceValidate(marketDir);
+    expect(validateCode).toBe(0);
+  });
+
+  it("scaffolded marketplace has all required files and dirs", async () => {
+    const code = await runMarketplaceCreate(marketDir, { defaults: true });
+    expect(code).toBe(0);
+
+    expect(existsSync(join(marketDir, ".kaizen", "marketplace.json"))).toBe(true);
+    expect(existsSync(join(marketDir, "plugins", ".gitkeep"))).toBe(true);
+    expect(existsSync(join(marketDir, "harnesses", ".gitkeep"))).toBe(true);
+    expect(existsSync(join(marketDir, "README.md"))).toBe(true);
+  });
+
+  it("scaffolded marketplace.json has correct v1.0.0 shape", async () => {
+    await runMarketplaceCreate(marketDir, { defaults: true });
+
+    const marketplace = JSON.parse(
+      readFileSync(join(marketDir, ".kaizen", "marketplace.json"), "utf8"),
+    ) as Record<string, unknown>;
+
+    expect(marketplace.version).toBe("1.0.0");
+    expect(marketplace.name).toBe("my-integration-market");
+    expect(Array.isArray(marketplace.entries)).toBe(true);
+    expect(marketplace.entries).toHaveLength(0);
+  });
+
+  it("runMarketplaceValidate returns 1 for empty dir (missing marketplace.json)", async () => {
+    // marketDir doesn't exist yet — validate should fail gracefully
+    const code = await runMarketplaceValidate(marketDir);
+    expect(code).toBe(1);
+  });
+});

--- a/src/commands/marketplace-create.test.ts
+++ b/src/commands/marketplace-create.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runMarketplaceCreate } from "./marketplace-create.js";
+import { runMarketplaceValidate } from "./marketplace-validate.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "kaizen-market-create-"));
+}
+
+describe("runMarketplaceCreate", () => {
+  // ─── Test 1: Non-interactive (defaults) mode ────────────────────────────────
+
+  it("generates marketplace scaffold in defaults mode with all files and dirs", async () => {
+    const tmpRoot = makeTmpDir();
+    const targetPath = join(tmpRoot, "my-market");
+
+    const code = await runMarketplaceCreate(targetPath, { defaults: true });
+    expect(code).toBe(0);
+
+    // Check directories exist
+    expect(existsSync(join(targetPath, ".kaizen"))).toBe(true);
+    expect(existsSync(join(targetPath, "plugins"))).toBe(true);
+    expect(existsSync(join(targetPath, "harnesses"))).toBe(true);
+
+    // Check files exist
+    expect(existsSync(join(targetPath, ".kaizen", "marketplace.json"))).toBe(true);
+    expect(existsSync(join(targetPath, "plugins", ".gitkeep"))).toBe(true);
+    expect(existsSync(join(targetPath, "harnesses", ".gitkeep"))).toBe(true);
+    expect(existsSync(join(targetPath, "README.md"))).toBe(true);
+
+    // Validate the generated marketplace with runMarketplaceValidate
+    const validateCode = await runMarketplaceValidate(targetPath);
+    expect(validateCode).toBe(0);
+  });
+
+  // ─── Test 2: Generated marketplace.json has correct shape ────────────────────
+
+  it("generates marketplace.json with correct v1.0.0 shape and entries array", async () => {
+    const tmpRoot = makeTmpDir();
+    const targetPath = join(tmpRoot, "my-market");
+
+    const code = await runMarketplaceCreate(targetPath, { defaults: true });
+    expect(code).toBe(0);
+
+    const marketplaceContent = readFileSync(join(targetPath, ".kaizen", "marketplace.json"), "utf8");
+    const marketplace = JSON.parse(marketplaceContent) as Record<string, unknown>;
+
+    // Check shape
+    expect(marketplace.version).toBe("1.0.0");
+    expect(typeof marketplace.name).toBe("string");
+    expect(marketplace.name).toBe("my-market");
+    expect(typeof marketplace.description).toBe("string");
+    expect(typeof marketplace.url).toBe("string");
+    expect(Array.isArray(marketplace.entries)).toBe(true);
+    expect(marketplace.entries).toEqual([]);
+
+    // Ensure no legacy shape
+    expect(marketplace.plugins).toBeUndefined();
+    expect(marketplace.harnesses).toBeUndefined();
+  });
+
+  // ─── Test 3: Target path already exists → return 1 ─────────────────────────
+
+  it("returns 1 when target path already exists", async () => {
+    const tmpRoot = makeTmpDir();
+    const targetPath = join(tmpRoot, "existing-market");
+
+    // Create the target first
+    await runMarketplaceCreate(targetPath, { defaults: true });
+
+    // Try to create again at the same path
+    const code = await runMarketplaceCreate(targetPath, { defaults: true });
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 4: Default name and description in defaults mode ──────────────────
+
+  it("uses basename as name and generates description in defaults mode", async () => {
+    const tmpRoot = makeTmpDir();
+    const targetPath = join(tmpRoot, "my-custom-market");
+
+    const code = await runMarketplaceCreate(targetPath, { defaults: true });
+    expect(code).toBe(0);
+
+    const marketplaceContent = readFileSync(join(targetPath, ".kaizen", "marketplace.json"), "utf8");
+    const marketplace = JSON.parse(marketplaceContent) as Record<string, unknown>;
+
+    expect(marketplace.name).toBe("my-custom-market");
+    expect(marketplace.description).toBe("Kaizen plugins for my-custom-market.");
+  });
+
+  // ─── Test 5: Default url in defaults mode ────────────────────────────────────
+
+  it("generates a non-empty placeholder URL in defaults mode", async () => {
+    const tmpRoot = makeTmpDir();
+    const targetPath = join(tmpRoot, "my-market");
+
+    const code = await runMarketplaceCreate(targetPath, { defaults: true });
+    expect(code).toBe(0);
+
+    const marketplaceContent = readFileSync(join(targetPath, ".kaizen", "marketplace.json"), "utf8");
+    const marketplace = JSON.parse(marketplaceContent) as Record<string, unknown>;
+
+    expect(typeof marketplace.url).toBe("string");
+    expect(marketplace.url).toBeTruthy(); // non-empty string
+    expect((marketplace.url as string).length).toBeGreaterThan(0);
+  });
+
+  // ─── Test 6: README.md is generated ──────────────────────────────────────────
+
+  it("generates a helpful README.md", async () => {
+    const tmpRoot = makeTmpDir();
+    const targetPath = join(tmpRoot, "my-market");
+
+    const code = await runMarketplaceCreate(targetPath, { defaults: true });
+    expect(code).toBe(0);
+
+    const readmeContent = readFileSync(join(targetPath, "README.md"), "utf8");
+
+    // Check for key content
+    expect(readmeContent).toContain("marketplace");
+    expect(readmeContent).toContain("plugin");
+    expect(readmeContent).toContain("harness");
+    expect(readmeContent).toContain("kind");
+    expect(readmeContent).toContain("source");
+    expect(readmeContent.toLowerCase()).toContain("validate");
+  });
+});

--- a/src/commands/marketplace-create.ts
+++ b/src/commands/marketplace-create.ts
@@ -1,0 +1,201 @@
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { join, basename } from "path";
+import * as readline from "readline";
+
+// ---------------------------------------------------------------------------
+// Marketplace configuration interface
+// ---------------------------------------------------------------------------
+
+export interface MarketplaceConfig {
+  name: string;
+  description: string;
+  url: string;
+}
+
+// ---------------------------------------------------------------------------
+// File generators
+// ---------------------------------------------------------------------------
+
+export function generateMarketplaceJson(cfg: MarketplaceConfig): string {
+  const marketplace = {
+    version: "1.0.0",
+    name: cfg.name,
+    description: cfg.description,
+    url: cfg.url,
+    entries: [],
+  };
+  return JSON.stringify(marketplace, null, 2) + "\n";
+}
+
+export function generateReadme(cfg: MarketplaceConfig): string {
+  return [
+    `# ${cfg.name}`,
+    ``,
+    cfg.description || "_No description provided._",
+    ``,
+    `## What is this marketplace?`,
+    ``,
+    `This marketplace contains Kaizen plugins and harnesses available for your Kaizen installation.`,
+    ``,
+    `## Adding a plugin entry`,
+    ``,
+    `Add entries to \`.kaizen/marketplace.json\` with \`kind: "plugin"\`. Specify a source type:`,
+    ``,
+    `### npm source`,
+    ``,
+    `\`\`\`json`,
+    `{`,
+    `  "kind": "plugin",`,
+    `  "name": "my-plugin",`,
+    `  "description": "A useful plugin",`,
+    `  "versions": [`,
+    `    {`,
+    `      "version": "1.0.0",`,
+    `      "source": {`,
+    `        "type": "npm",`,
+    `        "name": "my-plugin-package",`,
+    `        "version": "1.0.0"`,
+    `      }`,
+    `    }`,
+    `  ]`,
+    `}`,
+    `\`\`\``,
+    ``,
+    `### tarball source`,
+    ``,
+    `\`\`\`json`,
+    `{`,
+    `  "source": {`,
+    `    "type": "tarball",`,
+    `    "url": "https://example.com/my-plugin-1.0.0.tgz",`,
+    `    "sha256": "abc123...def456"`,
+    `  }`,
+    `}`,
+    `\`\`\``,
+    ``,
+    `### file source`,
+    ``,
+    `\`\`\`json`,
+    `{`,
+    `  "source": {`,
+    `    "type": "file",`,
+    `    "path": "plugins/my-plugin/index.ts"`,
+    `  }`,
+    `}`,
+    `\`\`\``,
+    ``,
+    `## Adding a harness entry`,
+    ``,
+    `Add entries with \`kind: "harness"\` and reference the harness path:`,
+    ``,
+    `\`\`\`json`,
+    `{`,
+    `  "kind": "harness",`,
+    `  "name": "my-harness",`,
+    `  "description": "A harness for Kaizen",`,
+    `  "versions": [`,
+    `    {`,
+    `      "version": "1.0.0",`,
+    `      "path": "harnesses/my-harness/kaizen.json"`,
+    `    }`,
+    `  ]`,
+    `}`,
+    `\`\`\``,
+    ``,
+    `## Adding this marketplace to Kaizen`,
+    ``,
+    `Users can add this marketplace with:`,
+    ``,
+    `\`\`\`sh`,
+    `kaizen marketplace add ${cfg.url}`,
+    `\`\`\``,
+    ``,
+    `## Validating the marketplace`,
+    ``,
+    `Before sharing, validate your marketplace:`,
+    ``,
+    `\`\`\`sh`,
+    `kaizen marketplace validate .`,
+    `\`\`\``,
+    ``,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Interactive prompting
+// ---------------------------------------------------------------------------
+
+async function prompt(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => resolve(answer.trim()));
+  });
+}
+
+async function promptConfig(rl: readline.Interface, targetPath: string): Promise<MarketplaceConfig> {
+  const defaultName = basename(targetPath);
+
+  const name = (await prompt(rl, `Marketplace name [${defaultName}]: `)) || defaultName;
+  const description = (await prompt(rl, `Description [Kaizen plugins for ${name}.]: `)) ||
+    `Kaizen plugins for ${name}.`;
+  const url = await prompt(rl, `Marketplace URL []: `);
+
+  return { name, description, url };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function runMarketplaceCreate(
+  targetPath: string,
+  opts: { defaults?: boolean },
+): Promise<number> {
+  // 1. Check target does not exist
+  if (existsSync(targetPath)) {
+    console.error(`Error: target path already exists: ${targetPath}`);
+    return 1;
+  }
+
+  let cfg: MarketplaceConfig;
+
+  if (opts.defaults) {
+    // 2. Defaults mode
+    const name = basename(targetPath);
+    cfg = {
+      name,
+      description: `Kaizen plugins for ${name}.`,
+      url: `https://example.com/${name}`,
+    };
+  } else {
+    // 3. Interactive mode
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    try {
+      cfg = await promptConfig(rl, targetPath);
+    } finally {
+      rl.close();
+    }
+  }
+
+  // 4. Create directories
+  mkdirSync(join(targetPath, ".kaizen"), { recursive: true });
+  mkdirSync(join(targetPath, "plugins"), { recursive: true });
+  mkdirSync(join(targetPath, "harnesses"), { recursive: true });
+
+  // 5. Write files
+  writeFileSync(join(targetPath, ".kaizen", "marketplace.json"), generateMarketplaceJson(cfg));
+  writeFileSync(join(targetPath, "plugins", ".gitkeep"), "");
+  writeFileSync(join(targetPath, "harnesses", ".gitkeep"), "");
+  writeFileSync(join(targetPath, "README.md"), generateReadme(cfg));
+
+  // 6. Print success message
+  const displayPath = `./${basename(targetPath)}`;
+  console.log(`Created marketplace scaffold at ${displayPath}`);
+  console.log(`Next steps:`);
+  console.log(`  Add plugin entries to .kaizen/marketplace.json`);
+  console.log(`  kaizen marketplace validate .`);
+
+  return 0;
+}

--- a/src/commands/marketplace-validate.test.ts
+++ b/src/commands/marketplace-validate.test.ts
@@ -1,0 +1,422 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runMarketplaceValidate } from "./marketplace-validate.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "kaizen-market-validate-"));
+}
+
+function writeMarketplace(dir: string, catalog: unknown): void {
+  const kaizenDir = join(dir, ".kaizen");
+  mkdirSync(kaizenDir, { recursive: true });
+  writeFileSync(join(kaizenDir, "marketplace.json"), JSON.stringify(catalog, null, 2));
+}
+
+function makeValidCatalog(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: "1.0.0",
+    name: "my-org-plugins",
+    description: "Test catalog",
+    url: "https://example.com/marketplace",
+    entries: [],
+    ...overrides,
+  };
+}
+
+// ─── Test 1: Valid entries[] catalog (mixed plugin + harness) ─────────────────
+
+describe("runMarketplaceValidate", () => {
+  it("passes a valid catalog with mixed plugin and harness entries", async () => {
+    const dir = makeTmpDir();
+    // Create referenced harness path
+    const harnessDir = join(dir, "harnesses", "my-harness");
+    mkdirSync(harnessDir, { recursive: true });
+    writeFileSync(join(harnessDir, "kaizen.json"), "{}");
+
+    writeMarketplace(dir, {
+      version: "1.0.0",
+      name: "my-org-plugins",
+      description: "Test catalog",
+      url: "https://example.com/marketplace",
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "A test plugin",
+          versions: [
+            {
+              version: "0.1.0",
+              source: { type: "npm", name: "my-plugin", version: "0.1.0" },
+            },
+          ],
+        },
+        {
+          kind: "harness",
+          name: "my-harness",
+          description: "A test harness",
+          versions: [
+            {
+              version: "0.1.0",
+              path: "harnesses/my-harness/kaizen.json",
+            },
+          ],
+        },
+      ],
+    });
+
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(0);
+  });
+
+  // ─── Test 2: Legacy {plugins, harnesses} shape ──────────────────────────────
+
+  it("fails with migration error for legacy {plugins, harnesses} shape", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, {
+      version: "1.0.0",
+      name: "my-org-plugins",
+      url: "https://example.com",
+      plugins: [{ name: "my-plugin" }],
+      harnesses: [],
+    });
+
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 3: Cross-kind name collision ──────────────────────────────────────
+
+  it("fails when a plugin and harness share the same name", async () => {
+    const dir = makeTmpDir();
+    // Create the harness path so it doesn't fail on that
+    const harnessDir = join(dir, "harnesses", "foo");
+    mkdirSync(harnessDir, { recursive: true });
+    writeFileSync(join(harnessDir, "kaizen.json"), "{}");
+
+    writeMarketplace(dir, {
+      version: "1.0.0",
+      name: "my-org-plugins",
+      url: "https://example.com",
+      entries: [
+        {
+          kind: "plugin",
+          name: "foo",
+          description: "Plugin foo",
+          versions: [{ version: "1.0.0", source: { type: "npm", name: "foo", version: "1.0.0" } }],
+        },
+        {
+          kind: "harness",
+          name: "foo",
+          description: "Harness foo",
+          versions: [{ version: "1.0.0", path: "harnesses/foo/kaizen.json" }],
+        },
+      ],
+    });
+
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 4a: npm valid ──────────────────────────────────────────────────────
+
+  it("passes for valid npm source", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [{ version: "1.0.0", source: { type: "npm", name: "my-plugin", version: "1.0.0" } }],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(0);
+  });
+
+  // ─── Test 4b: npm missing version ───────────────────────────────────────────
+
+  it("fails for npm source missing version", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [{ version: "1.0.0", source: { type: "npm", name: "my-plugin" } }],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 4c: tarball valid ──────────────────────────────────────────────────
+
+  it("passes for valid tarball source", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [
+            {
+              version: "1.0.0",
+              source: { type: "tarball", url: "https://example.com/my-plugin-1.0.0.tgz" },
+            },
+          ],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(0);
+  });
+
+  // ─── Test 4d: tarball bad sha256 ────────────────────────────────────────────
+
+  it("fails for tarball source with wrong-length sha256", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [
+            {
+              version: "1.0.0",
+              source: {
+                type: "tarball",
+                url: "https://example.com/my-plugin-1.0.0.tgz",
+                sha256: "tooshort",
+              },
+            },
+          ],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 4e: file with valid path ──────────────────────────────────────────
+
+  it("passes for file source with existing path", async () => {
+    const dir = makeTmpDir();
+    const pluginsDir = join(dir, "plugins", "my-plugin");
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, "index.ts"), "export default {};");
+
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [
+            {
+              version: "1.0.0",
+              source: { type: "file", path: "plugins/my-plugin/index.ts" },
+            },
+          ],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(0);
+  });
+
+  // ─── Test 4f: file with missing path ────────────────────────────────────────
+
+  it("fails for file source with missing path", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [
+            {
+              version: "1.0.0",
+              source: { type: "file", path: "plugins/my-plugin/index.ts" },
+            },
+          ],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 5: Missing harness path ───────────────────────────────────────────
+
+  it("fails when harness path does not exist", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "harness",
+          name: "my-harness",
+          description: "Harness",
+          versions: [{ version: "1.0.0", path: "harnesses/my-harness/kaizen.json" }],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 6: Bad semver in version ──────────────────────────────────────────
+
+  it("fails when entry version is not valid semver", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [{ version: "v1", source: { type: "npm", name: "my-plugin", version: "1.0.0" } }],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 7: minKaizenVersion with range ────────────────────────────────────
+
+  it("fails when minKaizenVersion is a semver range like ^1.0.0", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [
+            {
+              version: "1.0.0",
+              source: { type: "npm", name: "my-plugin", version: "1.0.0" },
+              minKaizenVersion: "^1.0.0",
+            },
+          ],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 8: minKaizenVersion bare semver ───────────────────────────────────
+
+  it("passes when minKaizenVersion is a bare semver", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [
+            {
+              version: "1.0.0",
+              source: { type: "npm", name: "my-plugin", version: "1.0.0" },
+              minKaizenVersion: "1.0.0",
+            },
+          ],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(0);
+  });
+
+  // ─── Test 9: Missing description ────────────────────────────────────────────
+
+  it("fails when entry description is missing", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          versions: [{ version: "1.0.0", source: { type: "npm", name: "my-plugin", version: "1.0.0" } }],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Test 10: Empty versions array ──────────────────────────────────────────
+
+  it("fails when entry versions array is empty", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  // ─── Additional edge cases ───────────────────────────────────────────────────
+
+  it("fails when .kaizen/marketplace.json is missing", async () => {
+    const dir = makeTmpDir();
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  it("fails when marketplace.json is invalid JSON", async () => {
+    const dir = makeTmpDir();
+    const kaizenDir = join(dir, ".kaizen");
+    mkdirSync(kaizenDir, { recursive: true });
+    writeFileSync(join(kaizenDir, "marketplace.json"), "{ invalid json }");
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  it("fails when version is not 1.0.0", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({ version: "2.0.0" }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  it("fails minKaizenVersion range with >= prefix", async () => {
+    const dir = makeTmpDir();
+    writeMarketplace(dir, makeValidCatalog({
+      entries: [
+        {
+          kind: "plugin",
+          name: "my-plugin",
+          description: "Plugin",
+          versions: [
+            {
+              version: "1.0.0",
+              source: { type: "npm", name: "my-plugin", version: "1.0.0" },
+              minKaizenVersion: ">=1.0.0",
+            },
+          ],
+        },
+      ],
+    }));
+    const code = await runMarketplaceValidate(dir);
+    expect(code).toBe(1);
+  });
+});

--- a/src/commands/marketplace-validate.ts
+++ b/src/commands/marketplace-validate.ts
@@ -1,0 +1,280 @@
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const SEMVER_RE = /^\d+\.\d+\.\d+/;
+const BARE_SEMVER_RE = /^\d+\.\d+\.\d+$/;
+const SEMVER_RANGE_PREFIX = /^[\^~>=<]/;
+const NAME_RE = /^[a-z][a-z0-9-]*$/;
+const SHA256_RE = /^[0-9a-fA-F]{64}$/;
+
+export interface ValidationResult {
+  rule: string;
+  status: "pass" | "fail";
+  message?: string;
+}
+
+function pass(rule: string): ValidationResult {
+  return { rule, status: "pass" };
+}
+
+function fail(rule: string, message: string): ValidationResult {
+  return { rule, status: "fail", message };
+}
+
+function validateSource(
+  dir: string,
+  source: Record<string, unknown>,
+  prefix: string,
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+  const type = source.type;
+
+  if (type === "npm") {
+    const name = source.name;
+    const version = source.version;
+    if (!name || typeof name !== "string" || name.trim() === "") {
+      results.push(fail(`${prefix}: npm source name`, `${prefix}: npm source missing non-empty name`));
+    } else {
+      results.push(pass(`${prefix}: npm source name`));
+    }
+    if (!version || typeof version !== "string" || !SEMVER_RE.test(version)) {
+      results.push(fail(`${prefix}: npm source version semver`, `${prefix}: npm source version "${String(version)}" is not semver`));
+    } else {
+      results.push(pass(`${prefix}: npm source version semver`));
+    }
+  } else if (type === "tarball") {
+    const url = source.url;
+    if (!url || typeof url !== "string" || url.trim() === "") {
+      results.push(fail(`${prefix}: tarball source url`, `${prefix}: tarball source missing non-empty url`));
+    } else {
+      results.push(pass(`${prefix}: tarball source url`));
+    }
+    if (source.sha256 !== undefined) {
+      if (typeof source.sha256 !== "string" || !SHA256_RE.test(source.sha256)) {
+        results.push(fail(`${prefix}: tarball source sha256`, `${prefix}: tarball source sha256 must be 64 hex chars, got "${String(source.sha256)}"`));
+      } else {
+        results.push(pass(`${prefix}: tarball source sha256`));
+      }
+    }
+  } else if (type === "file") {
+    const path = source.path;
+    if (!path || typeof path !== "string" || path.trim() === "") {
+      results.push(fail(`${prefix}: file source path`, `${prefix}: file source missing non-empty path`));
+    } else {
+      const abs = join(dir, path);
+      if (!existsSync(abs)) {
+        results.push(fail(`${prefix}: file source path exists`, `${prefix}: file source path '${path}' not found`));
+      } else {
+        results.push(pass(`${prefix}: file source path exists`));
+      }
+    }
+  } else {
+    results.push(fail(`${prefix}: source type`, `${prefix}: unknown source type "${String(type)}"`));
+  }
+
+  return results;
+}
+
+export async function runMarketplaceValidate(dir: string): Promise<number> {
+  console.log(`kaizen marketplace validate ${dir}\n`);
+
+  const results: ValidationResult[] = [];
+  const catalogPath = join(dir, ".kaizen", "marketplace.json");
+
+  // 1. File exists
+  if (!existsSync(catalogPath)) {
+    results.push(fail(".kaizen/marketplace.json present", ".kaizen/marketplace.json not found"));
+    printResults(results);
+    return 1;
+  }
+  results.push(pass(".kaizen/marketplace.json present"));
+
+  // 2. Parse JSON
+  let catalog: Record<string, unknown>;
+  try {
+    catalog = JSON.parse(readFileSync(catalogPath, "utf8")) as Record<string, unknown>;
+  } catch {
+    results.push(fail("marketplace.json parseable", "Failed to parse marketplace.json: invalid JSON"));
+    printResults(results);
+    return 1;
+  }
+  results.push(pass("marketplace.json parseable"));
+
+  // 3. Legacy shape rejection
+  if (
+    Array.isArray((catalog as Record<string, unknown>).plugins) ||
+    Array.isArray((catalog as Record<string, unknown>).harnesses)
+  ) {
+    results.push(
+      fail(
+        "entries[] shape",
+        "marketplace.json uses the legacy {plugins, harnesses} shape; convert to entries[] with kind tags per Spec 1.",
+      ),
+    );
+    printResults(results);
+    return 1;
+  }
+
+  // 4. version = "1.0.0"
+  if (catalog.version !== "1.0.0") {
+    results.push(fail("version: 1.0.0", `version must be "1.0.0", got ${JSON.stringify(catalog.version)}`));
+  } else {
+    results.push(pass("version: 1.0.0"));
+  }
+
+  // 5. name non-empty string
+  if (!catalog.name || typeof catalog.name !== "string" || catalog.name.trim() === "") {
+    results.push(fail("name non-empty", "name must be a non-empty string"));
+  } else {
+    results.push(pass(`name: ${catalog.name}`));
+  }
+
+  // 6. url non-empty string
+  if (!catalog.url || typeof catalog.url !== "string" || catalog.url.trim() === "") {
+    results.push(fail("url non-empty", "url must be a non-empty string"));
+  } else {
+    results.push(pass(`url: ${catalog.url}`));
+  }
+
+  // 7. entries is array
+  if (!Array.isArray(catalog.entries)) {
+    results.push(fail("entries is array", "entries must be an array"));
+    printResults(results);
+    return 1;
+  }
+  results.push(pass("entries is array"));
+
+  const entries = catalog.entries as Record<string, unknown>[];
+
+  // 9. Cross-kind name uniqueness (pre-scan before per-entry checks)
+  const nameMap = new Map<string, string>(); // name -> kind
+  for (const entry of entries) {
+    const entryName = typeof (entry as Record<string, unknown>).name === "string" ? (entry as Record<string, unknown>).name as string : "";
+    const entryKind = typeof (entry as Record<string, unknown>).kind === "string" ? (entry as Record<string, unknown>).kind as string : "";
+    if (entryName && entryKind) {
+      if (nameMap.has(entryName)) {
+        const existingKind = nameMap.get(entryName)!;
+        results.push(
+          fail(
+            `entry name uniqueness: '${entryName}'`,
+            `entry name '${entryName}' is used by both a ${existingKind} and a ${entryKind}`,
+          ),
+        );
+      } else {
+        nameMap.set(entryName, entryKind);
+      }
+    }
+  }
+
+  // 8. Per-entry checks
+  let entryIdx = 0;
+  for (const entry of entries) {
+    const i = entryIdx++;
+    const entryName = typeof entry.name === "string" ? entry.name : `[${i}]`;
+    const prefix = `entry '${entryName}'`;
+
+    // kind
+    const kind = entry.kind;
+    if (kind !== "plugin" && kind !== "harness") {
+      results.push(fail(`${prefix}: kind`, `${prefix}: kind must be "plugin" or "harness", got ${JSON.stringify(kind)}`));
+      continue;
+    }
+    results.push(pass(`${prefix}: kind`));
+
+    // name matches regex
+    if (!NAME_RE.test(entryName)) {
+      results.push(fail(`${prefix}: name format`, `${prefix}: name "${entryName}" must match ^[a-z][a-z0-9-]*$`));
+    } else {
+      results.push(pass(`${prefix}: name format`));
+    }
+
+    // description non-empty
+    if (!entry.description || typeof entry.description !== "string" || entry.description.trim() === "") {
+      results.push(fail(`${prefix}: description`, `${prefix}: description must be a non-empty string`));
+    } else {
+      results.push(pass(`${prefix}: description`));
+    }
+
+    // versions non-empty array
+    if (!Array.isArray(entry.versions) || entry.versions.length === 0) {
+      results.push(fail(`${prefix}: versions non-empty`, `${prefix}: versions must be a non-empty array`));
+      continue;
+    }
+    results.push(pass(`${prefix}: versions non-empty`));
+
+    const versions = entry.versions as Record<string, unknown>[];
+    let verIdx = 0;
+    for (const ver of versions) {
+      const j = verIdx++;
+      const verStr = typeof ver.version === "string" ? ver.version : `[${j}]`;
+      const vprefix = `${prefix}: version '${verStr}'`;
+
+      // version is valid semver
+      if (!ver.version || typeof ver.version !== "string" || !SEMVER_RE.test(ver.version)) {
+        results.push(fail(`${vprefix}: semver`, `${vprefix}: version "${String(ver.version)}" is not valid semver`));
+      } else {
+        results.push(pass(`${vprefix}: semver`));
+      }
+
+      if (kind === "plugin") {
+        // source must be present and valid
+        if (!ver.source || typeof ver.source !== "object") {
+          results.push(fail(`${vprefix}: source present`, `${vprefix}: source must be present`));
+        } else {
+          results.push(pass(`${vprefix}: source present`));
+          const sourceResults = validateSource(dir, ver.source as Record<string, unknown>, vprefix);
+          results.push(...sourceResults);
+        }
+      } else if (kind === "harness") {
+        // path non-empty and exists
+        const harnessPath = ver.path;
+        if (!harnessPath || typeof harnessPath !== "string" || harnessPath.trim() === "") {
+          results.push(fail(`${vprefix}: path non-empty`, `${vprefix}: path must be a non-empty string`));
+        } else {
+          const abs = join(dir, harnessPath);
+          if (!existsSync(abs)) {
+            results.push(fail(`${vprefix}: path exists`, `${vprefix}: harness path '${harnessPath}' not found`));
+          } else {
+            results.push(pass(`${vprefix}: path exists`));
+          }
+        }
+      }
+
+      // optional minKaizenVersion: bare semver only (no ranges)
+      if (ver.minKaizenVersion !== undefined) {
+        const mkv = ver.minKaizenVersion;
+        if (typeof mkv !== "string" || SEMVER_RANGE_PREFIX.test(mkv) || !BARE_SEMVER_RE.test(mkv)) {
+          results.push(
+            fail(
+              `${vprefix}: minKaizenVersion`,
+              `${vprefix}: minKaizenVersion "${String(mkv)}" must be a bare semver (e.g. "1.0.0"), not a range`,
+            ),
+          );
+        } else {
+          results.push(pass(`${vprefix}: minKaizenVersion`));
+        }
+      }
+    }
+  }
+
+  printResults(results);
+  return results.some((r) => r.status === "fail") ? 1 : 0;
+}
+
+function printResults(results: ValidationResult[]): void {
+  for (const r of results) {
+    if (r.status === "fail") {
+      console.log(`  ✗ ${r.message ?? r.rule}`);
+    } else {
+      console.log(`  ✓ ${r.rule}`);
+    }
+  }
+
+  const failures = results.filter((r) => r.status === "fail");
+  console.log("");
+  if (failures.length > 0) {
+    console.log(`${failures.length} error(s) found.`);
+  } else {
+    console.log("All checks passed.");
+  }
+}

--- a/src/commands/plugin-create.test.ts
+++ b/src/commands/plugin-create.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, existsSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runPluginCreate } from "./plugin-create.js";
+
+// Note: Full runPluginValidate integration test (checking the generated index.ts loads cleanly)
+// requires "kaizen/types" to be resolvable as a package. That integration test will run after
+// Task 7 wires the CLI and the package is published. For now we verify file structure only.
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "kaizen-create-"));
+}
+
+describe("runPluginCreate", () => {
+  let tmpBase: string;
+  let targetPath: string;
+
+  beforeEach(() => {
+    tmpBase = makeTmpDir();
+    targetPath = join(tmpBase, "my-plugin");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  describe("defaults mode", () => {
+    it("creates all required files", async () => {
+      const code = await runPluginCreate(targetPath, { defaults: true });
+      expect(code).toBe(0);
+
+      expect(existsSync(join(targetPath, "package.json"))).toBe(true);
+      expect(existsSync(join(targetPath, "tsconfig.json"))).toBe(true);
+      expect(existsSync(join(targetPath, "index.ts"))).toBe(true);
+      expect(existsSync(join(targetPath, "index.test.ts"))).toBe(true);
+      expect(existsSync(join(targetPath, "README.md"))).toBe(true);
+      expect(existsSync(join(targetPath, ".kaizen", ".gitkeep"))).toBe(true);
+    });
+
+    it("generates valid package.json", async () => {
+      await runPluginCreate(targetPath, { defaults: true });
+      const pkg = JSON.parse(readFileSync(join(targetPath, "package.json"), "utf8")) as Record<string, unknown>;
+      expect(pkg.name).toBe("my-plugin");
+      expect(pkg.version).toBe("0.1.0");
+      expect(pkg.type).toBe("module");
+      expect(pkg.keywords).toContain("kaizen-plugin");
+      expect((pkg.exports as Record<string, unknown>)["."]).toBe("./index.ts");
+    });
+
+    it("generates valid tsconfig.json", async () => {
+      await runPluginCreate(targetPath, { defaults: true });
+      const tsconfig = JSON.parse(readFileSync(join(targetPath, "tsconfig.json"), "utf8")) as Record<string, unknown>;
+      const opts = tsconfig.compilerOptions as Record<string, unknown>;
+      expect(opts.target).toBe("ESNext");
+      expect(opts.strict).toBe(true);
+    });
+
+    it("generates index.ts with correct plugin shape", async () => {
+      await runPluginCreate(targetPath, { defaults: true });
+      const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+      expect(src).toContain(`name: "my-plugin"`);
+      expect(src).toContain(`apiVersion: "2.0.0"`);
+      expect(src).toContain(`tier: "trusted"`);
+      expect(src).toContain(`export default plugin`);
+    });
+
+    it("generates index.test.ts with bun:test imports", async () => {
+      await runPluginCreate(targetPath, { defaults: true });
+      const src = readFileSync(join(targetPath, "index.test.ts"), "utf8");
+      expect(src).toContain(`from "bun:test"`);
+      expect(src).toContain(`has correct metadata`);
+      expect(src).toContain(`setup runs without error`);
+    });
+
+    it("generates README.md with plugin name", async () => {
+      await runPluginCreate(targetPath, { defaults: true });
+      const readme = readFileSync(join(targetPath, "README.md"), "utf8");
+      expect(readme).toContain("# my-plugin");
+      expect(readme).toContain("Installation");
+    });
+
+    it("uses basename of targetPath as name", async () => {
+      const nestedTarget = join(tmpBase, "nested", "my-nested-plugin");
+      const code = await runPluginCreate(nestedTarget, { defaults: true });
+      expect(code).toBe(0);
+      const pkg = JSON.parse(readFileSync(join(nestedTarget, "package.json"), "utf8")) as Record<string, unknown>;
+      expect(pkg.name).toBe("my-nested-plugin");
+    });
+  });
+
+  describe("target exists error", () => {
+    it("returns 1 if target path already exists", async () => {
+      // Create the dir first
+      await runPluginCreate(targetPath, { defaults: true });
+
+      // Try again — should fail
+      const code = await runPluginCreate(targetPath, { defaults: true });
+      expect(code).toBe(1);
+    });
+  });
+});

--- a/src/commands/plugin-create.ts
+++ b/src/commands/plugin-create.ts
@@ -1,0 +1,440 @@
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { join, basename } from "path";
+import * as readline from "readline";
+
+// ---------------------------------------------------------------------------
+// Config interface
+// ---------------------------------------------------------------------------
+
+export interface ConfigKey {
+  name: string;
+  type: string;
+  required: boolean;
+  secret: boolean;
+}
+
+export interface PluginScaffoldConfig {
+  name: string;
+  description: string;
+  tier: "trusted" | "scoped" | "unscoped";
+  grants: Array<"fs" | "net" | "env" | "exec" | "events">;
+  provides: string[];
+  consumes: string[];
+  hasConfig: boolean;
+  configKeys: ConfigKey[];
+}
+
+// ---------------------------------------------------------------------------
+// File generators
+// ---------------------------------------------------------------------------
+
+export function generatePackageJson(cfg: PluginScaffoldConfig): string {
+  const pkg = {
+    name: cfg.name,
+    version: "0.1.0",
+    description: cfg.description,
+    type: "module",
+    exports: { ".": "./index.ts" },
+    keywords: ["kaizen-plugin"],
+    devDependencies: {
+      "@types/bun": "latest",
+      typescript: "^5.4.0",
+    },
+  };
+  return JSON.stringify(pkg, null, 2) + "\n";
+}
+
+export function generateTsConfig(): string {
+  const tsconfig = {
+    compilerOptions: {
+      target: "ESNext",
+      module: "ESNext",
+      moduleResolution: "bundler",
+      strict: true,
+      skipLibCheck: true,
+    },
+  };
+  return JSON.stringify(tsconfig, null, 2) + "\n";
+}
+
+export function generateIndexTs(cfg: PluginScaffoldConfig): string {
+  const secretKeys = cfg.configKeys.filter((k) => k.secret);
+  const nonSecretKeys = cfg.configKeys.filter((k) => !k.secret);
+
+  // Build consumes array — add core-secrets:provider if secrets exist
+  const consumesArr = [...cfg.consumes];
+  if (secretKeys.length > 0 && !consumesArr.includes("core-secrets:provider")) {
+    consumesArr.push("core-secrets:provider");
+  }
+
+  // Build permissions block
+  const permissionsLines: string[] = [`  tier: "${cfg.tier}",`];
+  for (const grant of cfg.grants) {
+    if (grant === "events") {
+      permissionsLines.push(`  ${grant}: { subscribe: ["*"] },`);
+    } else {
+      permissionsLines.push(`  ${grant}: ["*"],`);
+    }
+  }
+
+  // Build capabilities block
+  const capsLines: string[] = [];
+  if (cfg.provides.length > 0) {
+    const provStr = cfg.provides.map((p) => `"${p}"`).join(", ");
+    capsLines.push(`    provides: [${provStr}],`);
+  }
+  if (consumesArr.length > 0) {
+    const consStr = consumesArr.map((c) => `"${c}"`).join(", ");
+    capsLines.push(`    consumes: [${consStr}],`);
+  }
+
+  // Build config block
+  let configBlock = "";
+  if (cfg.hasConfig && cfg.configKeys.length > 0) {
+    const allRequired = cfg.configKeys.filter((k) => k.required).map((k) => k.name);
+    const propLines = cfg.configKeys.map(
+      (k) => `      ${k.name}: { type: "${k.type}", description: "${k.name} config value." },`
+    );
+    const defaultLines = nonSecretKeys
+      .filter((k) => k.type === "number")
+      .map((k) => `      ${k.name}: 0,`);
+
+    const secretsLine =
+      secretKeys.length > 0
+        ? `    secrets: [${secretKeys.map((k) => `"${k.name}"`).join(", ")}],\n`
+        : "";
+
+    const requiredLine =
+      allRequired.length > 0
+        ? `      required: [${allRequired.map((r) => `"${r}"`).join(", ")}],\n`
+        : "";
+
+    configBlock =
+      `\n  config: {\n` +
+      `    schema: {\n` +
+      `      type: "object",\n` +
+      `      properties: {\n` +
+      propLines.join("\n") +
+      "\n" +
+      `      },\n` +
+      requiredLine +
+      `    },\n` +
+      (defaultLines.length > 0
+        ? `    defaults: {\n` + defaultLines.join("\n") + `\n    },\n`
+        : "") +
+      secretsLine +
+      `  },`;
+  }
+
+  // Build setup body
+  const setupLines: string[] = [];
+  if (secretKeys.length > 0) {
+    const first = secretKeys[0]!;
+    setupLines.push(`    const ${first.name} = await ctx.secrets.get("${first.name}");`);
+  }
+  setupLines.push("    ctx.log(`" + cfg.name + " setup complete`);");
+
+  const lines: string[] = [
+    `import type { KaizenPlugin } from "kaizen/types";`,
+    ``,
+    `const plugin: KaizenPlugin = {`,
+    `  name: "${cfg.name}",`,
+    `  apiVersion: "2.0.0",`,
+    `  permissions: {`,
+    ...permissionsLines,
+    `  },`,
+    `  capabilities: {`,
+    ...capsLines,
+    `  },`,
+  ];
+
+  if (configBlock) {
+    lines.push(configBlock);
+  }
+
+  lines.push(
+    ``,
+    `  async setup(ctx) {`,
+    ...setupLines,
+    `  },`,
+    `};`,
+    ``,
+    `export default plugin;`,
+    ``
+  );
+
+  return lines.join("\n");
+}
+
+export function generateIndexTestTs(cfg: PluginScaffoldConfig): string {
+  const secretKeys = cfg.configKeys.filter((k) => k.secret);
+  const nonSecretKeys = cfg.configKeys.filter((k) => !k.secret);
+
+  // Build config defaults for context
+  const configDefaults: string[] = [];
+  for (const k of nonSecretKeys) {
+    if (k.type === "number") {
+      configDefaults.push(`    ${k.name}: 0,`);
+    }
+    // string non-secrets — skip (no default)
+  }
+
+  const configObj =
+    configDefaults.length > 0
+      ? `{\n${configDefaults.join("\n")}\n  }`
+      : `{}`;
+
+  // For secrets in setup test: mock the first secret
+  let secretsMockGet: string;
+  if (secretKeys.length > 0) {
+    const first = secretKeys[0]!;
+    secretsMockGet =
+      `mock(async (_key: string): Promise<string | undefined> => ` +
+      `_key === "${first.name}" ? "test-value" : undefined)`;
+  } else {
+    secretsMockGet = `mock(async (_key: string): Promise<string | undefined> => undefined)`;
+  }
+
+  return [
+    `import { describe, it, expect, mock } from "bun:test";`,
+    `import plugin from "./index.ts";`,
+    ``,
+    `function makeCtx() {`,
+    `  return {`,
+    `    log: mock(() => {}),`,
+    `    config: ${configObj},`,
+    `    registerTool: mock(() => {}),`,
+    `    on: mock(() => {}),`,
+    `    defineEvent: mock(() => {}),`,
+    `    emit: mock(async () => []),`,
+    `    secrets: {`,
+    `      get: ${secretsMockGet},`,
+    `      refresh: mock(async (_key: string): Promise<string | undefined> => undefined),`,
+    `    },`,
+    `    capabilities: { register: mock(() => {}) },`,
+    `  } as any;`,
+    `}`,
+    ``,
+    `describe("${cfg.name}", () => {`,
+    `  it("has correct metadata", () => {`,
+    `    expect(plugin.name).toBe("${cfg.name}");`,
+    `    expect(plugin.apiVersion).toBe("2.0.0");`,
+    `  });`,
+    ``,
+    `  it("setup runs without error", async () => {`,
+    `    const ctx = makeCtx();`,
+    `    await plugin.setup(ctx);`,
+    `    expect(ctx.log).toHaveBeenCalled();`,
+    `  });`,
+    `});`,
+    ``,
+  ].join("\n");
+}
+
+export function generateReadme(cfg: PluginScaffoldConfig): string {
+  const hasSecretKeys = cfg.configKeys.some((k) => k.secret);
+  const hasConfigKeys = cfg.configKeys.length > 0;
+
+  const configTable =
+    hasConfigKeys
+      ? [
+          `| Key | Type | Required | Secret |`,
+          `|-----|------|----------|--------|`,
+          ...cfg.configKeys.map(
+            (k) =>
+              `| \`${k.name}\` | \`${k.type}\` | ${k.required ? "Yes" : "No"} | ${k.secret ? "Yes" : "No"} |`
+          ),
+        ].join("\n")
+      : "_No configuration keys defined._";
+
+  const secretsNote = hasSecretKeys
+    ? [
+        ``,
+        `## Secrets`,
+        ``,
+        `The following keys are treated as secrets and must be set separately:`,
+        ``,
+        ...cfg.configKeys
+          .filter((k) => k.secret)
+          .map((k) => `\`\`\`sh\nkaizen config set-secret ${cfg.name} ${k.name}\n\`\`\``),
+        ``,
+        `> Note: Secrets do NOT require an \`env\` grant — they are accessed through the secrets context.`,
+      ].join("\n")
+    : "";
+
+  const grantsList =
+    cfg.grants.length > 0
+      ? cfg.grants.map((g) => `- \`${g}\``).join("\n")
+      : "_No additional grants required._";
+
+  return [
+    `# ${cfg.name}`,
+    ``,
+    cfg.description || "_No description provided._",
+    ``,
+    `## Installation`,
+    ``,
+    `\`\`\`sh`,
+    `kaizen plugin install <marketplace>/${cfg.name}`,
+    `\`\`\``,
+    ``,
+    `## Configuration`,
+    ``,
+    configTable,
+    secretsNote,
+    ``,
+    `## Harness`,
+    ``,
+    `Add to your \`kaizen.json\`:`,
+    ``,
+    `\`\`\`json`,
+    `{`,
+    `  "plugins": ["<marketplace>/${cfg.name}@0.1.0"]`,
+    `}`,
+    `\`\`\``,
+    ``,
+    `## Permissions`,
+    ``,
+    `Tier: \`${cfg.tier}\``,
+    ``,
+    grantsList,
+    ``,
+    `## Development`,
+    ``,
+    `\`\`\`sh`,
+    `bun install`,
+    `bun test`,
+    `kaizen plugin validate .`,
+    `\`\`\``,
+    ``,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Interactive prompting
+// ---------------------------------------------------------------------------
+
+async function prompt(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => resolve(answer.trim()));
+  });
+}
+
+async function promptConfig(rl: readline.Interface, targetPath: string): Promise<PluginScaffoldConfig> {
+  const defaultName = basename(targetPath);
+
+  const name = (await prompt(rl, `Plugin name [${defaultName}]: `)) || defaultName;
+  const description = await prompt(rl, `Description: `);
+  const tierInput = await prompt(rl, `Tier (trusted/scoped/unscoped) [trusted]: `);
+  const tier = (["trusted", "scoped", "unscoped"].includes(tierInput) ? tierInput : "trusted") as
+    | "trusted"
+    | "scoped"
+    | "unscoped";
+
+  const grantsInput = await prompt(rl, `Grants (comma-separated: fs,net,env,exec,events) [none]: `);
+  const grants = grantsInput
+    ? (grantsInput
+        .split(",")
+        .map((g) => g.trim())
+        .filter((g) => ["fs", "net", "env", "exec", "events"].includes(g)) as Array<
+        "fs" | "net" | "env" | "exec" | "events"
+      >)
+    : [];
+
+  const providesInput = await prompt(rl, `Capabilities provided (comma-separated) [none]: `);
+  const provides = providesInput ? providesInput.split(",").map((s) => s.trim()).filter(Boolean) : [];
+
+  const consumesInput = await prompt(rl, `Capabilities consumed (comma-separated) [none]: `);
+  const consumes = consumesInput ? consumesInput.split(",").map((s) => s.trim()).filter(Boolean) : [];
+
+  const hasConfigInput = await prompt(rl, `Does this plugin have config? (y/N) [N]: `);
+  const hasConfig = hasConfigInput.toLowerCase() === "y";
+
+  const configKeys: ConfigKey[] = [];
+  if (hasConfig) {
+    const keysInput = await prompt(rl, `Config key names (comma-separated): `);
+    const keyNames = keysInput.split(",").map((s) => s.trim()).filter(Boolean);
+    for (const keyName of keyNames) {
+      const typeInput = (await prompt(rl, `  ${keyName} type (string/number) [string]: `)) || "string";
+      const requiredInput = await prompt(rl, `  ${keyName} required? (y/N) [N]: `);
+      const secretInput = await prompt(rl, `  ${keyName} secret? (y/N) [N]: `);
+      configKeys.push({
+        name: keyName,
+        type: ["string", "number"].includes(typeInput) ? typeInput : "string",
+        required: requiredInput.toLowerCase() === "y",
+        secret: secretInput.toLowerCase() === "y",
+      });
+    }
+  }
+
+  return { name, description, tier, grants, provides, consumes, hasConfig, configKeys };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function runPluginCreate(
+  targetPath: string,
+  opts: { defaults?: boolean }
+): Promise<number> {
+  // 1. Check target does not exist
+  if (existsSync(targetPath)) {
+    console.error(`Error: target path already exists: ${targetPath}`);
+    return 1;
+  }
+
+  let cfg: PluginScaffoldConfig;
+
+  if (opts.defaults) {
+    // 2. Defaults mode
+    cfg = {
+      name: basename(targetPath),
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+    };
+  } else {
+    // 3. Interactive mode
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    try {
+      cfg = await promptConfig(rl, targetPath);
+    } finally {
+      rl.close();
+    }
+  }
+
+  // 4. Create directory
+  mkdirSync(targetPath, { recursive: true });
+
+  // 5. Write files
+  writeFileSync(join(targetPath, "package.json"), generatePackageJson(cfg));
+  writeFileSync(join(targetPath, "tsconfig.json"), generateTsConfig());
+  writeFileSync(join(targetPath, "index.ts"), generateIndexTs(cfg));
+  writeFileSync(join(targetPath, "index.test.ts"), generateIndexTestTs(cfg));
+  writeFileSync(join(targetPath, "README.md"), generateReadme(cfg));
+
+  // 6. Create .kaizen dir
+  mkdirSync(join(targetPath, ".kaizen"), { recursive: true });
+
+  // 7. Write .gitkeep
+  writeFileSync(join(targetPath, ".kaizen", ".gitkeep"), "");
+
+  // 8. Print success message
+  const displayPath = `./${basename(targetPath)}`;
+  console.log(`Created plugin scaffold at ${displayPath}`);
+  console.log(`Next steps:`);
+  console.log(`  cd ${basename(targetPath)}`);
+  console.log(`  bun install`);
+  console.log(`  bun test`);
+  console.log(`  kaizen plugin validate .`);
+
+  return 0;
+}

--- a/src/commands/plugin-validate.test.ts
+++ b/src/commands/plugin-validate.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  checkPackageJson,
+  checkManifest,
+  checkConfigSchema,
+  scanImports,
+  checkFilesPresent,
+  runPluginValidate,
+} from "./plugin-validate.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "kaizen-validate-"));
+}
+
+function writeJson(dir: string, name: string, data: unknown): void {
+  writeFileSync(join(dir, name), JSON.stringify(data, null, 2));
+}
+
+function writePkg(dir: string, overrides: Record<string, unknown> = {}): void {
+  writeJson(dir, "package.json", {
+    name: "my-plugin",
+    version: "1.0.0",
+    type: "module",
+    exports: { ".": "./index.ts" },
+    keywords: ["kaizen-plugin"],
+    ...overrides,
+  });
+}
+
+function writeValidPlugin(dir: string, overrides: Record<string, unknown> = {}): void {
+  const plugin = {
+    name: "my-plugin",
+    apiVersion: "2.0.0",
+    permissions: { tier: "trusted" },
+    capabilities: {},
+    setup: async () => {},
+    ...overrides,
+  };
+  // Write as a TS file that Bun can import
+  const src = `const plugin = ${JSON.stringify({ ...plugin, setup: undefined })};
+plugin.setup = async () => {};
+export default plugin;
+`;
+  writeFileSync(join(dir, "index.ts"), src);
+}
+
+// ─── checkPackageJson ─────────────────────────────────────────────────────────
+
+describe("checkPackageJson", () => {
+  it("passes for a fully valid package.json", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir);
+    const results = await checkPackageJson(dir);
+    expect(results.every((r) => r.status === "pass")).toBe(true);
+  });
+
+  it("fails when package.json is missing", async () => {
+    const dir = makeTmpDir();
+    const results = await checkPackageJson(dir);
+    expect(results.some((r) => r.rule === "package.json present" && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when name is not kebab-case", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir, { name: "MyPlugin" });
+    const results = await checkPackageJson(dir);
+    expect(results.some((r) => r.rule.includes("kebab") && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when type is not module", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir, { type: "commonjs" });
+    const results = await checkPackageJson(dir);
+    expect(results.some((r) => r.rule === "type: module" && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when exports[\".\"] is missing", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir, { exports: {} });
+    const results = await checkPackageJson(dir);
+    expect(results.some((r) => r.rule.includes('exports') && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when keywords does not include kaizen-plugin", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir, { keywords: ["some-other-keyword"] });
+    const results = await checkPackageJson(dir);
+    expect(results.some((r) => r.rule.includes("kaizen-plugin") && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when version is missing", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir, { version: undefined });
+    const results = await checkPackageJson(dir);
+    expect(results.some((r) => r.rule.includes("version") && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when version is not semver", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir, { version: "v1" });
+    const results = await checkPackageJson(dir);
+    expect(results.some((r) => r.rule.includes("semver") && r.status === "fail")).toBe(true);
+  });
+});
+
+// ─── checkManifest ────────────────────────────────────────────────────────────
+
+describe("checkManifest", () => {
+  it("fails when plugin.name does not match package.json name", async () => {
+    const dir = makeTmpDir();
+    const pkg = { name: "my-plugin", exports: { ".": "./index.ts" } };
+    writeValidPlugin(dir, { name: "other-plugin" });
+    const results = await checkManifest(dir, pkg);
+    expect(results.some((r) => r.rule.includes("plugin.name") && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when plugin.apiVersion is missing", async () => {
+    const dir = makeTmpDir();
+    const pkg = { name: "my-plugin", exports: { ".": "./index.ts" } };
+    writeValidPlugin(dir, { apiVersion: undefined });
+    const results = await checkManifest(dir, pkg);
+    expect(results.some((r) => r.rule.includes("apiVersion") && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when plugin.permissions is missing", async () => {
+    const dir = makeTmpDir();
+    const pkg = { name: "my-plugin", exports: { ".": "./index.ts" } };
+    writeValidPlugin(dir, { permissions: undefined });
+    const results = await checkManifest(dir, pkg);
+    expect(results.some((r) => r.rule === "plugin.permissions present" && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when scoped tier has no grants", async () => {
+    const dir = makeTmpDir();
+    const pkg = { name: "my-plugin", exports: { ".": "./index.ts" } };
+    writeValidPlugin(dir, { permissions: { tier: "scoped" } });
+    const results = await checkManifest(dir, pkg);
+    expect(results.some((r) => r.rule.includes("scoped") && r.status === "fail")).toBe(true);
+  });
+
+  it("passes when scoped tier has at least one grant", async () => {
+    const dir = makeTmpDir();
+    const pkg = { name: "my-plugin", exports: { ".": "./index.ts" } };
+    writeValidPlugin(dir, { permissions: { tier: "scoped", env: ["HOME"] } });
+    const results = await checkManifest(dir, pkg);
+    expect(results.some((r) => r.rule.includes("scoped") && r.status === "fail")).toBe(false);
+  });
+
+  it("fails when plugin.capabilities is missing", async () => {
+    const dir = makeTmpDir();
+    const pkg = { name: "my-plugin", exports: { ".": "./index.ts" } };
+    writeValidPlugin(dir, { capabilities: undefined });
+    const results = await checkManifest(dir, pkg);
+    expect(results.some((r) => r.rule.includes("capabilities") && r.status === "fail")).toBe(true);
+  });
+
+  it("passes for fully valid plugin", async () => {
+    const dir = makeTmpDir();
+    const pkg = { name: "my-plugin", exports: { ".": "./index.ts" } };
+    writeValidPlugin(dir);
+    const results = await checkManifest(dir, pkg);
+    const failures = results.filter((r) => r.status === "fail");
+    expect(failures).toHaveLength(0);
+  });
+});
+
+// ─── checkConfigSchema ────────────────────────────────────────────────────────
+
+describe("checkConfigSchema", () => {
+  it("returns empty when no config declared", async () => {
+    const plugin = { name: "my-plugin", apiVersion: "2.0.0" };
+    const results = await checkConfigSchema(plugin);
+    expect(results).toHaveLength(0);
+  });
+
+  it("fails when config.secrets key not in schema.properties", async () => {
+    const plugin = {
+      name: "my-plugin",
+      apiVersion: "2.0.0",
+      config: {
+        schema: { type: "object", properties: { other_key: { type: "string" } } },
+        secrets: ["api_key"],
+      },
+    };
+    const results = await checkConfigSchema(plugin);
+    expect(results.some((r) => r.rule.includes("api_key") && r.status === "fail")).toBe(true);
+  });
+
+  it("passes when config.secrets keys are all in schema.properties", async () => {
+    const plugin = {
+      name: "my-plugin",
+      apiVersion: "2.0.0",
+      config: {
+        schema: { type: "object", properties: { api_key: { type: "string" } } },
+        secrets: ["api_key"],
+      },
+    };
+    const results = await checkConfigSchema(plugin);
+    expect(results.some((r) => r.status === "fail")).toBe(false);
+  });
+
+  it("warns when secrets non-empty and core-secrets:provider not in consumes", async () => {
+    const plugin = {
+      name: "my-plugin",
+      apiVersion: "2.0.0",
+      capabilities: { consumes: [] },
+      config: {
+        schema: { type: "object", properties: { api_key: { type: "string" } } },
+        secrets: ["api_key"],
+      },
+    };
+    const results = await checkConfigSchema(plugin);
+    expect(results.some((r) => r.status === "warn" && r.message?.includes("core-secrets:provider"))).toBe(true);
+  });
+
+  it("does not warn when core-secrets:provider is in consumes", async () => {
+    const plugin = {
+      name: "my-plugin",
+      apiVersion: "2.0.0",
+      capabilities: { consumes: ["core-secrets:provider"] },
+      config: {
+        schema: { type: "object", properties: { api_key: { type: "string" } } },
+        secrets: ["api_key"],
+      },
+    };
+    const results = await checkConfigSchema(plugin);
+    expect(results.some((r) => r.status === "warn" && r.message?.includes("core-secrets:provider"))).toBe(false);
+  });
+
+  it("passes secrets check regardless of env grant (secrets/env decoupling)", async () => {
+    // Secrets don't require env grants — they go through secrets context
+    const plugin = {
+      name: "my-plugin",
+      apiVersion: "2.0.0",
+      permissions: { tier: "scoped", fs: { read: ["./data"] } },
+      capabilities: { consumes: ["core-secrets:provider"] },
+      config: {
+        schema: { type: "object", properties: { api_key: { type: "string" } } },
+        secrets: ["api_key"],
+      },
+    };
+    const results = await checkConfigSchema(plugin);
+    expect(results.some((r) => r.status === "fail")).toBe(false);
+  });
+});
+
+// ─── scanImports ──────────────────────────────────────────────────────────────
+
+describe("scanImports", () => {
+  it("warns when trusted plugin imports node:fs", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "index.ts");
+    writeFileSync(filePath, `import fs from "node:fs";\nexport default {};\n`);
+    const results = await scanImports(filePath);
+    expect(results.some((r) => r.status === "warn" && r.message?.includes("node:fs"))).toBe(true);
+    expect(results.some((r) => r.message?.includes("runtime enforcer"))).toBe(true);
+  });
+
+  it("warns when plugin imports child_process", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "index.ts");
+    writeFileSync(filePath, `import { exec } from "child_process";\nexport default {};\n`);
+    const results = await scanImports(filePath);
+    expect(results.some((r) => r.status === "warn" && r.message?.includes("child_process"))).toBe(true);
+  });
+
+  it("returns no warnings for clean plugin", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "index.ts");
+    writeFileSync(filePath, `import { join } from "path";\nexport default {};\n`);
+    const results = await scanImports(filePath);
+    expect(results.filter((r) => r.status === "warn")).toHaveLength(0);
+  });
+
+  it("warns when file cannot be read", async () => {
+    const results = await scanImports("/nonexistent/path/index.ts");
+    expect(results.some((r) => r.status === "warn" && r.message?.includes("Could not parse"))).toBe(true);
+  });
+});
+
+// ─── checkFilesPresent ────────────────────────────────────────────────────────
+
+describe("checkFilesPresent", () => {
+  it("fails when no test file present", async () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "README.md"), "# My Plugin");
+    const results = await checkFilesPresent(dir);
+    expect(results.some((r) => r.rule.includes("test") && r.status === "fail")).toBe(true);
+  });
+
+  it("fails when README.md is missing", async () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "index.test.ts"), "// tests");
+    const results = await checkFilesPresent(dir);
+    expect(results.some((r) => r.rule.includes("README") && r.status === "fail")).toBe(true);
+  });
+
+  it("passes when both test file and README are present", async () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "index.test.ts"), "// tests");
+    writeFileSync(join(dir, "README.md"), "# My Plugin");
+    const results = await checkFilesPresent(dir);
+    expect(results.every((r) => r.status === "pass")).toBe(true);
+  });
+});
+
+// ─── runPluginValidate (integration) ──────────────────────────────────────────
+
+describe("runPluginValidate", () => {
+  it("returns 1 when package.json is missing", async () => {
+    const dir = makeTmpDir();
+    const code = await runPluginValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  it("returns 1 when multiple failures exist", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir, { name: "BadName", type: "commonjs" });
+    const code = await runPluginValidate(dir);
+    expect(code).toBe(1);
+  });
+
+  it("returns 0 for a fully valid plugin directory", async () => {
+    const dir = makeTmpDir();
+    writePkg(dir);
+    writeValidPlugin(dir);
+    writeFileSync(join(dir, "index.test.ts"), "// tests");
+    writeFileSync(join(dir, "README.md"), "# My Plugin");
+    const code = await runPluginValidate(dir);
+    expect(code).toBe(0);
+  });
+});

--- a/src/commands/plugin-validate.ts
+++ b/src/commands/plugin-validate.ts
@@ -1,0 +1,384 @@
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { join } from "path";
+import { pathToFileURL } from "url";
+import { validateSchemaItself } from "../core/config-validator.js";
+
+export interface ValidationResult {
+  rule: string;
+  status: "pass" | "fail" | "warn";
+  message?: string;
+}
+
+const SEMVER_RE = /^\d+\.\d+\.\d+/;
+const KEBAB_RE = /^[a-z][a-z0-9-]*$/;
+
+const FLAGGED_IMPORTS = new Set([
+  "node:fs",
+  "node:child_process",
+  "node:worker_threads",
+  "bun:ffi",
+  "fs",
+  "child_process",
+  "worker_threads",
+]);
+
+export async function checkPackageJson(dir: string): Promise<ValidationResult[]> {
+  const results: ValidationResult[] = [];
+  const pkgPath = join(dir, "package.json");
+
+  if (!existsSync(pkgPath)) {
+    results.push({ rule: "package.json present", status: "fail", message: "package.json not found" });
+    return results;
+  }
+  results.push({ rule: "package.json present", status: "pass" });
+
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as Record<string, unknown>;
+  } catch {
+    results.push({ rule: "package.json parseable", status: "fail", message: "Failed to parse package.json" });
+    return results;
+  }
+
+  // name
+  if (!pkg.name || typeof pkg.name !== "string") {
+    results.push({ rule: "name present", status: "fail", message: "package.json missing name" });
+  } else if (!KEBAB_RE.test(pkg.name)) {
+    results.push({ rule: "name is kebab-case", status: "fail", message: `name "${pkg.name}" does not match ^[a-z][a-z0-9-]*$` });
+  } else {
+    results.push({ rule: `name is kebab-case: ${pkg.name}`, status: "pass" });
+  }
+
+  // type: module
+  if (pkg.type !== "module") {
+    results.push({ rule: "type: module", status: "fail", message: `"type" must be "module", got ${JSON.stringify(pkg.type)}` });
+  } else {
+    results.push({ rule: "type: module", status: "pass" });
+  }
+
+  // exports["."]
+  const exports = pkg.exports as Record<string, unknown> | undefined;
+  if (!exports || !exports["."]) {
+    results.push({ rule: 'exports["."] present', status: "fail", message: 'package.json must have exports["."]' });
+  } else {
+    results.push({ rule: 'exports["."] present', status: "pass" });
+  }
+
+  // keywords includes kaizen-plugin
+  const keywords = pkg.keywords as string[] | undefined;
+  if (!Array.isArray(keywords) || !keywords.includes("kaizen-plugin")) {
+    results.push({ rule: 'keywords includes "kaizen-plugin"', status: "fail", message: 'keywords must include "kaizen-plugin"' });
+  } else {
+    results.push({ rule: 'keywords includes "kaizen-plugin"', status: "pass" });
+  }
+
+  // version semver
+  if (!pkg.version || typeof pkg.version !== "string") {
+    results.push({ rule: "version present", status: "fail", message: "package.json missing version" });
+  } else if (!SEMVER_RE.test(pkg.version)) {
+    results.push({ rule: "version is semver", status: "fail", message: `version "${pkg.version}" is not semver` });
+  } else {
+    results.push({ rule: "version is semver", status: "pass" });
+  }
+
+  return results;
+}
+
+export async function checkManifest(dir: string, pkg: Record<string, unknown>): Promise<ValidationResult[]> {
+  const results: ValidationResult[] = [];
+  const exports = pkg.exports as Record<string, unknown> | undefined;
+  const entryRelative = exports?.["."] as string | undefined;
+
+  if (!entryRelative) {
+    results.push({ rule: "plugin manifest loadable", status: "fail", message: 'No exports["."] to load plugin from' });
+    return results;
+  }
+
+  const entryPath = join(dir, entryRelative);
+  let plugin: Record<string, unknown>;
+  try {
+    const mod = await import(pathToFileURL(entryPath).href) as { default?: unknown };
+    plugin = (mod.default ?? mod) as Record<string, unknown>;
+  } catch (e) {
+    results.push({ rule: "plugin manifest loadable", status: "fail", message: `Failed to import plugin: ${String(e)}` });
+    return results;
+  }
+  results.push({ rule: "plugin manifest loadable", status: "pass" });
+
+  // plugin.name matches package.json name
+  if (plugin.name !== pkg.name) {
+    results.push({
+      rule: "plugin.name matches package.json name",
+      status: "fail",
+      message: `plugin.name "${String(plugin.name)}" does not match package.json name "${String(pkg.name)}"`,
+    });
+  } else {
+    results.push({ rule: "plugin.name matches package.json name", status: "pass" });
+  }
+
+  // apiVersion present and semver
+  if (!plugin.apiVersion || typeof plugin.apiVersion !== "string") {
+    results.push({ rule: "plugin.apiVersion present", status: "fail", message: "plugin.apiVersion is missing" });
+  } else if (!SEMVER_RE.test(plugin.apiVersion)) {
+    results.push({ rule: "plugin.apiVersion is semver", status: "fail", message: `plugin.apiVersion "${plugin.apiVersion}" is not semver` });
+  } else {
+    results.push({ rule: "plugin.apiVersion present and semver", status: "pass" });
+  }
+
+  // permissions present
+  const permissions = plugin.permissions as Record<string, unknown> | undefined;
+  if (!permissions || typeof permissions !== "object") {
+    results.push({ rule: "plugin.permissions present", status: "fail", message: "plugin.permissions is missing" });
+  } else {
+    results.push({ rule: "plugin.permissions present", status: "pass" });
+
+    // tier
+    const tier = permissions.tier as string | undefined;
+    if (!tier || !["trusted", "scoped", "unscoped"].includes(tier)) {
+      results.push({
+        rule: "plugin.permissions.tier valid",
+        status: "fail",
+        message: `permissions.tier must be "trusted", "scoped", or "unscoped", got ${JSON.stringify(tier)}`,
+      });
+    } else {
+      results.push({ rule: "plugin.permissions.tier valid", status: "pass" });
+
+      // scoped requires at least one grant
+      if (tier === "scoped") {
+        const grantKeys = ["fs", "net", "env", "exec", "events"];
+        const hasGrant = grantKeys.some((k) => {
+          const v = permissions[k];
+          if (!v) return false;
+          if (Array.isArray(v)) return v.length > 0;
+          if (typeof v === "object") return Object.keys(v as object).length > 0;
+          return Boolean(v);
+        });
+        if (!hasGrant) {
+          results.push({
+            rule: "scoped tier has at least one grant",
+            status: "fail",
+            message: 'tier is "scoped" but no grant keys (fs, net, env, exec, events) are populated',
+          });
+        } else {
+          results.push({ rule: "scoped tier has at least one grant", status: "pass" });
+        }
+      }
+    }
+  }
+
+  // capabilities present
+  if (!plugin.capabilities || typeof plugin.capabilities !== "object") {
+    results.push({ rule: "plugin.capabilities present", status: "fail", message: "plugin.capabilities is missing (may be {})" });
+  } else {
+    results.push({ rule: "plugin.capabilities present", status: "pass" });
+  }
+
+  // run config schema checks if config declared
+  const configResults = await checkConfigSchema(plugin);
+  results.push(...configResults);
+
+  return results;
+}
+
+export async function checkConfigSchema(plugin: Record<string, unknown>): Promise<ValidationResult[]> {
+  const results: ValidationResult[] = [];
+  const config = plugin.config as Record<string, unknown> | undefined;
+  if (!config) return results;
+
+  // schema is valid JSON Schema
+  if (config.schema !== undefined) {
+    const valid = validateSchemaItself(config.schema as Record<string, unknown>);
+    if (!valid) {
+      results.push({ rule: "plugin.config.schema is valid JSON Schema", status: "fail", message: "config.schema is not a valid JSON Schema" });
+    } else {
+      results.push({ rule: "plugin.config.schema is valid JSON Schema", status: "pass" });
+    }
+  }
+
+  // secrets keys appear in schema.properties
+  const secrets = config.secrets as string[] | undefined;
+  const schema = config.schema as Record<string, unknown> | undefined;
+  const schemaProperties = (schema?.properties as Record<string, unknown> | undefined) ?? {};
+
+  if (Array.isArray(secrets)) {
+    for (const key of secrets) {
+      if (!(key in schemaProperties)) {
+        results.push({
+          rule: `config secrets key "${key}" declared in schema`,
+          status: "fail",
+          message: `config secrets key "${key}" not declared in config.schema.properties`,
+        });
+      } else {
+        results.push({ rule: `config secrets key "${key}" declared in schema`, status: "pass" });
+      }
+    }
+
+    // warn if secrets non-empty and core-secrets:provider not in consumes
+    if (secrets.length > 0) {
+      const capabilities = plugin.capabilities as Record<string, unknown> | undefined;
+      const consumes = capabilities?.consumes as string[] | undefined;
+      if (!Array.isArray(consumes) || !consumes.includes("core-secrets:provider")) {
+        results.push({
+          rule: "core-secrets:provider in consumes",
+          status: "warn",
+          message: "core-secrets:provider dependency is implicit per Spec 2; list it explicitly for discoverability.",
+        });
+      } else {
+        results.push({ rule: "core-secrets:provider in consumes", status: "pass" });
+      }
+    }
+  }
+
+  return results;
+}
+
+export async function scanImports(filePath: string): Promise<ValidationResult[]> {
+  const results: ValidationResult[] = [];
+
+  let src: string;
+  try {
+    src = readFileSync(filePath, "utf8");
+  } catch {
+    results.push({
+      rule: "import scan",
+      status: "warn",
+      message: `Could not parse ${filePath} for import scan.`,
+    });
+    return results;
+  }
+
+  let imports: string[];
+  try {
+    const transpiler = new Bun.Transpiler({ loader: "ts" });
+    imports = transpiler.scanImports(src).map((i) => i.path);
+  } catch {
+    results.push({
+      rule: "import scan",
+      status: "warn",
+      message: `Could not parse ${filePath} for import scan.`,
+    });
+    return results;
+  }
+
+  for (const imp of imports) {
+    if (FLAGGED_IMPORTS.has(imp)) {
+      results.push({
+        rule: `import "${imp}" flagged`,
+        status: "warn",
+        message: `Direct import of "${imp}" detected. Note: runtime enforcer will block this regardless of validate status.`,
+      });
+    }
+  }
+
+  return results;
+}
+
+export async function checkFilesPresent(dir: string): Promise<ValidationResult[]> {
+  const results: ValidationResult[] = [];
+
+  // test file
+  let files: string[];
+  try {
+    files = readdirSync(dir);
+  } catch {
+    results.push({ rule: "test file present", status: "fail", message: `Could not read directory: ${dir}` });
+    results.push({ rule: "README.md present", status: "fail", message: `Could not read directory: ${dir}` });
+    return results;
+  }
+
+  const hasTest = files.some((f) => f.endsWith(".test.ts"));
+  if (hasTest) {
+    results.push({ rule: "*.test.ts file present", status: "pass" });
+  } else {
+    results.push({ rule: "*.test.ts file present", status: "fail", message: "No *.test.ts file found in plugin directory" });
+  }
+
+  const hasReadme = files.includes("README.md");
+  if (hasReadme) {
+    results.push({ rule: "README.md present", status: "pass" });
+  } else {
+    results.push({ rule: "README.md present", status: "fail", message: "README.md not found" });
+  }
+
+  return results;
+}
+
+function icon(status: "pass" | "fail" | "warn" | "info"): string {
+  switch (status) {
+    case "pass": return "✓";
+    case "fail": return "✗";
+    case "warn": return "⚠";
+    case "info": return "ℹ";
+  }
+}
+
+export async function runPluginValidate(dir: string): Promise<number> {
+  console.log(`kaizen plugin validate ${dir}\n`);
+
+  const allResults: ValidationResult[] = [];
+
+  // 1. Check package.json
+  const pkgResults = await checkPackageJson(dir);
+  allResults.push(...pkgResults);
+
+  // Load pkg for manifest checks
+  let pkg: Record<string, unknown> | undefined;
+  const pkgPath = join(dir, "package.json");
+  if (existsSync(pkgPath)) {
+    try {
+      pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as Record<string, unknown>;
+    } catch {
+      // already reported
+    }
+  }
+
+  // 2. Check manifest (if we have a valid pkg with exports)
+  if (pkg) {
+    const manifestResults = await checkManifest(dir, pkg);
+    allResults.push(...manifestResults);
+
+    // 4. Scan imports on entry file
+    const exports = pkg.exports as Record<string, unknown> | undefined;
+    const entryRelative = exports?.["."] as string | undefined;
+    if (entryRelative) {
+      const entryPath = join(dir, entryRelative);
+      if (existsSync(entryPath)) {
+        const importResults = await scanImports(entryPath);
+        allResults.push(...importResults);
+      }
+    }
+  }
+
+  // 5. Check files present
+  const fileResults = await checkFilesPresent(dir);
+  allResults.push(...fileResults);
+
+  // Print results
+  for (const r of allResults) {
+    const ic = icon(r.status === "warn" ? "warn" : r.status === "fail" ? "fail" : "pass");
+    if (r.status === "fail") {
+      console.log(`  ${ic} ${r.message ?? r.rule}`);
+    } else if (r.status === "warn") {
+      console.log(`  ⚠ ${r.message ?? r.rule}`);
+    } else {
+      console.log(`  ${ic} ${r.rule}`);
+    }
+  }
+
+  const failures = allResults.filter((r) => r.status === "fail");
+  const warns = allResults.filter((r) => r.status === "warn");
+
+  console.log("");
+  if (failures.length > 0) {
+    const warnNote = warns.length > 0 ? ` (${warns.length} warning(s))` : "";
+    console.log(`${failures.length} error(s) found${warnNote}. Fix errors before publishing.`);
+    return 1;
+  } else {
+    if (warns.length > 0) {
+      console.log(`All checks passed (${warns.length} warning(s)).`);
+    } else {
+      console.log("All checks passed.");
+    }
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary

- **`kaizen plugin create <path>`** — interactive scaffolder with `--defaults` flag; generates `package.json`, `tsconfig.json`, `index.ts`, `index.test.ts`, `README.md`, `.kaizen/.gitkeep`
- **`kaizen plugin validate [<path>]`** — static + structural checks: package.json shape, manifest fields, config schema validity, secrets/env decoupling, forbidden import scan, README/test presence
- **`kaizen marketplace create <path>`** — scaffolds `.kaizen/marketplace.json` (Spec 1 `entries[]` shape), `plugins/`, `harnesses/`, `README.md`
- **`kaizen marketplace validate [<path>]`** — validates catalog shape, legacy `{plugins,harnesses}` rejection, cross-kind name uniqueness, source type tagged unions, file/harness path existence
- **`docs/plugin-standards.md`** — canonical coding standards with `[required]`/`[guideline]` markers

## Prerequisites

- Spec 1 (marketplace `entries[]` format) — PR #5, merged ✓
- Spec 2 (unified config + secrets) — PR #7, merged ✓

## Test Plan

- [ ] 357 tests pass, 0 fail (`bun test`)
- [ ] `bun x tsc --noEmit` clean
- [ ] `kaizen plugin create ./tmp-plugin --defaults` generates valid scaffold
- [ ] `kaizen plugin validate ./tmp-plugin` exits 0 (after `bun install` in scaffold dir)
- [ ] `kaizen marketplace create ./tmp-market --defaults && kaizen marketplace validate ./tmp-market` exits 0
- [ ] Validator correctly rejects: missing `type:module`, bad semver, legacy catalog shape, cross-kind name collision, secrets key not in schema