### PR TITLE
Decouple lifecycle driver from plugin namespace (#13)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,6 +7,10 @@ Status: APPROVED (rev 2 — executor-as-plugin)
 Mode: Builder (Open Source Platform)
 Supersedes: craighton-master-design-20260402-203112.md
 
+> **Note (2026-04-20, issue #13):** "Role" terminology is deprecated. See the
+> Platform Contract / Capability definitions below and the lifecycle-driver
+> decoupling spec at `docs/superpowers/specs/2026-04-20-lifecycle-driver-decoupling-design.md`.
+
 ## Problem Statement
 
 LLM coding agents are locked to single providers and extend only via MCP — which
@@ -64,11 +68,25 @@ This is VS Code extensions for LLM assistants, without the IDE.
 
 ## Definitions
 
-**Role:** A named capability that a plugin may provide (e.g. `'lifecycle'`, `'ui'`).
-Roles decouple plugins from specific implementations — `depends: ['lifecycle']` works
-with any lifecycle plugin. Core enforces: if any loaded plugin declares a role in its
-`depends[]`, exactly one loaded plugin must `provide[]` that role. Roles with no
-dependents are not enforced.
+**Platform Contract:** After `bootstrap()`, core calls `start()` on exactly one
+loaded plugin — the **session driver**. A plugin declares itself as the driver
+by setting `lifecycle: true` on its default export. Exactly one loaded plugin
+must declare this; zero or more than one is a fatal startup error. This is the
+sole plugin-to-core contract; everything else (executor, UI, tools) is
+plugin-to-plugin and modeled as capabilities.
+
+**Capability:** A named plugin-to-plugin interface (`<owner-plugin>:<name>`)
+registered at startup. Providers register their implementation; consumers
+declare they'll use it. Core validates cardinality (`one` vs `many`) but
+holds no opinion about semantics — capabilities are agreements between
+plugins. The owner-prefix rule (name must match the defining plugin's name)
+prevents namespace hijacking.
+
+**(Historical note: earlier drafts used "role" as a first-class concept. The
+capability registry subsumed roles for plugin-to-plugin interfaces; the
+session-driver hand-off was decoupled from capabilities entirely via the
+`lifecycle` flag. Other "role" language in this document is stale and
+will be revised incrementally.)**
 
 **Plugin:** A self-contained npm package that exports a `KaizenPlugin` default.
 

--- a/docs/superpowers/plans/2026-04-20-lifecycle-driver-decoupling.md
+++ b/docs/superpowers/plans/2026-04-20-lifecycle-driver-decoupling.md
@@ -1,0 +1,731 @@
+# Lifecycle Driver Decoupling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded `core-lifecycle:lifecycle.drive` capability lookup with a `lifecycle: true` manifest flag, so any plugin can be the session driver without pretending to own the `core-lifecycle` namespace.
+
+**Architecture:** Core identifies the session driver by scanning loaded plugins for a boolean `lifecycle` flag on the default export. The capability registry keeps its ownership-prefix rule. The `core-lifecycle:lifecycle.drive` capability is deleted; other `core-lifecycle:*` capabilities (executor.send, ui.input, ui.output) are untouched because `core-lifecycle` legitimately owns them. Coordinated release with `kaizen-official-plugins` — three consumer plugins drop a now-meaningless `consumes` line, and `core-lifecycle` gains the flag.
+
+**Tech Stack:** TypeScript, Bun, `bun test`. Plan touches two repos: `kaizen` (this repo) and `kaizen-official-plugins` (sibling checkout at `~/git/kaizen-official-plugins`).
+
+**Spec:** `docs/superpowers/specs/2026-04-20-lifecycle-driver-decoupling-design.md`
+
+---
+
+## File Structure
+
+**kaizen repo (this repo):**
+- Modify `src/types/plugin.ts` — add `lifecycle?: boolean` to `KaizenPlugin`.
+- Modify `src/core/plugin-manager.ts` — replace driver-lookup block (~lines 449–457); update `isCritical` (~line 207) to treat `lifecycle: true` plugins as critical.
+- Modify `src/core/plugin-manager.test.ts` — convert existing lifecycle fixtures to use the flag; add error-path tests.
+- Modify `tests/fixtures/ci-marketplace/plugins/fixture-lifecycle/index.mjs` — rename back to `fixture-lifecycle`, add flag, drop `lifecycle.drive` capability, remove issue-#13 comment.
+- Modify `DESIGN.md` — narrow update: add "Platform Contract" framing; deprecate "role" language for the lifecycle hand-off.
+
+**kaizen-official-plugins repo:**
+- Modify `plugins/core-lifecycle/index.ts` — add `lifecycle: true`; remove `lifecycle.drive` provides + defineCapability.
+- Modify `plugins/core-lifecycle/index.test.ts` — update affected assertions.
+- Modify `plugins/core-cli/index.ts` — drop `consumes: ["core-lifecycle:lifecycle.drive"]`.
+- Modify `plugins/core-plugin-manager/index.ts` — same.
+- Modify `plugins/timestamps/index.ts` — remove `lifecycle.drive` from consumes.
+
+---
+
+## Task 1: Add `lifecycle` flag to plugin manifest type
+
+**Files:**
+- Modify: `src/types/plugin.ts:338-362`
+
+- [ ] **Step 1: Add the optional flag to `KaizenPlugin`**
+
+Edit `src/types/plugin.ts`. In the `KaizenPlugin` interface (starts around line 338), add a new optional field between `name`/`apiVersion` and `capabilities`:
+
+```ts
+export interface KaizenPlugin {
+  /** kebab-case. Must match the config namespace key in kaizen.json. */
+  name: string;
+
+  /** semver. Core warns if major != PLUGIN_API_VERSION. */
+  apiVersion: string;
+
+  /**
+   * True if this plugin drives the session loop. Core calls start() on the
+   * one plugin with lifecycle=true after bootstrap. Exactly one loaded
+   * plugin must declare this; zero or two+ is a fatal startup error.
+   */
+  lifecycle?: boolean;
+
+  /** What this plugin provides and consumes in the capability registry. */
+  capabilities?: PluginCapabilities;
+
+  // ... rest unchanged
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run tsc --noEmit -p tsconfig.json` (or the repo's usual typecheck command — check `package.json` scripts).
+Expected: No new errors. Existing code is untouched because the field is optional.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/plugin.ts
+git commit -m "feat(types): add lifecycle flag to KaizenPlugin manifest (#13)"
+```
+
+---
+
+## Task 2: Update `isCritical` to treat flagged plugins as critical
+
+**Files:**
+- Modify: `src/core/plugin-manager.ts:207-215`
+- Test: `src/core/plugin-manager.test.ts`
+
+**Why:** Today, `isCritical` returns true only when a plugin provides a `cardinality: "one"` capability that has consumers. After we remove the `lifecycle.drive` capability, `core-lifecycle` would no longer be critical by that rule, so a `setup()` throw would be demoted from fatal to warning. The `lifecycle: true` flag must preserve criticality.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `src/core/plugin-manager.test.ts` in the `PluginManager.initialize` describe block (around line 89–153 area):
+
+```ts
+test("plugin with lifecycle:true is treated as critical — setup throws are fatal", async () => {
+  const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+  executorRegistry.register(stubExecutor, "test-exec");
+  uiRegistry.register(stubUi, "test-ui");
+
+  const life: KaizenPlugin = {
+    name: "core-lifecycle",
+    apiVersion: "2",
+    lifecycle: true,
+    async setup() { throw new Error("boom"); },
+    async start() {},
+  };
+  const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+  const manager = new PluginManager(
+    { plugins: ["core-lifecycle"] }, { "core-lifecycle": life },
+    eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, options,
+  );
+  await expect(manager.initialize()).rejects.toThrow(/provides critical capability.*boom/i);
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run: `bun test src/core/plugin-manager.test.ts -t "lifecycle:true is treated as critical"`
+Expected: FAIL (the plugin is not treated as critical — setup throw becomes a logged failure, not a thrown fatal).
+
+- [ ] **Step 3: Update `isCritical`**
+
+In `src/core/plugin-manager.ts`, replace the body of `isCritical` (lines ~207–215) with:
+
+```ts
+function isCritical(plugin: KaizenPlugin, reg: CapabilityRegistry): boolean {
+  if (plugin.lifecycle === true) return true;
+  const aliases = plugin.aliases ?? {};
+  for (const raw of plugin.capabilities?.provides ?? []) {
+    const cap = resolveCapName(raw, aliases);
+    const spec = reg.getSpec(cap);
+    if (spec?.cardinality === "one" && reg.consumersOf(cap).length > 0) return true;
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `bun test src/core/plugin-manager.test.ts -t "lifecycle:true is treated as critical"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-manager.ts src/core/plugin-manager.test.ts
+git commit -m "feat(core): treat lifecycle-flagged plugins as critical during setup (#13)"
+```
+
+---
+
+## Task 3: Replace the hardcoded driver lookup with the manifest-flag scan
+
+**Files:**
+- Modify: `src/core/plugin-manager.ts:449-457`
+- Test: `src/core/plugin-manager.test.ts`
+
+- [ ] **Step 1: Write the failing test — driver found via flag**
+
+In `src/core/plugin-manager.test.ts`, add this test inside the `PluginManager.initialize` describe:
+
+```ts
+test("finds session driver via lifecycle:true flag — no capability required", async () => {
+  const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+  executorRegistry.register(stubExecutor, "test-exec");
+  uiRegistry.register(stubUi, "test-ui");
+
+  const driver: KaizenPlugin = {
+    name: "fixture-lifecycle",
+    apiVersion: "2",
+    lifecycle: true,
+    async setup() {},
+    async start() {},
+  };
+  const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+  const manager = new PluginManager(
+    { plugins: ["fixture-lifecycle"] }, { "fixture-lifecycle": driver },
+    eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, options,
+  );
+  const { lifecycleProvider } = await manager.initialize();
+  expect(lifecycleProvider.name).toBe("fixture-lifecycle");
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run: `bun test src/core/plugin-manager.test.ts -t "finds session driver via lifecycle:true flag"`
+Expected: FAIL — the current code greps the capability registry for `core-lifecycle:lifecycle.drive` and finds no provider.
+
+- [ ] **Step 3: Replace the driver lookup block**
+
+In `src/core/plugin-manager.ts`, find the block starting at the comment `// Resolve lifecycle provider` (around line 449) and replace it with:
+
+```ts
+    // Resolve lifecycle provider — the one plugin with `lifecycle: true`.
+    // Core's single cross-plugin contract: call start() on the session driver.
+    const lifecyclePluginNames: string[] = [];
+    for (const [name, entry] of this.plugins) {
+      if (entry.plugin.lifecycle === true && entry.entry.status === "loaded") {
+        lifecyclePluginNames.push(name);
+      }
+    }
+    if (lifecyclePluginNames.length === 0) {
+      fatal("No lifecycle plugin found. A plugin with 'lifecycle: true' must be loaded. Add one to kaizen.json.");
+    }
+    if (lifecyclePluginNames.length > 1) {
+      const quoted = lifecyclePluginNames.map((n) => `'${n}'`).join(", ");
+      fatal(
+        `Multiple lifecycle plugins loaded: ${quoted}. ` +
+        `A harness may have exactly one plugin with 'lifecycle: true'. Remove one from your kaizen.json.`,
+      );
+    }
+    const lifecycleName = lifecyclePluginNames[0]!;
+    const lifecycleProvider = this.plugins.get(lifecycleName)?.plugin;
+    if (!lifecycleProvider || typeof lifecycleProvider.start !== "function") {
+      fatal(`Plugin '${lifecycleName}' declares 'lifecycle: true' but does not export a start() function.`);
+    }
+
+    return { lifecycleProvider: lifecycleProvider! };
+  }
+```
+
+- [ ] **Step 4: Run the new test to confirm it passes**
+
+Run: `bun test src/core/plugin-manager.test.ts -t "finds session driver via lifecycle:true flag"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full file to see what else breaks**
+
+Run: `bun test src/core/plugin-manager.test.ts`
+Expected: Existing tests that rely on `provides: ["core-lifecycle:lifecycle.drive"]` now fail with "No lifecycle plugin found." — that's expected; Task 4 fixes them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/plugin-manager.ts src/core/plugin-manager.test.ts
+git commit -m "feat(core): resolve session driver via lifecycle flag, not capability (#13)"
+```
+
+---
+
+## Task 4: Migrate existing plugin-manager tests to the flag
+
+**Files:**
+- Modify: `src/core/plugin-manager.test.ts` (multiple locations)
+
+**Goal:** Every existing test that set up a lifecycle plugin via `provides: ["core-lifecycle:lifecycle.drive"]` + `defineCapability` must switch to `lifecycle: true`. There are 6 occurrences (lines ~100, 135, 286, 417, 458, 486 per the spec's grep).
+
+- [ ] **Step 1: Convert all lifecycle fixture declarations**
+
+For each of the six test fixture objects that currently look like this:
+
+```ts
+const lifecyclePlugin: KaizenPlugin = {
+  name: "core-lifecycle", apiVersion: "2",
+  capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
+  async setup(ctx) {
+    ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "lifecycle" });
+    // (optionally more setup code)
+  },
+  async start() {},
+};
+```
+
+rewrite them to:
+
+```ts
+const lifecyclePlugin: KaizenPlugin = {
+  name: "core-lifecycle", apiVersion: "2",
+  lifecycle: true,
+  async setup(ctx) {
+    // (preserve any remaining setup code — drop only the lifecycle.drive defineCapability)
+  },
+  async start() {},
+};
+```
+
+Preserve any other body in `setup()` (for example, the test at line ~454 defines additional capabilities or registers tools — keep those). Only remove the `capabilities.provides` entry for `core-lifecycle:lifecycle.drive` and its matching `defineCapability` call.
+
+**Special case — alias resolution test (around line 454):** the test asserts a consumer plugin with `aliases: { "lifecycle": "core-lifecycle:lifecycle.drive" }` consumes `["lifecycle"]`. Since we're deleting the `lifecycle.drive` capability, this assertion is now testing a scenario that can't occur in production. Rewrite the test to assert alias resolution against some *other* capability that still exists — e.g. have the lifecycle plugin also define `core-lifecycle:executor.send` (cardinality "many") and consume that through the alias, OR replace the test's capability with a made-up one like `core-lifecycle:ui` with cardinality "many". Pick whichever is a smaller diff. The goal of the test is alias resolution mechanics, not lifecycle specifically.
+
+- [ ] **Step 2: Run the affected test file**
+
+Run: `bun test src/core/plugin-manager.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run the whole suite to catch collateral damage**
+
+Run: `bun test`
+Expected: All tests pass. Any failures are expected in `src/core/orchestration.test.ts` (fixed in Task 6) or are real regressions needing investigation.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/plugin-manager.test.ts
+git commit -m "test(core): migrate lifecycle fixtures to lifecycle flag (#13)"
+```
+
+---
+
+## Task 5: Add error-path tests for zero / multiple / missing-start
+
+**Files:**
+- Modify: `src/core/plugin-manager.test.ts`
+
+- [ ] **Step 1: Write the "zero lifecycle plugins" failing test**
+
+Add to the `PluginManager.initialize` describe block:
+
+```ts
+test("fatals when no plugin declares lifecycle:true", async () => {
+  const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+  const plain = makePlugin("tool-only", async () => {});
+  const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+  const manager = new PluginManager(
+    { plugins: ["tool-only"] }, { "tool-only": plain },
+    eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, options,
+  );
+  await expect(manager.initialize()).rejects.toThrow(/No lifecycle plugin found.*lifecycle: true/);
+});
+```
+
+- [ ] **Step 2: Write the "multiple lifecycle plugins" failing test**
+
+```ts
+test("fatals with names listed when two plugins declare lifecycle:true", async () => {
+  const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+  executorRegistry.register(stubExecutor, "test-exec");
+  uiRegistry.register(stubUi, "test-ui");
+  const a: KaizenPlugin = { name: "a-life", apiVersion: "2", lifecycle: true, async setup() {}, async start() {} };
+  const b: KaizenPlugin = { name: "b-life", apiVersion: "2", lifecycle: true, async setup() {}, async start() {} };
+  const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+  const manager = new PluginManager(
+    { plugins: ["a-life", "b-life"] }, { "a-life": a, "b-life": b },
+    eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, options,
+  );
+  await expect(manager.initialize()).rejects.toThrow(
+    /Multiple lifecycle plugins loaded: 'a-life', 'b-life'.*exactly one/,
+  );
+});
+```
+
+- [ ] **Step 3: Write the "lifecycle flag but no start()" failing test**
+
+```ts
+test("fatals when lifecycle plugin has no start() function", async () => {
+  const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+  executorRegistry.register(stubExecutor, "test-exec");
+  uiRegistry.register(stubUi, "test-ui");
+  // Deliberately omit start().
+  const broken: KaizenPlugin = {
+    name: "broken-life",
+    apiVersion: "2",
+    lifecycle: true,
+    async setup() {},
+  };
+  const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+  const manager = new PluginManager(
+    { plugins: ["broken-life"] }, { "broken-life": broken },
+    eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, options,
+  );
+  await expect(manager.initialize()).rejects.toThrow(
+    /'broken-life' declares 'lifecycle: true' but does not export a start\(\) function/,
+  );
+});
+```
+
+- [ ] **Step 4: Run the three new tests**
+
+Run: `bun test src/core/plugin-manager.test.ts -t "fatals"`
+Expected: All three pass (the production code from Task 3 already throws these messages).
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `bun test`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/plugin-manager.test.ts
+git commit -m "test(core): cover zero/multiple/missing-start lifecycle errors (#13)"
+```
+
+---
+
+## Task 6: Fix the CI-marketplace fixture and orchestration test
+
+**Files:**
+- Modify: `tests/fixtures/ci-marketplace/plugins/fixture-lifecycle/index.mjs`
+
+- [ ] **Step 1: Rewrite the fixture manifest**
+
+Replace the entire contents of `tests/fixtures/ci-marketplace/plugins/fixture-lifecycle/index.mjs` with:
+
+```js
+// Minimal lifecycle provider. Drives exactly one session turn, emits
+// test:lifecycle:start / :end bracketing the work, then returns so
+// bootstrap() resolves.
+export default {
+  name: "fixture-lifecycle",
+  apiVersion: "2",
+  lifecycle: true,
+  capabilities: {
+    consumes: ["core-lifecycle:executor.send", "core-lifecycle:ui"],
+  },
+  async setup(ctx) {
+    ctx.defineCapability("core-lifecycle:executor.send", { cardinality: "one", description: "LLM executor" });
+    ctx.defineCapability("core-lifecycle:ui", { cardinality: "many", description: "UI provider" });
+  },
+  async start(ctx) {
+    await ctx.emit("test:lifecycle:start");
+    await ctx.emit("session:start");
+
+    const ui = ctx.runtime.ui.getFirst();
+    const executor = ctx.runtime.executors.getFirst();
+
+    for await (const channel of ui.accept()) {
+      const userMsg = await channel.receive();
+      if (!userMsg) break;
+      await ctx.emit("session:user_message", userMsg);
+
+      const tools = ctx.runtime.tools.list();
+      const response = await executor.send([userMsg], tools);
+      await ctx.emit("session:response", response);
+      await channel.send({ type: "text", content: response.content });
+
+      await channel.close();
+      break;
+    }
+
+    await ctx.emit("session:end");
+    await ctx.emit("test:lifecycle:end");
+  },
+};
+```
+
+Notes on the diff from the current file:
+- `name` changes from `"core-lifecycle"` back to `"fixture-lifecycle"`.
+- The 6-line `// Workaround for issue #13` comment is deleted.
+- `lifecycle: true` added.
+- `provides: ["core-lifecycle:lifecycle.drive"]` removed from `capabilities`.
+- The `defineCapability("core-lifecycle:lifecycle.drive", ...)` call is removed from `setup`.
+- `capabilities.consumes` and the remaining two `defineCapability` calls are preserved — the fixture still needs an executor and UI, and it still owns defining those capabilities in this CI harness.
+
+**Why it still defines `core-lifecycle:*` capabilities even though its name is no longer `core-lifecycle`:** The ownership-prefix rule in the capability registry (`src/core/capability-registry.ts:19`) will throw when `fixture-lifecycle` tries to `defineCapability("core-lifecycle:executor.send", ...)`. This fixture is the *only* plugin in the CI marketplace, and it needs an executor and UI capability to exist for validation. Two options:
+
+1. **Preferred:** Change the defined capability names to `fixture-lifecycle:executor.send` / `fixture-lifecycle:ui`, and update the matching `consumes` entries (and the CI marketplace's executor/UI fixture plugins, if any exist — check `tests/fixtures/ci-marketplace/plugins/` for siblings).
+2. If that expands the blast radius too far, leave the names as `core-lifecycle:*` and temporarily loosen (or work around) the ownership check in the fixture. Do *not* pursue this without explicit sign-off — it reintroduces the smell #13 was trying to eliminate.
+
+Before implementing, `ls tests/fixtures/ci-marketplace/plugins/` and `grep -r "core-lifecycle:" tests/fixtures/ci-marketplace/` to survey. If the only definitions are in `fixture-lifecycle`, option 1 is mechanical.
+
+- [ ] **Step 2: Survey sibling fixtures**
+
+Run:
+```bash
+ls tests/fixtures/ci-marketplace/plugins/
+grep -rn "core-lifecycle:\|defineCapability\|provides\|consumes" tests/fixtures/ci-marketplace/plugins/
+```
+Expected: understand which fixture plugins in the CI marketplace reference `core-lifecycle:*` capabilities. If `fixture-lifecycle` is the sole defining site, proceed with option 1 (rename the capabilities to `fixture-lifecycle:*`).
+
+- [ ] **Step 3: Apply option 1 if applicable**
+
+If the survey shows other fixtures provide `core-lifecycle:executor.send` or `core-lifecycle:ui`, update each to `fixture-lifecycle:executor.send` / `fixture-lifecycle:ui` so the namespace matches the defining plugin. Update the `consumes` list in `fixture-lifecycle/index.mjs` to match, and update the two `defineCapability` calls' names.
+
+Final `fixture-lifecycle/index.mjs` (option 1 applied):
+
+```js
+export default {
+  name: "fixture-lifecycle",
+  apiVersion: "2",
+  lifecycle: true,
+  capabilities: {
+    consumes: ["fixture-lifecycle:executor.send", "fixture-lifecycle:ui"],
+  },
+  async setup(ctx) {
+    ctx.defineCapability("fixture-lifecycle:executor.send", { cardinality: "one", description: "LLM executor" });
+    ctx.defineCapability("fixture-lifecycle:ui", { cardinality: "many", description: "UI provider" });
+  },
+  async start(ctx) {
+    // (body unchanged from Step 1)
+  },
+};
+```
+
+- [ ] **Step 4: Run the orchestration test**
+
+Run: `bun test src/core/orchestration.test.ts`
+Expected: PASS. The fixture is now a legitimate `fixture-lifecycle` plugin, no name spoofing required, and the ownership check is satisfied because every defined capability uses the `fixture-lifecycle:` prefix.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `bun test`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/ci-marketplace/plugins/fixture-lifecycle/index.mjs
+# Include any sibling fixture files touched in Step 3
+git commit -m "test(fixtures): rename fixture-lifecycle back to its real name (#13)"
+```
+
+---
+
+## Task 7: Update DESIGN.md — narrow framing update
+
+**Files:**
+- Modify: `DESIGN.md`
+
+**Scope:** Add the "Platform Contract" framing. Do *not* attempt a full doc rewrite — "role" language appears throughout DESIGN.md (lines 67–70, 99–102, 130–142, etc.) and tackling all of it exceeds this plan. The goal here is to make the current reality discoverable to future readers.
+
+- [ ] **Step 1: Replace the "Role" definition**
+
+In `DESIGN.md`, find the `**Role:**` definition (around line 67) and replace the paragraph with:
+
+```markdown
+**Platform Contract:** After `bootstrap()`, core calls `start()` on exactly one
+loaded plugin — the **session driver**. A plugin declares itself as the driver
+by setting `lifecycle: true` on its default export. Exactly one loaded plugin
+must declare this; zero or more than one is a fatal startup error. This is the
+sole plugin-to-core contract; everything else (executor, UI, tools) is
+plugin-to-plugin and modeled as capabilities.
+
+**Capability:** A named plugin-to-plugin interface (`<owner-plugin>:<name>`)
+registered at startup. Providers register their implementation; consumers
+declare they'll use it. Core validates cardinality (`one` vs `many`) but
+holds no opinion about semantics — capabilities are agreements between
+plugins. The owner-prefix rule (name must match the defining plugin's name)
+prevents namespace hijacking.
+
+**(Historical note: earlier drafts used "role" as a first-class concept. The
+capability registry subsumed roles for plugin-to-plugin interfaces; the
+session-driver hand-off was decoupled from capabilities entirely via the
+`lifecycle` flag. Other "role" language in this document is stale and
+will be revised incrementally.)**
+```
+
+- [ ] **Step 2: Add a one-line deprecation note at the top of DESIGN.md**
+
+Below the frontmatter (around line 9), after the existing `Supersedes:` line, add:
+
+```markdown
+
+> **Note (2026-04-20, issue #13):** "Role" terminology is deprecated. See the
+> Platform Contract / Capability definitions below and the lifecycle-driver
+> decoupling spec at `docs/superpowers/specs/2026-04-20-lifecycle-driver-decoupling-design.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DESIGN.md
+git commit -m "docs(design): document platform contract and deprecate role language (#13)"
+```
+
+---
+
+## Task 8: Update `core-lifecycle` in kaizen-official-plugins
+
+**Files (in sibling repo):**
+- Modify: `~/git/kaizen-official-plugins/plugins/core-lifecycle/index.ts`
+- Modify: `~/git/kaizen-official-plugins/plugins/core-lifecycle/index.test.ts`
+
+**Context:** This task and Task 9 happen in the sibling checkout `~/git/kaizen-official-plugins`. All `cd` into that repo first. The kaizen dev-setup script (`scripts/dev-setup.sh`) wires the sibling repo in for local integration; the coordinated release is a paired commit in each repo.
+
+- [ ] **Step 1: Inspect current `core-lifecycle/index.ts`**
+
+Run: `cat ~/git/kaizen-official-plugins/plugins/core-lifecycle/index.ts`
+
+You should see (abridged):
+
+```ts
+export default {
+  name: "core-lifecycle",
+  apiVersion: "2",
+  capabilities: {
+    provides: ["core-lifecycle:lifecycle.drive"],
+    consumes: [ /* executor.send, ui.input, ui.output */ ],
+  },
+  async setup(ctx) {
+    ctx.defineCapability("core-lifecycle:lifecycle.drive", { ... });
+    ctx.defineCapability("core-lifecycle:ui.input",  { ... });
+    ctx.defineCapability("core-lifecycle:ui.output", { ... });
+    ctx.defineCapability("core-lifecycle:executor.send", { ... });
+  },
+  async start(ctx) { /* ... */ },
+};
+```
+
+- [ ] **Step 2: Apply the edits**
+
+Make three changes to `core-lifecycle/index.ts`:
+
+1. Add `lifecycle: true,` to the default export, between `apiVersion` and `capabilities`.
+2. Remove `"core-lifecycle:lifecycle.drive"` from the `capabilities.provides` array. If that leaves `provides` empty, drop the `provides` key entirely.
+3. Remove the `ctx.defineCapability("core-lifecycle:lifecycle.drive", { ... })` call from `setup(ctx)`.
+
+Keep all other capabilities (`ui.input`, `ui.output`, `executor.send`) and all other `setup` logic unchanged.
+
+- [ ] **Step 3: Update tests**
+
+Inspect `plugins/core-lifecycle/index.test.ts`. If any test asserts on `core-lifecycle:lifecycle.drive` (either in `capabilities.provides` or via a `defineCapability` spy/mock), update or delete that assertion. The plugin's tests should now assert `lifecycle === true` on the default export.
+
+- [ ] **Step 4: Run the plugin's tests**
+
+Run: `cd ~/git/kaizen-official-plugins && bun test plugins/core-lifecycle/`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit (in the official-plugins repo)**
+
+```bash
+cd ~/git/kaizen-official-plugins
+git add plugins/core-lifecycle/index.ts plugins/core-lifecycle/index.test.ts
+git commit -m "feat(core-lifecycle): declare lifecycle flag, drop lifecycle.drive capability"
+```
+
+---
+
+## Task 9: Drop vestigial `lifecycle.drive` consumes from three plugins
+
+**Files (in sibling repo):**
+- Modify: `~/git/kaizen-official-plugins/plugins/core-cli/index.ts`
+- Modify: `~/git/kaizen-official-plugins/plugins/core-plugin-manager/index.ts`
+- Modify: `~/git/kaizen-official-plugins/plugins/timestamps/index.ts`
+
+**Why:** These plugins declare `consumes: ["core-lifecycle:lifecycle.drive"]` but never reference the capability at runtime — confirmed via grep earlier. It was a declarative "ensure a lifecycle plugin is loaded" signal. With the flag-based driver lookup, that check is handled at driver-resolution time.
+
+- [ ] **Step 1: core-cli**
+
+Edit `plugins/core-cli/index.ts`. Find the line (around line 148):
+
+```ts
+capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] },
+```
+
+Delete the entire `capabilities` key from the default export (it has no other entries — verify by reading the line; if there *are* other entries, delete only the `lifecycle.drive` string from the array).
+
+- [ ] **Step 2: core-plugin-manager**
+
+Edit `plugins/core-plugin-manager/index.ts`. Same pattern — find the `capabilities: { consumes: ["core-lifecycle:lifecycle.drive"] }` line (around line 7) and delete the `capabilities` key (or the one array entry if there are siblings).
+
+- [ ] **Step 3: timestamps**
+
+Edit `plugins/timestamps/index.ts`. Find (around line 12):
+
+```ts
+capabilities: { consumes: ["core-lifecycle:lifecycle.drive", "core-events:service"] },
+```
+
+Change to:
+
+```ts
+capabilities: { consumes: ["core-events:service"] },
+```
+
+- [ ] **Step 4: Run all three plugins' tests**
+
+Run: `cd ~/git/kaizen-official-plugins && bun test plugins/core-cli/ plugins/core-plugin-manager/ plugins/timestamps/`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit (in the official-plugins repo)**
+
+```bash
+cd ~/git/kaizen-official-plugins
+git add plugins/core-cli/index.ts plugins/core-plugin-manager/index.ts plugins/timestamps/index.ts
+git commit -m "chore: drop vestigial core-lifecycle:lifecycle.drive consumes"
+```
+
+---
+
+## Task 10: End-to-end verification
+
+**Files:** None modified. Verification only.
+
+- [ ] **Step 1: Run the kaizen test suite**
+
+Run: `cd ~/git/kaizen && bun test`
+Expected: All tests pass. No failures related to lifecycle or capability lookup.
+
+- [ ] **Step 2: Run the official-plugins test suite**
+
+Run: `cd ~/git/kaizen-official-plugins && bun test`
+Expected: All tests pass.
+
+- [ ] **Step 3: Wire the sibling repo and boot the default stack**
+
+Run:
+```bash
+cd ~/git/kaizen
+./scripts/dev-setup.sh
+bun run build    # or equivalent — check package.json for the build script
+# Attempt a dry boot. Check the repo's CONTRIBUTING.md or package.json for how
+# it's usually smoke-tested. Something like:
+bun run kaizen --help
+```
+Expected: Binary builds without errors. `--help` runs to completion.
+
+- [ ] **Step 4: Confirm the #13 acceptance criteria**
+
+Manually verify against the spec's Acceptance section:
+
+```bash
+cd ~/git/kaizen
+grep -rn 'core-lifecycle:lifecycle.drive' src/ tests/ docs/
+```
+Expected output: no hits in `src/core/` runtime code. Any remaining hits should only be in the design doc / comments.
+
+```bash
+cd ~/git/kaizen-official-plugins
+grep -rn 'core-lifecycle:lifecycle.drive' plugins/
+```
+Expected: no hits.
+
+- [ ] **Step 5: Report**
+
+Summarize: (a) files changed in each repo, (b) tests added, (c) grep proofs that `lifecycle.drive` is gone, (d) that #13's acceptance bullets are met. If anything is unclear or the integration test couldn't be run, say so explicitly rather than claiming success.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every acceptance bullet maps to a task — Task 6 (fixture rename), Tasks 3+5 (flag-based lookup + errors), Tasks 8+9 (no more `lifecycle.drive` capability anywhere), Task 10 (grep proof). Non-goals in the spec (capability registry unchanged, no roles, no config override) are respected.
+- **Placeholder scan:** every step contains concrete code, paths, or commands.
+- **Type consistency:** the flag is named `lifecycle` consistently throughout (Task 1 declares it, Task 2 checks it in `isCritical`, Task 3 scans for it, tests use it).
+- **Ambiguity flagged explicitly:** Task 6 Step 1 calls out the ownership-rule collision for capability names defined by the fixture and prescribes the preferred resolution (rename to `fixture-lifecycle:` prefix). No handwaving.

--- a/docs/superpowers/specs/2026-04-20-lifecycle-driver-decoupling-design.md
+++ b/docs/superpowers/specs/2026-04-20-lifecycle-driver-decoupling-design.md
@@ -1,0 +1,210 @@
+# Lifecycle Driver Decoupling
+
+**Status:** Draft
+**Date:** 2026-04-20
+**Issue:** [#13](https://github.com/CraightonH/kaizen/issues/13)
+
+## Problem
+
+Core hardcodes the session-driver lookup to a specific plugin's capability
+namespace:
+
+```ts
+// src/core/plugin-manager.ts:450
+const lifeProviders = this.capabilityRegistry.providersOf("core-lifecycle:lifecycle.drive");
+```
+
+Combined with the capability registry's ownership rule (a capability
+`<plugin>:<name>` may only be `defineCapability`'d by a plugin whose `name`
+matches the prefix — `src/core/capability-registry.ts:19`), this means **only
+a plugin literally named `core-lifecycle` can ever drive the session**.
+
+The fixture plugin for the core orchestration tests (issue #12) had to
+identify as `core-lifecycle` to satisfy the ownership check — a workaround for
+a name-level coupling the platform has no business enforcing. The driver is a
+slot; any plugin should be allowed to fill it.
+
+## Framing
+
+Walking back through what the platform actually does reveals that the bug is
+smaller than the original issue suggests — and that a prior design decision
+was the real mistake.
+
+After `bootstrap()`, core does exactly one thing with plugins: it hands
+control to one of them by calling its `start()` method. That hand-off is the
+**single contract between core and plugins**. Everything else
+(executors, UI, tools, secrets, events) is plugins talking to plugins — core
+has no stake in it.
+
+Earlier design language (`DESIGN.md`) introduced "roles" as a separate
+concept, and executor, UI, and lifecycle were all modeled as roles. That
+conflation caused two problems:
+
+1. **Executor was wrongly elevated.** "Executor" is a convenience interface
+   between `core-lifecycle` and its executor plugins. It is not a
+   platform-level concept. A different lifecycle plugin might not use
+   executors at all. Core should not know about it.
+2. **Lifecycle was wrongly demoted.** Treating lifecycle as "just another
+   capability" forced it through the registry's ownership-prefix rule,
+   which is exactly what produced the hardcoded-namespace bug.
+
+The fix separates these layers cleanly.
+
+## Design
+
+### Core holds exactly one opinion
+
+Kaizen is a plugin platform with a single required contract: **one loaded
+plugin must be the session driver.** Core loads plugins, validates
+capabilities, then calls `start()` on that one plugin and gets out of the
+way.
+
+This is the minimum opinion the binary must hold — without it there is no
+session to run. Everything else (what the driver does, what it calls, what
+other plugins it consults) is plugin-land. Core holds no opinion about any
+of it.
+
+### Manifest flag identifies the driver
+
+A plugin declares itself as the session driver by adding `lifecycle: true` to
+its default export:
+
+```ts
+export default {
+  name: "core-lifecycle",
+  apiVersion: "2",
+  lifecycle: true,
+  capabilities: { ... },
+  async setup(ctx) { ... },
+  async start(ctx) { ... },
+};
+```
+
+Core identifies the driver by scanning loaded plugins for this flag.
+
+**No config-key fallback, no override mechanism.** Rationale: multiple
+resolution paths invite "works on my machine" drift, where a developer flips
+a config key locally and forgets to do it in CI. Declaring lifecycle-ness
+belongs in the plugin's code, not harness configuration. Harnesses select a
+lifecycle by installing exactly one plugin that declares the flag.
+
+### Validation rules
+
+Evaluated after all plugins are loaded and capability validation passes:
+
+| Condition | Outcome |
+|---|---|
+| Exactly one plugin has `lifecycle: true` | Core calls its `start()`. |
+| Zero plugins have `lifecycle: true` | Fatal: `No lifecycle plugin found. A plugin with 'lifecycle: true' must be loaded.` |
+| Two or more plugins have `lifecycle: true` | Fatal: `Multiple lifecycle plugins loaded: 'a', 'b'. A harness may have exactly one plugin with 'lifecycle: true'. Remove one from your kaizen.json.` |
+| Flagged plugin exists but has no `start` function | Fatal: `Plugin 'x' declares 'lifecycle: true' but does not export a start() function.` |
+
+The multi-driver error lists all offending plugin names so the user knows
+exactly which to remove.
+
+### Capability registry unchanged
+
+The registry keeps its current behavior — in particular, the ownership-prefix
+rule for `defineCapability` stays. Capabilities are plugin-to-plugin
+interfaces; the rule is a useful nudge that prevents one plugin from defining
+something in another's namespace.
+
+The `core-lifecycle:lifecycle.drive` capability is **deleted**. It exists
+today solely as the hardcoded lookup key. With the manifest flag replacing
+it, no one needs it:
+
+- `core-lifecycle` no longer provides or defines it.
+- Three consumer plugins (`core-cli`, `core-plugin-manager`, `timestamps`)
+  declare `consumes: ["core-lifecycle:lifecycle.drive"]` but never reference
+  it at runtime — it was a declarative "ensure a lifecycle is loaded"
+  signal. That check is now subsumed by the driver-lookup error, which fires
+  at the same bootstrap phase with a clearer message.
+
+Other `core-lifecycle:*` capabilities (`ui.input`, `ui.output`,
+`executor.send`) are untouched. They are real plugin-to-plugin interfaces
+legitimately owned by `core-lifecycle`.
+
+### Plugin type change
+
+Add `lifecycle?: boolean` to the `KaizenPlugin` type in
+`src/types/plugin.ts`. Optional; defaults to false/absent.
+
+## Implementation
+
+### Core (`kaizen`)
+
+1. **`src/types/plugin.ts`** — add `lifecycle?: boolean` to `KaizenPlugin`.
+2. **`src/core/plugin-manager.ts`** — replace the hardcoded capability lookup
+   (lines ~449–455) with a scan of loaded plugins for `lifecycle === true`.
+   Enforce the three validation rules above. Error messages per the table.
+3. **`src/core/plugin-manager.test.ts`** — update existing tests that build
+   fixtures via `provides: ["core-lifecycle:lifecycle.drive"]` to use
+   `lifecycle: true` instead. Add tests for the zero / multiple / missing-start
+   error paths.
+4. **`src/core/orchestration.test.ts`** — no change needed (it consumes
+   fixture plugins, doesn't define the driver directly).
+5. **`tests/fixtures/ci-marketplace/plugins/fixture-lifecycle/index.mjs`** —
+   rename `name` back to `"fixture-lifecycle"`, add `lifecycle: true`, drop
+   the `core-lifecycle:lifecycle.drive` provides entry and the corresponding
+   `defineCapability`. Remove the issue #13 workaround comment.
+6. **`DESIGN.md`** — replace the "Role" definition and any role-framed
+   prose with the platform-contract framing: core's single opinion is the
+   session-driver hand-off; everything else is plugin-to-plugin. Remove
+   references to executor/UI as roles.
+
+### Official plugins (`kaizen-official-plugins`)
+
+Coordinated release alongside core. Mechanical edits:
+
+1. **`plugins/core-lifecycle/index.ts`**
+   - Add `lifecycle: true` to the default export.
+   - Remove `"core-lifecycle:lifecycle.drive"` from `capabilities.provides`.
+   - Remove the matching `ctx.defineCapability("core-lifecycle:lifecycle.drive", ...)` call.
+2. **`plugins/core-cli/index.ts`** — remove `consumes: ["core-lifecycle:lifecycle.drive"]`.
+3. **`plugins/core-plugin-manager/index.ts`** — same.
+4. **`plugins/timestamps/index.ts`** — remove the `lifecycle.drive` entry from its
+   `consumes` list (keep `core-events:service`).
+5. **Tests** — update any per-plugin tests that assert on the deleted
+   capability.
+
+No executor, UI, secrets, or events plugin is touched. No capability names
+are renamed.
+
+### Release coordination
+
+Core change and official-plugins change ship together. The kaizen binary
+loading an old `core-lifecycle` (still providing `core-lifecycle:lifecycle.drive`
+but without `lifecycle: true`) would fail with the "no lifecycle plugin
+found" error. Old kaizen binary loading new `core-lifecycle` (no
+`lifecycle.drive` capability) would also fail.
+
+This is a breaking change for any third-party lifecycle plugins (none known
+to exist at this stage of the project). No deprecation period.
+
+## Acceptance
+
+- A fixture plugin named `fixture-lifecycle` (or any other name) can drive
+  the session without identifying as `core-lifecycle`.
+- `tests/fixtures/ci-marketplace/plugins/fixture-lifecycle/` reverts to
+  `name: "fixture-lifecycle"` with the workaround comment removed.
+- The `core-lifecycle:lifecycle.drive` capability no longer exists anywhere
+  in either repo.
+- Real `core-lifecycle` still works; the default stack still boots.
+- Loading two plugins with `lifecycle: true` produces the prescribed error.
+- Loading zero lifecycle plugins produces the prescribed error.
+- `grep -r 'core-lifecycle:' src/core/` in the kaizen repo returns no
+  hardcoded capability strings in runtime code (only in tests and comments,
+  if any).
+
+## Non-goals
+
+- Relaxing or removing the capability-registry ownership-prefix rule. Out of
+  scope; the rule provides value for plugin-owned interfaces and is not what
+  this issue is about.
+- Introducing a formal "roles" concept. Explicitly rejected — capabilities
+  cover plugin-to-plugin contracts; the single core contract is the driver
+  hand-off.
+- Config-based driver selection or override. Rejected for the reasons in the
+  Manifest Flag section.
+- Reworking executor, UI, or any other capability shape. Those stay as
+  plugin-owned capabilities.

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -172,6 +172,29 @@ describe("PluginManager.initialize", () => {
     );
     await expect(manager.initialize()).rejects.toThrow(/provides critical capability.*boom/i);
   });
+
+  test("finds session driver via lifecycle:true flag — no capability required", async () => {
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+    executorRegistry.register(stubExecutor, "test-exec");
+    uiRegistry.register(stubUi, "test-ui");
+
+    const driver: KaizenPlugin = {
+      name: "fixture-lifecycle",
+      apiVersion: "2",
+      lifecycle: true,
+      async setup() {},
+      async start() {},
+    };
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: ["fixture-lifecycle"] }, { "fixture-lifecycle": driver },
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+    const { lifecycleProvider } = await manager.initialize();
+    expect(lifecycleProvider.name).toBe("fixture-lifecycle");
+  });
 });
 
 describe("PluginManager.load + unload + reload", () => {

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -97,9 +97,8 @@ describe("PluginManager.initialize", () => {
     const lifecyclePlugin: KaizenPlugin = {
       name: "core-lifecycle",
       apiVersion: "2",
-      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
-      async setup(ctx) {
-        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "lifecycle" });
+      lifecycle: true,
+      async setup() {
         setupCalls.push("core-lifecycle");
       },
       async start() {},
@@ -132,10 +131,8 @@ describe("PluginManager.initialize", () => {
     });
     const lifecyclePlugin: KaizenPlugin = {
       name: "core-lifecycle", apiVersion: "2",
-      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
-      async setup(ctx) {
-        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "lifecycle" });
-      },
+      lifecycle: true,
+      async setup() {},
       async start() {},
     };
 
@@ -328,10 +325,8 @@ describe("PluginManager runtime accept-and-record (item 2)", () => {
     // Need a lifecycle provider for initialize() to succeed.
     const lifePlugin: KaizenPlugin = {
       name: "core-lifecycle", apiVersion: "2",
-      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
-      async setup(ctx) {
-        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "" });
-      },
+      lifecycle: true,
+      async setup() {},
       async start() {},
     };
 
@@ -459,10 +454,8 @@ describe("PluginManager capability validation", () => {
     };
     const life: KaizenPlugin = {
       name: "core-lifecycle", apiVersion: "2",
-      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
-      async setup(ctx) {
-        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "" });
-      },
+      lifecycle: true,
+      async setup() {},
       async start() {},
     };
     const manager = new PluginManager(
@@ -500,17 +493,18 @@ describe("PluginManager capability validation", () => {
     const regs = baseRegistries();
     const life: KaizenPlugin = {
       name: "core-lifecycle", apiVersion: "2",
-      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
+      lifecycle: true,
+      capabilities: { provides: ["core-lifecycle:executor.send"] },
       async setup(ctx) {
-        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "" });
+        ctx.defineCapability("core-lifecycle:executor.send", { cardinality: "many", description: "" });
       },
       async start() {},
     };
     let consumerRan = false;
     const consumer: KaizenPlugin = {
       name: "consumer", apiVersion: "2",
-      aliases: { "lifecycle": "core-lifecycle:lifecycle.drive" },
-      capabilities: { consumes: ["lifecycle"] },
+      aliases: { "executor": "core-lifecycle:executor.send" },
+      capabilities: { consumes: ["executor"] },
       async setup() { consumerRan = true; },
     };
     const manager = new PluginManager(
@@ -528,10 +522,8 @@ describe("PluginManager capability validation", () => {
     const regs = baseRegistries();
     const life: KaizenPlugin = {
       name: "core-lifecycle", apiVersion: "2",
-      capabilities: { provides: ["core-lifecycle:lifecycle.drive"] },
-      async setup(ctx) {
-        ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "" });
-      },
+      lifecycle: true,
+      async setup() {},
       async start() {},
     };
     const bad: KaizenPlugin = {

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -192,6 +192,60 @@ describe("PluginManager.initialize", () => {
     const { lifecycleProvider } = await manager.initialize();
     expect(lifecycleProvider.name).toBe("fixture-lifecycle");
   });
+
+  test("fatals when no plugin declares lifecycle:true", async () => {
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+    const plain = makePlugin("tool-only", async () => {});
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: ["tool-only"] }, { "tool-only": plain },
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+    await expect(manager.initialize()).rejects.toThrow(/No lifecycle plugin found.*lifecycle: true/);
+  });
+
+  test("fatals with names listed when two plugins declare lifecycle:true", async () => {
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+    executorRegistry.register(stubExecutor, "test-exec");
+    uiRegistry.register(stubUi, "test-ui");
+    const a: KaizenPlugin = { name: "a-life", apiVersion: "2", lifecycle: true, async setup() {}, async start() {} };
+    const b: KaizenPlugin = { name: "b-life", apiVersion: "2", lifecycle: true, async setup() {}, async start() {} };
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: ["a-life", "b-life"] }, { "a-life": a, "b-life": b },
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+    await expect(manager.initialize()).rejects.toThrow(
+      /Multiple lifecycle plugins loaded: 'a-life', 'b-life'.*exactly one/,
+    );
+  });
+
+  test("fatals when lifecycle plugin has no start() function", async () => {
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+    executorRegistry.register(stubExecutor, "test-exec");
+    uiRegistry.register(stubUi, "test-ui");
+    // Deliberately omit start().
+    const broken: KaizenPlugin = {
+      name: "broken-life",
+      apiVersion: "2",
+      lifecycle: true,
+      async setup() {},
+    };
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: ["broken-life"] }, { "broken-life": broken },
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+    await expect(manager.initialize()).rejects.toThrow(
+      /'broken-life' declares 'lifecycle: true' but does not export a start\(\) function/,
+    );
+  });
 });
 
 describe("PluginManager.load + unload + reload", () => {

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -150,6 +150,28 @@ describe("PluginManager.initialize", () => {
     await manager.initialize();
     expect(toolRegistry.list().map((t) => t.name)).toContain("my-tool");
   });
+
+  test("plugin with lifecycle:true is treated as critical — setup throws are fatal", async () => {
+    const { eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry } = makeRegistries();
+    executorRegistry.register(stubExecutor, "test-exec");
+    uiRegistry.register(stubUi, "test-ui");
+
+    const life: KaizenPlugin = {
+      name: "core-lifecycle",
+      apiVersion: "2",
+      lifecycle: true,
+      async setup() { throw new Error("boom"); },
+      async start() {},
+    };
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: ["core-lifecycle"] }, { "core-lifecycle": life },
+      eventBus, toolRegistry, executorRegistry, uiRegistry, capabilityRegistry, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+    await expect(manager.initialize()).rejects.toThrow(/provides critical capability.*boom/i);
+  });
 });
 
 describe("PluginManager.load + unload + reload", () => {

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -205,6 +205,7 @@ function resolveCapName(name: string, aliases: Record<string, string>): string {
 }
 
 function isCritical(plugin: KaizenPlugin, reg: CapabilityRegistry): boolean {
+  if (plugin.lifecycle === true) return true;
   const aliases = plugin.aliases ?? {};
   for (const raw of plugin.capabilities?.provides ?? []) {
     const cap = resolveCapName(raw, aliases);

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -447,12 +447,28 @@ export class PluginManager {
       if (!claimedKeys.has(key)) warn(`Unknown config key '${key}'. No plugin claimed it.`);
     }
 
-    // Resolve lifecycle provider — sole provider of core-lifecycle:lifecycle.drive
-    const lifeProviders = this.capabilityRegistry.providersOf("core-lifecycle:lifecycle.drive");
-    if (lifeProviders.length === 0) fatal("No lifecycle plugin found. Add one to kaizen.json.");
-    const lifecycleProvider = this.plugins.get(lifeProviders[0]!)?.plugin;
+    // Resolve lifecycle provider — the one plugin with `lifecycle: true`.
+    // Core's single cross-plugin contract: call start() on the session driver.
+    const lifecyclePluginNames: string[] = [];
+    for (const [name, entry] of this.plugins) {
+      if (entry.plugin.lifecycle === true && entry.entry.status === "loaded") {
+        lifecyclePluginNames.push(name);
+      }
+    }
+    if (lifecyclePluginNames.length === 0) {
+      fatal("No lifecycle plugin found. A plugin with 'lifecycle: true' must be loaded. Add one to kaizen.json.");
+    }
+    if (lifecyclePluginNames.length > 1) {
+      const quoted = lifecyclePluginNames.map((n) => `'${n}'`).join(", ");
+      fatal(
+        `Multiple lifecycle plugins loaded: ${quoted}. ` +
+        `A harness may have exactly one plugin with 'lifecycle: true'. Remove one from your kaizen.json.`,
+      );
+    }
+    const lifecycleName = lifecyclePluginNames[0]!;
+    const lifecycleProvider = this.plugins.get(lifecycleName)?.plugin;
     if (!lifecycleProvider || typeof lifecycleProvider.start !== "function") {
-      fatal("No lifecycle plugin found. Add one to kaizen.json.");
+      fatal(`Plugin '${lifecycleName}' declares 'lifecycle: true' but does not export a start() function.`);
     }
 
     return { lifecycleProvider: lifecycleProvider! };

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -342,6 +342,13 @@ export interface KaizenPlugin {
   /** semver. Core warns if major != PLUGIN_API_VERSION. */
   apiVersion: string;
 
+  /**
+   * True if this plugin drives the session loop. Core calls start() on the
+   * one plugin with lifecycle=true after bootstrap. Exactly one loaded
+   * plugin must declare this; zero or two+ is a fatal startup error.
+   */
+  lifecycle?: boolean;
+
   /** What this plugin provides and consumes in the capability registry. */
   capabilities?: PluginCapabilities;
 

--- a/tests/fixtures/ci-marketplace/plugins/fixture-executor/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/fixture-executor/index.mjs
@@ -3,7 +3,7 @@
 export default {
   name: "fixture-executor",
   apiVersion: "2",
-  capabilities: { provides: ["core-lifecycle:executor.send"] },
+  capabilities: { provides: ["fixture-lifecycle:executor.send"] },
   async setup(ctx) {
     ctx.registerExecutor({
       async send(messages, tools) {

--- a/tests/fixtures/ci-marketplace/plugins/fixture-lifecycle/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/fixture-lifecycle/index.mjs
@@ -1,22 +1,16 @@
 // Minimal lifecycle provider. Drives exactly one session turn, emits
 // test:lifecycle:start / :end bracketing the work, then returns so
 // bootstrap() resolves.
-// Workaround for issue #13: core hardcodes "core-lifecycle:lifecycle.drive"
-// as the session-driver lookup, and the capability-namespace ownership rule
-// requires the defining plugin's name to match the namespace prefix. Until
-// that coupling is removed, any lifecycle-driver plugin must identify as
-// "core-lifecycle". Rename to "fixture-lifecycle" once #13 lands.
 export default {
-  name: "core-lifecycle",
+  name: "fixture-lifecycle",
   apiVersion: "2",
+  lifecycle: true,
   capabilities: {
-    provides: ["core-lifecycle:lifecycle.drive"],
-    consumes: ["core-lifecycle:executor.send", "core-lifecycle:ui"],
+    consumes: ["fixture-lifecycle:executor.send", "fixture-lifecycle:ui"],
   },
   async setup(ctx) {
-    ctx.defineCapability("core-lifecycle:lifecycle.drive", { cardinality: "one", description: "lifecycle driver" });
-    ctx.defineCapability("core-lifecycle:executor.send", { cardinality: "one", description: "LLM executor" });
-    ctx.defineCapability("core-lifecycle:ui", { cardinality: "many", description: "UI provider" });
+    ctx.defineCapability("fixture-lifecycle:executor.send", { cardinality: "one", description: "LLM executor" });
+    ctx.defineCapability("fixture-lifecycle:ui", { cardinality: "many", description: "UI provider" });
   },
   async start(ctx) {
     await ctx.emit("test:lifecycle:start");

--- a/tests/fixtures/ci-marketplace/plugins/fixture-ui/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/fixture-ui/index.mjs
@@ -3,7 +3,7 @@
 export default {
   name: "fixture-ui",
   apiVersion: "2",
-  capabilities: { provides: ["core-lifecycle:ui"] },
+  capabilities: { provides: ["fixture-lifecycle:ui"] },
   async setup(ctx) {
     ctx.registerUi({
       async *accept() {


### PR DESCRIPTION
## Summary

Fixes #13. Replaces the hardcoded `core-lifecycle:lifecycle.drive` capability lookup with a `lifecycle: true` manifest flag, so any plugin can drive the session without pretending to own the `core-lifecycle` namespace.

- **Core contract clarified:** the session-driver hand-off is the *only* plugin-to-core contract. Everything else (executor, UI, tools) is plugin-to-plugin via the capability registry. "Role" language is deprecated.
- **Manifest flag only** — no config-key fallback. Multiple lifecycle plugins loaded → clear fatal with plugin names. Zero lifecycle plugins → clear fatal. Flagged plugin without `start()` → clear fatal.
- **Capability registry unchanged.** Ownership-prefix rule stays; it guards plugin-to-plugin interfaces. Only `core-lifecycle:lifecycle.drive` was deleted.
- **CI fixture `fixture-lifecycle` reverts to its real name** and its now-legitimately-owned capabilities move to `fixture-lifecycle:` prefix.

## Coordinated change

Paired with [CraightonH/kaizen-official-plugins#feat/lifecycle-flag-13](https://github.com/CraightonH/kaizen-official-plugins/tree/feat/lifecycle-flag-13), which adds the flag to `core-lifecycle`, drops the deleted capability, and removes three vestigial `consumes` entries. Merge together.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-04-20-lifecycle-driver-decoupling-design.md`
- Plan: `docs/superpowers/plans/2026-04-20-lifecycle-driver-decoupling.md`

## Test plan

- [x] Full suite passes (360/360)
- [x] Orchestration test passes with `fixture-lifecycle` as its real name
- [x] New tests cover zero/multiple/missing-start error paths
- [x] `grep -r 'core-lifecycle:lifecycle.drive' src/ tests/` returns no hits