### PR TITLE
docs(install): document installer and rename REPO to KAIZEN_REPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ The installer seeds the `official` marketplace and pre-installs a default
 stack. From source, run `scripts/dev-setup.sh` against a sibling checkout — see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CraightonH/kaizen/master/scripts/install.sh | bash
+```
+
+The script detects your platform (macOS/Linux, x64/arm64), downloads the
+matching release binary from GitHub, verifies its checksum, installs it to
+`/usr/local/bin/kaizen`, and seeds the `official` marketplace under
+`$KAIZEN_HOME` (default `~/.kaizen`).
+
+Environment overrides:
+
+- `KAIZEN_HOME` — marketplace/state dir (default `~/.kaizen`)
+- `INSTALL_DIR` — binary install dir (default `/usr/local/bin`)
+- `KAIZEN_REPO` — GitHub repo to pull releases from (default `CraightonH/kaizen`)
+
 ## Concepts
 
 ### Harnesses

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 KAIZEN_HOME="${KAIZEN_HOME:-$HOME/.kaizen}"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
-REPO="${REPO:-CraightonH/kaizen}"
+KAIZEN_REPO="${KAIZEN_REPO:-CraightonH/kaizen}"
 BINARY="kaizen"
 
 # ---------------------------------------------------------------------------
@@ -121,7 +121,7 @@ bootstrap() {
 }
 
 latest_release_tag() {
-  local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+  local api_url="https://api.github.com/repos/${KAIZEN_REPO}/releases/latest"
   local tag
   if command -v curl >/dev/null 2>&1; then
     tag="$(curl -fsSL "$api_url" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
@@ -158,7 +158,7 @@ main() {
   asset_name="$(detect_platform)"
   info "Asset:   $asset_name"
 
-  local base_url="https://github.com/${REPO}/releases/download/${version}"
+  local base_url="https://github.com/${KAIZEN_REPO}/releases/download/${version}"
 
   local tmpdir
   tmpdir="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- Add an **Install** section to the README with the `curl | bash` one-liner targeting `scripts/install.sh` on `master`, plus a short description of what the installer does and its env overrides.
- Rename the generic `REPO` env var in `scripts/install.sh` to `KAIZEN_REPO` to avoid clashing with other tools' conventions. Updates all three usages (declaration, `latest_release_tag` API URL, release download base URL) and the README env-overrides list.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] `curl -fsSL .../install.sh | bash` still resolves and installs
- [ ] `KAIZEN_REPO=fork/kaizen bash scripts/install.sh` pulls from the fork