### PR TITLE
Remove builtins plugin-injection seam (#25)

### DIFF
--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -140,8 +140,10 @@ that depends on this — fix the manifest.
 
 See the "What's not enforced" section in [`../README.md`](../README.md) — in
 short, this sandbox defeats honest-but-buggy and casually-malicious plugins,
-not V8 JIT escapes, FFI, or supply-chain attacks. Lockfile hash verification
-catches post-consent code swaps but does not verify npm resolution itself.
+not V8 JIT escapes, FFI, or supply-chain attacks. The lockfile hash is a
+canonical hash of the plugin's tier and permissions — changes to the declared
+permission manifest force re-consent, but plugin file contents are not hashed,
+so post-consent code swaps that keep the same manifest are not detected.
 
 ## Further reading
 

--- a/docs/core-internals.md
+++ b/docs/core-internals.md
@@ -24,7 +24,7 @@ src/core/
 `src/core/index.ts` is the single public entry point for the runtime:
 
 ```typescript
-await bootstrap(kaizenConfig, builtins);
+await bootstrap(kaizenConfig);
 ```
 
 1. Creates `EventBus`, `CapabilityRegistry`, `ServiceRegistry`.
@@ -34,10 +34,8 @@ await bootstrap(kaizenConfig, builtins);
 5. Calls `lifecycleProvider.start(ctx)` — control passes to the lifecycle plugin.
 6. Sets state to `CLOSED` in a `finally` block.
 
-`builtins` is a `Record<string, KaizenPlugin>` populated by the CLI entrypoint
-with statically-imported plugins. The loader checks builtins first; if no match,
-it attempts marketplace-install resolution. The compiled binary can ship with
-built-in plugins and never touch the filesystem for them.
+All plugins are resolved from canonical marketplace refs or local paths — the
+core binary ships with no built-in plugins.
 
 ## Plugin loader (`plugin-manager.ts`)
 
@@ -52,8 +50,7 @@ For each plugin name in `config.plugins`:
 3. Otherwise: fail with a helpful error.
 
 There is no `node_modules` involvement, no `npm`/`bun` global lookup, and no
-bare-name authored-plugin fallback. The `builtins` parameter on
-`initializePluginSystem` is a test-only seam — the shipping CLI passes `{}`.
+bare-name authored-plugin fallback.
 
 ### Topological sort
 

--- a/docs/superpowers/plans/2026-04-21-remove-builtins-plugin-seam.md
+++ b/docs/superpowers/plans/2026-04-21-remove-builtins-plugin-seam.md
@@ -1,0 +1,674 @@
+# Remove `builtins` Plugin-Injection Seam — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the `builtins: Record<string, KaizenPlugin>` parameter that is threaded through the plugin system as a test-only injection seam, and rewrite its only live consumer (`driver-capability-resolution.test.ts`) to use real fixtures installed from the existing local `ci-marketplace`.
+
+**Architecture:** Two workstreams. (1) Test-first: add new `cap-*` fixture plugins to `tests/fixtures/ci-marketplace/`, then rewrite `driver-capability-resolution.test.ts` to install them via `addMarketplace` + `runUnifiedInstall` (full-fidelity) before the old seam is removed — so the test exercises the real production path. (2) After the rewritten test is green, delete `builtins` from all production signatures in one compiler-enforced pass.
+
+**Tech Stack:** TypeScript, Bun test runner, existing `tests/fixtures/ci-marketplace` local marketplace (symlinked via `addMarketplace({ local: true })`).
+
+**Spec:** `docs/superpowers/specs/2026-04-21-remove-builtins-plugin-seam-design.md`
+
+**Issue:** https://github.com/CraightonH/kaizen/issues/25
+
+---
+
+## File Structure
+
+**New fixture plugins** (under `tests/fixtures/ci-marketplace/plugins/`):
+- `cap-provider/{package.json,index.mjs}` — defines + provides `cap:thing` (cardinality one)
+- `cap-driver/{package.json,index.mjs}` — lifecycle plugin, consumes `cap:thing`
+- `cap-owner/{package.json,index.mjs}` — defines `conflict:thing` (cardinality one)
+- `cap-dup-a/{package.json,index.mjs}` — provides `conflict:thing`
+- `cap-dup-b/{package.json,index.mjs}` — provides `conflict:thing`
+- `cap-driver-conflict/{package.json,index.mjs}` — lifecycle plugin, consumes `conflict:thing`
+
+**Modified files:**
+- `tests/fixtures/ci-marketplace/.kaizen/marketplace.json` — append 6 new entries
+- `src/core/integration/driver-capability-resolution.test.ts` — full rewrite (inline install helper)
+- `src/core/plugin-manager.ts` — drop `Builtins` type + `builtins` param from ctor and `resolvePlugin`
+- `src/core/index.ts` — drop `builtins` from `initializePluginSystem`, `runHarness`, `bootstrap`; drop `Builtins` re-export
+- `src/commands/manage.ts` — drop `builtins` param from `cmdPluginList` and `statusFor`
+- `src/commands/plugin-dev.ts` — drop `builtins` from `runPluginDevObserve` args
+- `src/cli.ts` — delete `const builtins = {}` (line 29) and all four pass-sites; remove `KaizenPlugin` import if unused
+
+---
+
+## Task 1: Add `cap-*` fixture plugins to ci-marketplace
+
+**Files:**
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-provider/package.json`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-provider/index.mjs`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-driver/package.json`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-driver/index.mjs`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-owner/package.json`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-owner/index.mjs`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-dup-a/package.json`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-dup-a/index.mjs`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-dup-b/package.json`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-dup-b/index.mjs`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/package.json`
+- Create: `tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/index.mjs`
+- Modify: `tests/fixtures/ci-marketplace/.kaizen/marketplace.json`
+
+- [ ] **Step 1: Create `cap-provider` plugin**
+
+`tests/fixtures/ci-marketplace/plugins/cap-provider/package.json`:
+```json
+{
+  "name": "cap-provider",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}
+```
+
+`tests/fixtures/ci-marketplace/plugins/cap-provider/index.mjs`:
+```js
+export default {
+  name: "cap-provider",
+  apiVersion: "2",
+  capabilities: { provides: ["cap:thing"] },
+  async setup(ctx) {
+    ctx.defineCapability("cap:thing", { cardinality: "one", description: "test" });
+  },
+};
+```
+
+- [ ] **Step 2: Create `cap-driver` plugin**
+
+`tests/fixtures/ci-marketplace/plugins/cap-driver/package.json`:
+```json
+{
+  "name": "cap-driver",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}
+```
+
+`tests/fixtures/ci-marketplace/plugins/cap-driver/index.mjs`:
+```js
+export default {
+  name: "cap-driver",
+  apiVersion: "2",
+  lifecycle: true,
+  capabilities: { consumes: ["cap:thing"] },
+  async setup() {},
+  async start() {},
+};
+```
+
+- [ ] **Step 3: Create `cap-owner` plugin**
+
+`tests/fixtures/ci-marketplace/plugins/cap-owner/package.json`:
+```json
+{
+  "name": "cap-owner",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}
+```
+
+`tests/fixtures/ci-marketplace/plugins/cap-owner/index.mjs`:
+```js
+export default {
+  name: "cap-owner",
+  apiVersion: "2",
+  async setup(ctx) {
+    ctx.defineCapability("conflict:thing", { cardinality: "one", description: "test" });
+  },
+};
+```
+
+- [ ] **Step 4: Create `cap-dup-a` plugin**
+
+`tests/fixtures/ci-marketplace/plugins/cap-dup-a/package.json`:
+```json
+{
+  "name": "cap-dup-a",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}
+```
+
+`tests/fixtures/ci-marketplace/plugins/cap-dup-a/index.mjs`:
+```js
+export default {
+  name: "cap-dup-a",
+  apiVersion: "2",
+  capabilities: { provides: ["conflict:thing"] },
+  async setup() {},
+};
+```
+
+- [ ] **Step 5: Create `cap-dup-b` plugin**
+
+`tests/fixtures/ci-marketplace/plugins/cap-dup-b/package.json`:
+```json
+{
+  "name": "cap-dup-b",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}
+```
+
+`tests/fixtures/ci-marketplace/plugins/cap-dup-b/index.mjs`:
+```js
+export default {
+  name: "cap-dup-b",
+  apiVersion: "2",
+  capabilities: { provides: ["conflict:thing"] },
+  async setup() {},
+};
+```
+
+- [ ] **Step 6: Create `cap-driver-conflict` plugin**
+
+`tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/package.json`:
+```json
+{
+  "name": "cap-driver-conflict",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}
+```
+
+`tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/index.mjs`:
+```js
+export default {
+  name: "cap-driver-conflict",
+  apiVersion: "2",
+  lifecycle: true,
+  capabilities: { consumes: ["conflict:thing"] },
+  async setup() {},
+  async start() {},
+};
+```
+
+- [ ] **Step 7: Append new entries to marketplace catalog**
+
+Modify `tests/fixtures/ci-marketplace/.kaizen/marketplace.json`. Append these six entries to the existing `entries` array (after `fixture-lifecycle`, preserving JSON array syntax — add a trailing comma after the prior last entry):
+
+```json
+    {
+      "kind": "plugin",
+      "name": "cap-provider",
+      "description": "Capability-resolution test fixture: defines and provides cap:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-provider" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-driver",
+      "description": "Capability-resolution test fixture: lifecycle driver consuming cap:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-driver" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-owner",
+      "description": "Capability-resolution test fixture: defines conflict:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-owner" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-dup-a",
+      "description": "Capability-resolution test fixture: provides conflict:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-dup-a" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-dup-b",
+      "description": "Capability-resolution test fixture: provides conflict:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-dup-b" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-driver-conflict",
+      "description": "Capability-resolution test fixture: lifecycle driver consuming conflict:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-driver-conflict" } }
+      ]
+    }
+```
+
+- [ ] **Step 8: Verify marketplace JSON parses**
+
+Run: `bun -e 'JSON.parse(require("fs").readFileSync("tests/fixtures/ci-marketplace/.kaizen/marketplace.json","utf8")); console.log("ok")'`
+
+Expected output: `ok`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tests/fixtures/ci-marketplace/
+git commit -m "test(fixtures): add cap-* plugins to ci-marketplace for capability-resolution tests"
+```
+
+---
+
+## Task 2: Rewrite `driver-capability-resolution.test.ts` to use installed fixtures
+
+**Note:** This task does NOT yet remove `builtins` from `PluginManager`. The rewritten test still calls the current constructor passing `{}` for `builtins` (since the param is still there). After Task 2 is green, Task 3 removes the param and this call-site gets updated inline with the compiler failure.
+
+**Files:**
+- Modify: `src/core/integration/driver-capability-resolution.test.ts` (full rewrite, ~100 → ~140 LOC)
+
+- [ ] **Step 1: Replace the test file**
+
+Overwrite `src/core/integration/driver-capability-resolution.test.ts` with:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { PluginManager } from "../plugin-manager.js";
+import { EventBus } from "../event-bus.js";
+import { ServiceRegistry } from "../service-registry.js";
+import { CapabilityRegistry } from "../capability-registry.js";
+import { PermissionEnforcer } from "../permission-enforcer.js";
+import { AuditLog } from "../audit-log.js";
+import { addMarketplace } from "../marketplace.js";
+import { runUnifiedInstall } from "../../commands/install.js";
+import type { KaizenConfig } from "../../types/plugin.js";
+
+const CI_MARKETPLACE = resolve(__dirname, "../../../tests/fixtures/ci-marketplace");
+const MARKETPLACE_ID = "ci-marketplace";
+
+async function installFixtures(names: string[], lockfilePath: string): Promise<void> {
+  await addMarketplace(CI_MARKETPLACE, { id: MARKETPLACE_ID, local: true });
+  for (const name of names) {
+    const code = await runUnifiedInstall({
+      ref: `${MARKETPLACE_ID}/${name}@1.0.0`,
+      lockfilePath,
+      allowUnscoped: false,
+      nonInteractive: true,
+    });
+    if (code !== 0) throw new Error(`install failed for ${name} (code ${code})`);
+  }
+}
+
+function makeHarness(pluginRefs: string[], lockfilePath: string) {
+  const eventBus = new EventBus();
+  const capabilityRegistry = new CapabilityRegistry();
+  const serviceRegistry = new ServiceRegistry();
+  const enforcer = new PermissionEnforcer({ mode: "log-only" });
+  const auditLog = new AuditLog({
+    rootDir: mkdtempSync(join(tmpdir(), "kz-driver-cap-audit-")),
+    sessionId: "test",
+    enabled: false,
+  });
+  const options = { trustLockfile: false, allowUnscoped: false, nonInteractive: true };
+  const config: KaizenConfig = { plugins: pluginRefs };
+
+  const manager = new PluginManager(
+    config, {},
+    eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, options,
+  );
+  return { manager, capabilityRegistry };
+}
+
+describe("driver capability resolution (post-registry-refactor)", () => {
+  let home: string;
+  let lockfilePath: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kz-driver-cap-home-"));
+    process.env.KAIZEN_HOME_OVERRIDE = home;
+    lockfilePath = join(mkdtempSync(join(tmpdir(), "kz-driver-cap-lock-")), "kaizen.permissions.lock");
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env.KAIZEN_HOME_OVERRIDE;
+  });
+
+  it("resolves a provider by name via CapabilityRegistry when one plugin provides it", async () => {
+    await installFixtures(["cap-provider", "cap-driver"], lockfilePath);
+
+    const { manager, capabilityRegistry } = makeHarness(
+      [`${MARKETPLACE_ID}/cap-provider@1.0.0`, `${MARKETPLACE_ID}/cap-driver@1.0.0`],
+      lockfilePath,
+    );
+
+    await manager.initialize();
+    expect(capabilityRegistry.providersOf("cap:thing")).toContain("cap-provider");
+  });
+
+  it("fails initialization when a cardinality-one capability has two providers", async () => {
+    await installFixtures(
+      ["cap-owner", "cap-dup-a", "cap-dup-b", "cap-driver-conflict"],
+      lockfilePath,
+    );
+
+    const { manager } = makeHarness(
+      [
+        `${MARKETPLACE_ID}/cap-owner@1.0.0`,
+        `${MARKETPLACE_ID}/cap-dup-a@1.0.0`,
+        `${MARKETPLACE_ID}/cap-dup-b@1.0.0`,
+        `${MARKETPLACE_ID}/cap-driver-conflict@1.0.0`,
+      ],
+      lockfilePath,
+    );
+
+    await expect(manager.initialize()).rejects.toThrow(/Multiple plugins provide/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the rewritten test**
+
+Run: `bun test src/core/integration/driver-capability-resolution.test.ts`
+
+Expected: both tests PASS. If they fail, investigate before proceeding — the rewrite must be green before removing `builtins`.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `bun test`
+
+Expected: all tests PASS (no regressions introduced by the marketplace additions).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/integration/driver-capability-resolution.test.ts
+git commit -m "test(integration): install driver-capability fixtures via runUnifiedInstall"
+```
+
+---
+
+## Task 3: Remove `builtins` parameter from production code
+
+**Files:**
+- Modify: `src/core/plugin-manager.ts`
+- Modify: `src/core/index.ts`
+- Modify: `src/commands/manage.ts`
+- Modify: `src/commands/plugin-dev.ts`
+- Modify: `src/cli.ts`
+- Modify: `src/core/integration/driver-capability-resolution.test.ts` (drop `{}` positional arg from ctor call)
+
+- [ ] **Step 1: Remove `builtins` from `src/core/plugin-manager.ts`**
+
+Three edits in `src/core/plugin-manager.ts`:
+
+(a) Delete the `Builtins` type alias (line 59):
+```ts
+export type Builtins = Record<string, KaizenPlugin>;
+```
+Remove this line entirely. The `KaizenPlugin` import may become unused if not referenced elsewhere in the file — remove it from the import if so (compiler will flag unused imports).
+
+(b) In `resolvePlugin` (line 138), change:
+```ts
+async function resolvePlugin(name: string, builtins: Builtins): Promise<LoadedPlugin | null> {
+  if (builtins[name]) return { plugin: builtins[name]!, resolvedPath: null };
+
+  const isPath = name.startsWith("./") || name.startsWith("/") || name.startsWith("../");
+```
+to:
+```ts
+async function resolvePlugin(name: string): Promise<LoadedPlugin | null> {
+  const isPath = name.startsWith("./") || name.startsWith("/") || name.startsWith("../");
+```
+
+(c) In `PluginManager` constructor (line 262), delete the `private readonly builtins: Builtins,` line so the signature becomes:
+```ts
+  constructor(
+    private readonly config: KaizenConfig,
+    private readonly eventBus: EventBus,
+    private readonly capabilityRegistry: CapabilityRegistry,
+    private readonly serviceRegistry: ServiceRegistry,
+    private readonly enforcer: PermissionEnforcer,
+    private readonly auditLog: AuditLog,
+    private readonly lockfilePath: string,
+    private readonly options: { trustLockfile: boolean; allowUnscoped: boolean; nonInteractive: boolean },
+    private readonly globalConfig?: KaizenGlobalConfig,
+  ) {
+```
+
+(d) Update both call sites of `resolvePlugin`:
+- Line 343: `const loaded = await resolvePlugin(String(name), this.builtins);` → `const loaded = await resolvePlugin(String(name));`
+- Line 450: `const loaded = await resolvePlugin(name, this.builtins);` → `const loaded = await resolvePlugin(name);`
+
+- [ ] **Step 2: Remove `builtins` from `src/core/index.ts`**
+
+Edits in `src/core/index.ts`:
+
+(a) Line 7: Change `import { PluginManager, type Builtins } from "./plugin-manager.js";` → `import { PluginManager } from "./plugin-manager.js";`
+
+(b) Line 21: Delete the re-export line `export type { Builtins } from "./plugin-manager.js";`
+
+(c) `initializePluginSystem` (lines 34-67): Remove the `builtins` parameter and the positional arg in the `PluginManager` ctor call:
+```ts
+export async function initializePluginSystem(
+  kaizenConfig: KaizenConfig,
+  injectedEnforcer?: PermissionEnforcer,
+): Promise<InitializedSystem> {
+  // ... unchanged body until PluginManager construction ...
+  const manager = new PluginManager(
+    kaizenConfig,
+    eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, { trustLockfile, allowUnscoped, nonInteractive },
+  );
+```
+
+(d) `RunHarnessOpts` interface (line 75): Remove the `builtins?: Builtins;` line.
+
+(e) `runHarness` (line 81): Change to:
+```ts
+export async function runHarness(opts: RunHarnessOpts): Promise<void> {
+  const { kaizenConfig, enforcer: injectedEnforcer } = opts;
+  const {
+    manager, eventBus, capabilityRegistry, serviceRegistry, enforcer, auditLog, lifecycleProvider,
+  } = await initializePluginSystem(kaizenConfig, injectedEnforcer);
+```
+
+(f) `bootstrap` (line 110):
+```ts
+export async function bootstrap(kaizenConfig: KaizenConfig): Promise<void> {
+  return runHarness({ kaizenConfig });
+}
+```
+
+- [ ] **Step 3: Remove `builtins` from `src/commands/manage.ts`**
+
+(a) In `statusFor` (line 43), change:
+```ts
+function statusFor(
+  name: string,
+  builtins: Record<string, KaizenPlugin>,
+): InstallStatus {
+  if (Object.prototype.hasOwnProperty.call(builtins, name)) {
+    return { status: "built-in", version: "" };
+  }
+
+  try {
+```
+to:
+```ts
+function statusFor(name: string): InstallStatus {
+  try {
+```
+
+(b) Remove the `InstallStatus` status variant `"built-in"` if it exists only to serve this branch. Check the type definition — if `status: "built-in" | "installed" | "NOT INSTALLED"` has three variants, drop `"built-in"`.
+
+(c) In `cmdPluginList` (line 69), change:
+```ts
+export function cmdPluginList(builtins: Record<string, KaizenPlugin>): void {
+```
+to:
+```ts
+export function cmdPluginList(): void {
+```
+
+(d) Line 82: change `const s = statusFor(name, builtins);` → `const s = statusFor(name);`
+
+(e) Line 84: Remove the `s.status === "built-in" ? "built-in" :` branch in the label ternary (if variant was dropped in (b)):
+```ts
+    const label =
+      s.status === "NOT INSTALLED" ? (s.version ? `NOT INSTALLED (${s.version})` : "NOT INSTALLED")
+      : s.version;
+```
+
+(f) Remove the `KaizenPlugin` import at the top of the file if it is now unused.
+
+- [ ] **Step 4: Remove `builtins` from `src/commands/plugin-dev.ts`**
+
+In `src/commands/plugin-dev.ts`:
+
+(a) Line 11: Delete the import `import type { Builtins } from "../core/plugin-manager.js";`
+
+(b) Line 14: Change `runPluginDevObserve` args:
+```ts
+export async function runPluginDevObserve(args: {
+  pluginName: string;
+  pluginDir: string;
+  outDir: string;
+  kaizenConfig: KaizenConfig;
+}): Promise<number> {
+```
+
+(c) Line 46: change `await runHarness({ kaizenConfig: args.kaizenConfig, builtins: args.builtins, enforcer });` → `await runHarness({ kaizenConfig: args.kaizenConfig, enforcer });`
+
+- [ ] **Step 5: Remove `builtins` from `src/cli.ts`**
+
+In `src/cli.ts`:
+
+(a) Line 29: Delete `const builtins: Record<string, KaizenPlugin> = {};`
+
+(b) Line 21: Delete `import type { KaizenPlugin } from "./types/plugin.js";` if the type is no longer used anywhere in this file. (Search the file; if unused, remove.)
+
+(c) Line 326: Change `await runPluginDevObserve({ pluginName, pluginDir, outDir, kaizenConfig: devConfig, builtins });` → `await runPluginDevObserve({ pluginName, pluginDir, outDir, kaizenConfig: devConfig });`
+
+(d) Line 364: Change `cmdPluginList(builtins);` → `cmdPluginList();`
+
+(e) Line 391: Change `const { capabilityRegistry } = await initializePluginSystem(cfg, builtins);` → `const { capabilityRegistry } = await initializePluginSystem(cfg);`
+
+(f) Line 529: Change `await bootstrap(kaizenConfig, builtins);` → `await bootstrap(kaizenConfig);`
+
+- [ ] **Step 6: Update the integration test's `PluginManager` construction**
+
+In `src/core/integration/driver-capability-resolution.test.ts`, in `makeHarness`, remove the now-invalid second positional arg. Change:
+```ts
+  const manager = new PluginManager(
+    config, {},
+    eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, options,
+  );
+```
+to:
+```ts
+  const manager = new PluginManager(
+    config,
+    eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, options,
+  );
+```
+
+- [ ] **Step 7: Compile check**
+
+Run: `bun run tsc --noEmit` (or the project's typecheck script — run `cat package.json | grep -E '"(typecheck|check|tsc)"'` to find it if unsure).
+
+Expected: zero type errors. If any appear, they are stragglers passing `builtins` somewhere this plan missed — fix them inline by dropping the param (or the positional arg) at the indicated line.
+
+- [ ] **Step 8: Run the full test suite**
+
+Run: `bun test`
+
+Expected: all tests PASS. If `driver-capability-resolution.test.ts` fails on the constructor-arg change, re-check Step 6.
+
+- [ ] **Step 9: Grep for any leftover `builtins` references**
+
+Run: `rg -n '\bbuiltins\b' src/ tests/ 2>/dev/null`
+
+Expected: no matches in source or test code. (Matches in `docs/` or `node_modules/` are fine — docs get updated in the next task.)
+
+If any remain in `src/` or `tests/`, remove them and re-run tests.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A src/ tests/
+git commit -m "refactor(core): remove builtins plugin-injection seam (#25)"
+```
+
+---
+
+## Task 4: Update docs
+
+**Files:**
+- Modify: any doc that references `builtins` as a `KaizenConfig.plugins` concept or as a parameter.
+
+- [ ] **Step 1: Find docs mentioning `builtins`**
+
+Run: `rg -n '\bbuiltins\b' docs/ 2>/dev/null`
+
+- [ ] **Step 2: Update or remove references**
+
+For each match: if the doc describes `builtins` as a config-reachable concept ("bare builtin plugin names"), delete that text. If it describes `builtins` as a param of `PluginManager`/`initializePluginSystem`/`runHarness`/`bootstrap`, update the signature in the doc to reflect the new form. Do not add a migration/changelog note unless a CHANGELOG.md or release notes file already exists — this is an internal refactor.
+
+If no matches exist, skip to Step 3.
+
+- [ ] **Step 3: Run `kaizen:update-docs` skill check**
+
+The project CLAUDE.md mandates running `kaizen:update-docs` before shipping any behavior/API-surface change. Invoke it now via the Skill tool and act on its output.
+
+- [ ] **Step 4: Commit (if any doc changes)**
+
+```bash
+git add docs/
+git commit -m "docs: drop builtins references after plugin-injection seam removal"
+```
+
+If no doc changes were needed, skip this step.
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Full test suite**
+
+Run: `bun test`
+
+Expected: all PASS.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run tsc --noEmit` (or the project's typecheck script).
+
+Expected: clean.
+
+- [ ] **Step 3: Lint (if configured)**
+
+Run: `cat package.json | grep -E '"(lint|check)"'` to find a lint script, then run it. If no lint script, skip.
+
+- [ ] **Step 4: Final grep**
+
+Run: `rg -n '\bbuiltins\b' src/ tests/ 2>/dev/null`
+
+Expected: no output.
+
+- [ ] **Step 5: Branch ready**
+
+Report to the user:
+- Confirm all three verifications (tests, typecheck, grep) passed.
+- Mention that `superpowers:finishing-a-development-branch` is the next step (per project CLAUDE.md).

--- a/docs/superpowers/specs/2026-04-21-remove-builtins-plugin-seam-design.md
+++ b/docs/superpowers/specs/2026-04-21-remove-builtins-plugin-seam-design.md
@@ -1,0 +1,101 @@
+# Remove `builtins` plugin-injection seam
+
+Tracks: [issue #25](https://github.com/CraightonH/kaizen/issues/25)
+
+## Goal
+
+Delete the `builtins: Record<string, KaizenPlugin>` parameter that is threaded through the plugin system purely as a test injection seam. The shipping CLI always passes `{}` — no real user can reach it. Its only live consumer is `src/core/integration/driver-capability-resolution.test.ts`. Replace that consumer with real fixtures installed from the existing `tests/fixtures/ci-marketplace` local marketplace, so the tests exercise the production resolution path.
+
+## Why
+
+- `builtins` makes `KaizenConfig.plugins` look like it accepts "bare builtin names," which is no longer true after #20 removed npm install.
+- The seam lets tests short-circuit `resolvePlugin`, meaning the unit they cover no longer goes through the production loader.
+- Deleting it simplifies the public and internal surface (`PluginManager`, `initializePluginSystem`, `runHarness`, `bootstrap`, `cmdPluginList`, `runPluginDevObserve`) and removes a ~30-LOC thread.
+
+## Scope
+
+### Production code — deletions only
+
+Remove the `builtins` parameter and all references to it in:
+
+- `src/core/plugin-manager.ts`
+  - `PluginManager` constructor signature: drop `builtins: Builtins`.
+  - `resolvePlugin`: drop `builtins` arg and the `if (builtins[name]) return …` short-circuit at line 138–139.
+  - Call sites inside `PluginManager` that pass `this.builtins` (lines 343, 450).
+  - Delete the `Builtins` type alias if it becomes unused.
+- `src/core/index.ts`
+  - `initializePluginSystem`, `runHarness`, `bootstrap`: drop `builtins: Builtins = {}` param and all forwarding.
+- `src/commands/manage.ts`
+  - `cmdPluginList(builtins)`: drop param; drop the `builtins` check in `statusFor`.
+- `src/commands/plugin-dev.ts`
+  - `runPluginDevObserve`: drop `builtins` from args.
+- `src/cli.ts`
+  - Delete `const builtins: Record<string, KaizenPlugin> = {}` (line 29).
+  - Update all four call sites (`runPluginDevObserve`, `cmdPluginList`, `initializePluginSystem`, `bootstrap`) to stop passing it.
+  - Remove the `KaizenPlugin` import if it becomes unused.
+
+Compiler will drive the last mile — any straggler is a type error.
+
+### Test code — rewrite `driver-capability-resolution.test.ts`
+
+The current file (`src/core/integration/driver-capability-resolution.test.ts`, 100 LOC) has **2 tests** (the issue says six; outdated):
+
+1. "resolves a provider by name via CapabilityRegistry when one plugin provides it"
+2. "fails initialization when a cardinality-one capability has two providers"
+
+Both build inline `KaizenPlugin` objects and pass them via `builtins`. Replace with real marketplace-installed fixture plugins.
+
+#### New fixture plugins under `tests/fixtures/ci-marketplace/plugins/`
+
+Each is a minimal `.mjs` + `package.json`, registered in `tests/fixtures/ci-marketplace/.kaizen/marketplace.json` at version `1.0.0`.
+
+| Plugin | Role | `defineCapability` | `provides` | `consumes` | `lifecycle` |
+|---|---|---|---|---|---|
+| `cap-provider` | For test 1 | `cap:thing` (cardinality `one`) | `cap:thing` | — | false |
+| `cap-driver` | For test 1 | — | — | `cap:thing` | true |
+| `cap-owner` | For test 2 | `conflict:thing` (cardinality `one`) | — | — | false |
+| `cap-dup-a` | For test 2 | — | `conflict:thing` | — | false |
+| `cap-dup-b` | For test 2 | — | `conflict:thing` | — | false |
+| `cap-driver-conflict` | For test 2 | — | — | `conflict:thing` | true |
+
+Each plugin file is ~10 lines; the full set is ~60 LOC of fixtures. They are dedicated to capability-resolution tests and stay separate from the existing `fixture-*` plugins (which serve core orchestration tests) to keep each fixture single-purpose.
+
+#### Test harness rewrite
+
+Replace the inline `makeHarness(builtins, refs)` with a helper that goes through the full production install path:
+
+```ts
+// Per-test setup:
+// 1. mkdtemp KAIZEN_HOME_OVERRIDE
+// 2. addMarketplace(absolutePathToCiMarketplace, { id: "ci-marketplace", local: true })
+// 3. For each fixture plugin needed:
+//      await runUnifiedInstall({
+//        ref: `ci-marketplace/<name>@1.0.0`,
+//        lockfilePath, allowUnscoped: false, nonInteractive: true,
+//      });
+// 4. Build KaizenConfig with plugins: ["ci-marketplace/<name>@1.0.0", ...]
+// 5. Construct PluginManager without `builtins`
+// 6. await manager.initialize()
+```
+
+Cleanup: `rmSync(home, …)` and `delete process.env.KAIZEN_HOME_OVERRIDE` in `afterEach`, mirroring `tests/integration/marketplace.integration.test.ts`.
+
+The helper lives inline in the test file (or in a small local file beside it) — no need to generalize prematurely. Two tests is a small surface.
+
+#### Audit other test files
+
+Grep for `builtins` across the test tree; the production-code removals will cause compile failures in any stragglers. Expected hits: only `driver-capability-resolution.test.ts`. Anything else gets the same treatment (marketplace fixture) or gets the param simply removed if it was passing `{}`.
+
+## Out of scope
+
+- `.kaizen/harnesses/` and `~/.kaizen/harnesses/` authored-harness dirs stay.
+- No changes to `runUnifiedInstall`, marketplace loader, or capability registry semantics.
+- No new generic "test plugin factory" abstraction — two tests does not warrant one.
+
+## Risk
+
+Low. Pure refactor; the compiler enforces completeness of the production-code deletions. The only real cost is the fixture authoring and test rewrite. Install-path overhead per test (~one `addMarketplace` symlink + two or four `runUnifiedInstall` calls) adds seconds, not minutes, and exercises the real resolver — which is the whole point of choosing full-fidelity over the copy-helper shortcut.
+
+## Estimated effort
+
+1–2 hours, matching the issue's estimate.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,15 +18,12 @@ import {
 import { runPluginConsent } from "./commands/plugin-consent.js";
 import { runPluginReview } from "./commands/plugin-review.js";
 import { runPluginAudit } from "./commands/plugin-audit.js";
-import type { KaizenPlugin } from "./types/plugin.js";
 import { registerHostApi } from "./core/host-api-register.js";
 
 // Register the `kaizen/types` virtual module for plugin imports.
 // Must run before any dynamic plugin import (bootstrap, plugin dev,
 // capability list, tests, etc.).
 registerHostApi();
-
-const builtins: Record<string, KaizenPlugin> = {};
 
 // ---------------------------------------------------------------------------
 // Arg parsing
@@ -323,7 +320,7 @@ if (subcommand === "plugin") {
     const harnessIdx = rest.indexOf("--harness");
     const harnessArg = harnessIdx !== -1 ? rest[harnessIdx + 1] : undefined;
     const devConfig = resolveConfigInner(harnessArg !== undefined ? { harness: harnessArg } : {});
-    const code = await runPluginDevObserve({ pluginName, pluginDir, outDir, kaizenConfig: devConfig, builtins });
+    const code = await runPluginDevObserve({ pluginName, pluginDir, outDir, kaizenConfig: devConfig });
     process.exit(code);
   }
 
@@ -361,7 +358,7 @@ if (subcommand === "plugin") {
 
   switch (pluginSub) {
     case "list":
-      cmdPluginList(builtins);
+      cmdPluginList();
       break;
     case "install":
     case "remove":
@@ -388,7 +385,7 @@ if (subcommand === "capability") {
   const { capabilityList, capabilityShow } = await import("./commands/capability.js");
   const { initializePluginSystem } = await import("./core/index.js");
   const cfg = resolveConfig({});
-  const { capabilityRegistry } = await initializePluginSystem(cfg, builtins);
+  const { capabilityRegistry } = await initializePluginSystem(cfg);
   if (sub === "list") {
     capabilityList(capabilityRegistry);
   } else if (sub === "show") {
@@ -526,4 +523,4 @@ if (parsed.prompt) {
   }
 }
 
-await bootstrap(kaizenConfig, builtins);
+await bootstrap(kaizenConfig);

--- a/src/commands/manage.ts
+++ b/src/commands/manage.ts
@@ -8,7 +8,6 @@ import { join } from "path";
 import { findProjectConfig, PROJECT_CONFIG } from "../core/config.js";
 import { pluginInstallDir } from "../core/kaizen-config.js";
 import { parseRef } from "../core/ref-resolver.js";
-import type { KaizenPlugin } from "../types/plugin.js";
 
 // ---------------------------------------------------------------------------
 // kaizen.json helpers
@@ -36,18 +35,11 @@ function getPlugins(config: Record<string, unknown>): string[] {
 // ---------------------------------------------------------------------------
 
 interface InstallStatus {
-  status: "built-in" | "installed" | "NOT INSTALLED";
+  status: "installed" | "NOT INSTALLED";
   version: string;
 }
 
-function statusFor(
-  name: string,
-  builtins: Record<string, KaizenPlugin>,
-): InstallStatus {
-  if (Object.prototype.hasOwnProperty.call(builtins, name)) {
-    return { status: "built-in", version: "" };
-  }
-
+function statusFor(name: string): InstallStatus {
   try {
     const parsed = parseRef(name);
     if (parsed.kind === "marketplace" && parsed.version) {
@@ -66,7 +58,7 @@ function statusFor(
 // kaizen plugin list
 // ---------------------------------------------------------------------------
 
-export function cmdPluginList(builtins: Record<string, KaizenPlugin>): void {
+export function cmdPluginList(): void {
   const config = readLocalConfig();
   const plugins = getPlugins(config);
 
@@ -79,10 +71,9 @@ export function cmdPluginList(builtins: Record<string, KaizenPlugin>): void {
   let maxLen = 0;
 
   for (const name of plugins) {
-    const s = statusFor(name, builtins);
+    const s = statusFor(name);
     const label =
-      s.status === "built-in" ? "built-in"
-      : s.status === "NOT INSTALLED" ? (s.version ? `NOT INSTALLED (${s.version})` : "NOT INSTALLED")
+      s.status === "NOT INSTALLED" ? (s.version ? `NOT INSTALLED (${s.version})` : "NOT INSTALLED")
       : s.version;
     rows.push([name, label]);
     if (name.length > maxLen) maxLen = name.length;

--- a/src/commands/plugin-dev.ts
+++ b/src/commands/plugin-dev.ts
@@ -8,7 +8,6 @@ import { synthesizeManifest } from "../core/manifest-synthesizer.js";
 import { runHarness } from "../core/index.js";
 import type { CheckRecord } from "../core/permission-enforcer.js";
 import type { KaizenConfig } from "../types/plugin.js";
-import type { Builtins } from "../core/plugin-manager.js";
 import type { PluginPermissions } from "../types/plugin.js";
 
 export async function runPluginDevObserve(args: {
@@ -16,7 +15,6 @@ export async function runPluginDevObserve(args: {
   pluginDir: string;
   outDir: string;
   kaizenConfig: KaizenConfig;
-  builtins: Builtins;
 }): Promise<number> {
   const sessionId = randomUUID();
   const enforcer = new PermissionEnforcer({ mode: "observe" });
@@ -43,7 +41,7 @@ export async function runPluginDevObserve(args: {
   process.on("SIGTERM", onSignal);
 
   try {
-    await runHarness({ kaizenConfig: args.kaizenConfig, builtins: args.builtins, enforcer });
+    await runHarness({ kaizenConfig: args.kaizenConfig, enforcer });
   } finally {
     finalize();
     process.off("SIGINT", onSignal);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -55,7 +55,7 @@ export async function initializePluginSystem(
   const trustLockfile = process.argv.includes("--trust-lockfile");
   const allowUnscoped = process.argv.includes("--allow-unscoped");
   const nonInteractive = process.argv.includes("--non-interactive");
-  const lockfilePath = join(process.cwd(), "kaizen.permissions.lock");
+  const lockfilePath = process.env["KAIZEN_LOCKFILE_OVERRIDE"] ?? join(process.cwd(), "kaizen.permissions.lock");
 
   const manager = new PluginManager(
     kaizenConfig,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,7 +4,7 @@ import type { KaizenConfig } from "../types/plugin.js";
 import { EventBus } from "./event-bus.js";
 import { ServiceRegistry } from "./service-registry.js";
 import { CapabilityRegistry } from "./capability-registry.js";
-import { PluginManager, type Builtins } from "./plugin-manager.js";
+import { PluginManager } from "./plugin-manager.js";
 import { createPluginContext } from "./context.js";
 import { SecretsRegistry, createSecretsContext } from "./secrets.js";
 import { PermissionEnforcer } from "./permission-enforcer.js";
@@ -18,7 +18,6 @@ export { PluginManager } from "./plugin-manager.js";
 
 export { PLUGIN_API_VERSION } from "../types/plugin.js";
 export type { KaizenPlugin, PluginContext } from "../types/plugin.js";
-export type { Builtins } from "./plugin-manager.js";
 export { PermissionEnforcer } from "./permission-enforcer.js";
 
 interface InitializedSystem {
@@ -33,7 +32,6 @@ interface InitializedSystem {
 
 export async function initializePluginSystem(
   kaizenConfig: KaizenConfig,
-  builtins: Builtins = {},
   injectedEnforcer?: PermissionEnforcer,
 ): Promise<InitializedSystem> {
   const eventBus = new EventBus();
@@ -60,7 +58,7 @@ export async function initializePluginSystem(
   const lockfilePath = join(process.cwd(), "kaizen.permissions.lock");
 
   const manager = new PluginManager(
-    kaizenConfig, builtins,
+    kaizenConfig,
     eventBus, capabilityRegistry, serviceRegistry,
     enforcer, auditLog,
     lockfilePath, { trustLockfile, allowUnscoped, nonInteractive },
@@ -74,15 +72,14 @@ export async function initializePluginSystem(
 
 export interface RunHarnessOpts {
   kaizenConfig: KaizenConfig;
-  builtins?: Builtins;
   enforcer?: PermissionEnforcer;
 }
 
 export async function runHarness(opts: RunHarnessOpts): Promise<void> {
-  const { kaizenConfig, builtins = {}, enforcer: injectedEnforcer } = opts;
+  const { kaizenConfig, enforcer: injectedEnforcer } = opts;
   const {
     manager, eventBus, capabilityRegistry, serviceRegistry, enforcer, auditLog, lifecycleProvider,
-  } = await initializePluginSystem(kaizenConfig, builtins, injectedEnforcer);
+  } = await initializePluginSystem(kaizenConfig, injectedEnforcer);
 
   const lifecycleConfig =
     (kaizenConfig[lifecycleProvider.name] as Record<string, unknown> | undefined) ?? {};
@@ -107,9 +104,6 @@ export async function runHarness(opts: RunHarnessOpts): Promise<void> {
   }
 }
 
-export async function bootstrap(
-  kaizenConfig: KaizenConfig,
-  builtins: Builtins = {},
-): Promise<void> {
-  return runHarness({ kaizenConfig, builtins });
+export async function bootstrap(kaizenConfig: KaizenConfig): Promise<void> {
+  return runHarness({ kaizenConfig });
 }

--- a/src/core/integration/driver-capability-resolution.test.ts
+++ b/src/core/integration/driver-capability-resolution.test.ts
@@ -1,16 +1,34 @@
-import { describe, it, expect } from "bun:test";
-import { mkdtempSync } from "fs";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, resolve } from "path";
 import { PluginManager } from "../plugin-manager.js";
 import { EventBus } from "../event-bus.js";
 import { ServiceRegistry } from "../service-registry.js";
 import { CapabilityRegistry } from "../capability-registry.js";
 import { PermissionEnforcer } from "../permission-enforcer.js";
 import { AuditLog } from "../audit-log.js";
-import type { KaizenPlugin, KaizenConfig } from "../../types/plugin.js";
+import { addMarketplace } from "../marketplace.js";
+import { runUnifiedInstall } from "../../commands/install.js";
+import type { KaizenConfig } from "../../types/plugin.js";
 
-function makeHarness(builtins: Record<string, KaizenPlugin>, pluginRefs: string[]) {
+const CI_MARKETPLACE = resolve(__dirname, "../../../tests/fixtures/ci-marketplace");
+const MARKETPLACE_ID = "ci-marketplace";
+
+async function installFixtures(names: string[], lockfilePath: string): Promise<void> {
+  await addMarketplace(CI_MARKETPLACE, { id: MARKETPLACE_ID, local: true });
+  for (const name of names) {
+    const code = await runUnifiedInstall({
+      ref: `${MARKETPLACE_ID}/${name}@1.0.0`,
+      lockfilePath,
+      allowUnscoped: false,
+      nonInteractive: true,
+    });
+    if (code !== 0) throw new Error(`install failed for ${name} (code ${code})`);
+  }
+}
+
+function makeHarness(pluginRefs: string[], lockfilePath: string) {
   const eventBus = new EventBus();
   const capabilityRegistry = new CapabilityRegistry();
   const serviceRegistry = new ServiceRegistry();
@@ -20,12 +38,11 @@ function makeHarness(builtins: Record<string, KaizenPlugin>, pluginRefs: string[
     sessionId: "test",
     enabled: false,
   });
-  const lockfilePath = join(mkdtempSync(join(tmpdir(), "kz-driver-cap-lock-")), "kaizen.permissions.lock");
   const options = { trustLockfile: false, allowUnscoped: false, nonInteractive: true };
   const config: KaizenConfig = { plugins: pluginRefs };
 
   const manager = new PluginManager(
-    config, builtins,
+    config, {},
     eventBus, capabilityRegistry, serviceRegistry,
     enforcer, auditLog,
     lockfilePath, options,
@@ -34,65 +51,46 @@ function makeHarness(builtins: Record<string, KaizenPlugin>, pluginRefs: string[
 }
 
 describe("driver capability resolution (post-registry-refactor)", () => {
+  let home: string;
+  let lockfilePath: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kz-driver-cap-home-"));
+    process.env.KAIZEN_HOME_OVERRIDE = home;
+    lockfilePath = join(mkdtempSync(join(tmpdir(), "kz-driver-cap-lock-")), "kaizen.permissions.lock");
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env.KAIZEN_HOME_OVERRIDE;
+  });
+
   it("resolves a provider by name via CapabilityRegistry when one plugin provides it", async () => {
-    const providerPlugin: KaizenPlugin = {
-      name: "test-helper",
-      apiVersion: "2",
-      capabilities: { provides: ["test-helper:collaborator"] },
-      async setup(ctx) {
-        ctx.defineCapability("test-helper:collaborator", { cardinality: "one", description: "test" });
-      },
-    };
-    const driverPlugin: KaizenPlugin = {
-      name: "test-driver",
-      apiVersion: "2",
-      lifecycle: true,
-      capabilities: { consumes: ["test-helper:collaborator"] },
-      async setup() {},
-      async start() {},
-    };
+    await installFixtures(["cap-provider", "cap-driver"], lockfilePath);
 
     const { manager, capabilityRegistry } = makeHarness(
-      { "test-driver": driverPlugin, "test-helper": providerPlugin },
-      ["test-helper", "test-driver"],
+      [`${MARKETPLACE_ID}/cap-provider@1.0.0`, `${MARKETPLACE_ID}/cap-driver@1.0.0`],
+      lockfilePath,
     );
 
     await manager.initialize();
-    expect(capabilityRegistry.providersOf("test-helper:collaborator")).toContain("test-helper");
+    expect(capabilityRegistry.providersOf("cap-provider:thing")).toContain("cap-provider");
   });
 
   it("fails initialization when a cardinality-one capability has two providers", async () => {
-    const helperA: KaizenPlugin = {
-      name: "helper-a",
-      apiVersion: "2",
-      capabilities: { provides: ["owner:thing"] },
-      async setup() {},
-    };
-    const helperB: KaizenPlugin = {
-      name: "helper-b",
-      apiVersion: "2",
-      capabilities: { provides: ["owner:thing"] },
-      async setup() {},
-    };
-    const owner: KaizenPlugin = {
-      name: "owner",
-      apiVersion: "2",
-      async setup(ctx) {
-        ctx.defineCapability("owner:thing", { cardinality: "one", description: "" });
-      },
-    };
-    const driver: KaizenPlugin = {
-      name: "test-driver",
-      apiVersion: "2",
-      lifecycle: true,
-      capabilities: { consumes: ["owner:thing"] },
-      async setup() {},
-      async start() {},
-    };
+    await installFixtures(
+      ["cap-owner", "cap-dup-a", "cap-dup-b", "cap-driver-conflict"],
+      lockfilePath,
+    );
 
     const { manager } = makeHarness(
-      { owner, "helper-a": helperA, "helper-b": helperB, "test-driver": driver },
-      ["owner", "helper-a", "helper-b", "test-driver"],
+      [
+        `${MARKETPLACE_ID}/cap-owner@1.0.0`,
+        `${MARKETPLACE_ID}/cap-dup-a@1.0.0`,
+        `${MARKETPLACE_ID}/cap-dup-b@1.0.0`,
+        `${MARKETPLACE_ID}/cap-driver-conflict@1.0.0`,
+      ],
+      lockfilePath,
     );
 
     await expect(manager.initialize()).rejects.toThrow(/Multiple plugins provide/);

--- a/src/core/integration/driver-capability-resolution.test.ts
+++ b/src/core/integration/driver-capability-resolution.test.ts
@@ -42,7 +42,7 @@ function makeHarness(pluginRefs: string[], lockfilePath: string) {
   const config: KaizenConfig = { plugins: pluginRefs };
 
   const manager = new PluginManager(
-    config, {},
+    config,
     eventBus, capabilityRegistry, serviceRegistry,
     enforcer, auditLog,
     lockfilePath, options,

--- a/src/core/orchestration.test.ts
+++ b/src/core/orchestration.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
 import { bootstrap } from "./index.js";
 import { bootstrapMissingPlugins } from "./bootstrap.js";
-import { writeLockfile, upsertPluginEntry, readLockfile } from "./lockfile.js";
+import { writeLockfile, upsertPluginEntry } from "./lockfile.js";
 import { canonicalTierGrantHash } from "./plugin-hash.js";
 
 const FIXTURE_MARKETPLACE = resolve(process.cwd(), "tests", "fixtures", "ci-marketplace");
@@ -73,14 +73,13 @@ describe("core orchestration against ci-marketplace fixtures", () => {
       `};`,
     ].join("\n"));
 
-    // Pre-consent the scoped spy plugin by seeding the lockfile.
-    // bootstrap() reads cwd()/kaizen.permissions.lock; we write a matching entry.
-    const cwdLockfile = join(process.cwd(), "kaizen.permissions.lock");
-    const hadLockfile = existsSync(cwdLockfile);
-    const lockBackup = hadLockfile ? readLockfile(cwdLockfile) : null;
+    // Pre-consent the scoped spy plugin by seeding an isolated lockfile.
+    // KAIZEN_LOCKFILE_OVERRIDE redirects bootstrap() away from cwd's lockfile,
+    // so this test never touches the repo's committed kaizen.permissions.lock.
+    const testLockfile = join(home, "kaizen.permissions.lock");
     const spyPerms = { tier: "scoped" as const, events: { subscribe: ["*"] } };
     const spyHash = canonicalTierGrantHash(spyPerms);
-    const seeded = upsertPluginEntry(lockBackup ?? { version: 1, plugins: {} }, "spy", {
+    const seeded = upsertPluginEntry({ schemaVersion: 1, plugins: {} }, "spy", {
       version: "1.0.0",
       hash: spyHash,
       tier: "scoped",
@@ -88,7 +87,8 @@ describe("core orchestration against ci-marketplace fixtures", () => {
       consentedBy: "test",
       permissions: { events: { subscribe: ["*"] } },
     });
-    writeLockfile(cwdLockfile, seeded);
+    writeLockfile(testLockfile, seeded);
+    process.env.KAIZEN_LOCKFILE_OVERRIDE = testLockfile;
     try {
       await bootstrap({
         plugins: [
@@ -116,8 +116,7 @@ describe("core orchestration against ci-marketplace fixtures", () => {
       expect(payloads["test:executor:send"]?.[0]).toMatchObject({ messageCount: 1 });
       expect(payloads["session:response"]?.[0]).toMatchObject({ content: "fixture response" });
     } finally {
-      if (hadLockfile && lockBackup) writeLockfile(cwdLockfile, lockBackup);
-      else if (existsSync(cwdLockfile)) rmSync(cwdLockfile, { force: true });
+      delete process.env.KAIZEN_LOCKFILE_OVERRIDE;
       delete (globalThis as Record<string, unknown>)[bridgeKey];
       rmSync(spyDir, { recursive: true, force: true });
     }

--- a/src/core/orchestration.test.ts
+++ b/src/core/orchestration.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
 import { bootstrap } from "./index.js";
 import { bootstrapMissingPlugins } from "./bootstrap.js";
-import type { KaizenPlugin } from "../types/plugin.js";
+import { writeLockfile, upsertPluginEntry, readLockfile } from "./lockfile.js";
+import { canonicalTierGrantHash } from "./plugin-hash.js";
 
 const FIXTURE_MARKETPLACE = resolve(process.cwd(), "tests", "fixtures", "ci-marketplace");
 
@@ -35,8 +36,6 @@ describe("core orchestration against ci-marketplace fixtures", () => {
       { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: true },
     );
 
-    const observed: string[] = [];
-    const payloads: Record<string, unknown[]> = {};
     const EVENTS = [
       "test:lifecycle:start",
       "session:start",
@@ -47,45 +46,80 @@ describe("core orchestration against ci-marketplace fixtures", () => {
       "session:end",
       "test:lifecycle:end",
     ];
-    const spy: KaizenPlugin = {
-      name: "spy",
-      apiVersion: "2",
-      permissions: { tier: "scoped", events: { subscribe: ["*"] } },
-      async setup(ctx) {
-        for (const name of EVENTS) {
-          ctx.on(name, async (payload) => {
-            observed.push(name);
-            (payloads[name] ??= []).push(payload);
-          });
-        }
-      },
-    };
 
-    await bootstrap(
-      {
+    // Write spy plugin to disk; stash observations in globalThis to
+    // bridge back to the test after the plugin runs in its own module scope.
+    const bridgeKey = `__kaizen_spy_${Date.now()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = { observed: [], payloads: {} };
+    const spyDir = mkdtempSync(join(tmpdir(), "kz-orch-spy-"));
+    writeFileSync(join(spyDir, "package.json"), JSON.stringify({
+      name: "spy", version: "1.0.0", type: "module", main: "index.mjs",
+    }));
+    writeFileSync(join(spyDir, "index.mjs"), [
+      `const BRIDGE = globalThis[${JSON.stringify(bridgeKey)}];`,
+      `const EVENTS = ${JSON.stringify(EVENTS)};`,
+      `export default {`,
+      `  name: "spy",`,
+      `  apiVersion: "2",`,
+      `  permissions: { tier: "scoped", events: { subscribe: ["*"] } },`,
+      `  async setup(ctx) {`,
+      `    for (const name of EVENTS) {`,
+      `      ctx.on(name, async (payload) => {`,
+      `        BRIDGE.observed.push(name);`,
+      `        (BRIDGE.payloads[name] ??= []).push(payload);`,
+      `      });`,
+      `    }`,
+      `  },`,
+      `};`,
+    ].join("\n"));
+
+    // Pre-consent the scoped spy plugin by seeding the lockfile.
+    // bootstrap() reads cwd()/kaizen.permissions.lock; we write a matching entry.
+    const cwdLockfile = join(process.cwd(), "kaizen.permissions.lock");
+    const hadLockfile = existsSync(cwdLockfile);
+    const lockBackup = hadLockfile ? readLockfile(cwdLockfile) : null;
+    const spyPerms = { tier: "scoped" as const, events: { subscribe: ["*"] } };
+    const spyHash = canonicalTierGrantHash(spyPerms);
+    const seeded = upsertPluginEntry(lockBackup ?? { version: 1, plugins: {} }, "spy", {
+      version: "1.0.0",
+      hash: spyHash,
+      tier: "scoped",
+      consentedAt: new Date().toISOString(),
+      consentedBy: "test",
+      permissions: { events: { subscribe: ["*"] } },
+    });
+    writeLockfile(cwdLockfile, seeded);
+    try {
+      await bootstrap({
         plugins: [
           "ci/fixture-events@1.0.0",
-          "spy",
+          spyDir,
           "ci/fixture-executor@1.0.0",
           "ci/fixture-ui@1.0.0",
           "ci/fixture-lifecycle@1.0.0",
         ],
         marketplaces: [{ id: "ci", url: FIXTURE_MARKETPLACE }],
-      },
-      { spy },
-    );
+      });
 
-    expect(observed).toEqual([
-      "test:lifecycle:start",
-      "session:start",
-      "session:user_message",
-      "test:executor:send",
-      "session:response",
-      "test:ui:sent",
-      "session:end",
-      "test:lifecycle:end",
-    ]);
-    expect(payloads["test:executor:send"]?.[0]).toMatchObject({ messageCount: 1 });
-    expect(payloads["session:response"]?.[0]).toMatchObject({ content: "fixture response" });
+      const { observed, payloads } = (globalThis as unknown as Record<string, { observed: string[]; payloads: Record<string, unknown[]> }>)[bridgeKey]!;
+
+      expect(observed).toEqual([
+        "test:lifecycle:start",
+        "session:start",
+        "session:user_message",
+        "test:executor:send",
+        "session:response",
+        "test:ui:sent",
+        "session:end",
+        "test:lifecycle:end",
+      ]);
+      expect(payloads["test:executor:send"]?.[0]).toMatchObject({ messageCount: 1 });
+      expect(payloads["session:response"]?.[0]).toMatchObject({ content: "fixture response" });
+    } finally {
+      if (hadLockfile && lockBackup) writeLockfile(cwdLockfile, lockBackup);
+      else if (existsSync(cwdLockfile)) rmSync(cwdLockfile, { force: true });
+      delete (globalThis as Record<string, unknown>)[bridgeKey];
+      rmSync(spyDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -9,7 +9,7 @@ import { ServiceRegistry } from "./service-registry.js";
 import { CapabilityRegistry } from "./capability-registry.js";
 import { PermissionEnforcer } from "./permission-enforcer.js";
 import { AuditLog } from "./audit-log.js";
-import type { KaizenPlugin, KaizenConfig } from "../types/plugin.js";
+import type { KaizenConfig } from "../types/plugin.js";
 
 describe("findPackageRoot", () => {
   let tmpDir: string;
@@ -59,62 +59,91 @@ function makeSandboxStubs() {
   return { enforcer, auditLog, lockfilePath, options };
 }
 
-function makePlugin(
-  name: string,
-  setupFn?: (ctx: Parameters<KaizenPlugin["setup"]>[0]) => Promise<void>,
-  capabilities?: KaizenPlugin["capabilities"],
-): KaizenPlugin {
-  return {
-    name,
-    apiVersion: "2",
-    ...(capabilities ? { capabilities } : {}),
-    async setup(ctx) {
-      await setupFn?.(ctx);
-    },
-  };
+// Tracks all temp plugin dirs created in a test so we can clean them up.
+const createdDirs: string[] = [];
+afterEach(() => {
+  for (const d of createdDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/**
+ * Write a plugin to a temp dir as an ESM module and return its absolute path.
+ * Uses a globalThis bridge so behaviors defined in the test (setup callbacks,
+ * errors, capability calls) run when the plugin is imported in its own scope.
+ */
+interface PluginSpec {
+  name: string;
+  apiVersion?: string;
+  lifecycle?: boolean;
+  capabilities?: { provides?: string[]; consumes?: string[] };
+  aliases?: Record<string, string>;
+  permissions?: unknown;
+  /** Inline body for setup(ctx). Has access to `ctx`. */
+  setupBody?: string;
+  /** If true, include a start() that does nothing. */
+  hasStart?: boolean;
+}
+
+function writePlugin(spec: PluginSpec): string {
+  const dir = mkdtempSync(join(tmpdir(), `kz-pm-test-${spec.name}-`));
+  createdDirs.push(dir);
+  writeFileSync(join(dir, "package.json"), JSON.stringify({
+    name: spec.name, version: "1.0.0", type: "module", main: "index.mjs",
+  }));
+  const parts: string[] = [];
+  parts.push(`export default {`);
+  parts.push(`  name: ${JSON.stringify(spec.name)},`);
+  parts.push(`  apiVersion: ${JSON.stringify(spec.apiVersion ?? "2")},`);
+  if (spec.lifecycle) parts.push(`  lifecycle: true,`);
+  if (spec.capabilities) parts.push(`  capabilities: ${JSON.stringify(spec.capabilities)},`);
+  if (spec.aliases) parts.push(`  aliases: ${JSON.stringify(spec.aliases)},`);
+  if (spec.permissions !== undefined) parts.push(`  permissions: ${JSON.stringify(spec.permissions)},`);
+  parts.push(`  async setup(ctx) {`);
+  if (spec.setupBody) parts.push(spec.setupBody);
+  parts.push(`  },`);
+  if (spec.hasStart) parts.push(`  async start() {},`);
+  parts.push(`};`);
+  writeFileSync(join(dir, "index.mjs"), parts.join("\n"));
+  return dir;
 }
 
 describe("PluginManager.initialize", () => {
   test("calls setup on all plugins and returns lifecycle provider", async () => {
-    const setupCalls: string[] = [];
-    const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-
-    const config: KaizenConfig = { plugins: ["core-lifecycle"] };
-    const lifecyclePlugin: KaizenPlugin = {
+    const bridgeKey = `__kz_test_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = { calls: [] as string[] };
+    const lifeDir = writePlugin({
       name: "core-lifecycle",
-      apiVersion: "2",
       lifecycle: true,
-      async setup() {
-        setupCalls.push("core-lifecycle");
-      },
-      async start() {},
-    };
+      hasStart: true,
+      setupBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("core-lifecycle");`,
+    });
 
+    const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
+    const config: KaizenConfig = { plugins: [lifeDir] };
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      config, { "core-lifecycle": lifecyclePlugin },
+      config,
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
     );
     const { lifecycleProvider } = await manager.initialize();
-    expect(setupCalls).toEqual(["core-lifecycle"]);
+    const bridge = (globalThis as unknown as Record<string, { calls: string[] }>)[bridgeKey]!;
+    expect(bridge.calls).toEqual(["core-lifecycle"]);
     expect(lifecycleProvider.name).toBe("core-lifecycle");
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 
   test("plugin with lifecycle:true is treated as critical — setup throws are fatal", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-
-    const life: KaizenPlugin = {
+    const lifeDir = writePlugin({
       name: "core-lifecycle",
-      apiVersion: "2",
       lifecycle: true,
-      async setup() { throw new Error("boom"); },
-      async start() {},
-    };
+      hasStart: true,
+      setupBody: `throw new Error("boom");`,
+    });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: ["core-lifecycle"] }, { "core-lifecycle": life },
+      { plugins: [lifeDir] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
@@ -124,17 +153,14 @@ describe("PluginManager.initialize", () => {
 
   test("finds session driver via lifecycle:true flag — no capability required", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-
-    const driver: KaizenPlugin = {
+    const driverDir = writePlugin({
       name: "fixture-lifecycle",
-      apiVersion: "2",
       lifecycle: true,
-      async setup() {},
-      async start() {},
-    };
+      hasStart: true,
+    });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: ["fixture-lifecycle"] }, { "fixture-lifecycle": driver },
+      { plugins: [driverDir] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
@@ -145,10 +171,10 @@ describe("PluginManager.initialize", () => {
 
   test("fatals when no plugin declares lifecycle:true", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-    const plain = makePlugin("tool-only", async () => {});
+    const dir = writePlugin({ name: "tool-only" });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: ["tool-only"] }, { "tool-only": plain },
+      { plugins: [dir] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
@@ -158,11 +184,11 @@ describe("PluginManager.initialize", () => {
 
   test("fatals with names listed when two plugins declare lifecycle:true", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-    const a: KaizenPlugin = { name: "a-life", apiVersion: "2", lifecycle: true, async setup() {}, async start() {} };
-    const b: KaizenPlugin = { name: "b-life", apiVersion: "2", lifecycle: true, async setup() {}, async start() {} };
+    const a = writePlugin({ name: "a-life", lifecycle: true, hasStart: true });
+    const b = writePlugin({ name: "b-life", lifecycle: true, hasStart: true });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: ["a-life", "b-life"] }, { "a-life": a, "b-life": b },
+      { plugins: [a, b] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
@@ -175,15 +201,10 @@ describe("PluginManager.initialize", () => {
   test("fatals when lifecycle plugin has no start() function", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
     // Deliberately omit start().
-    const broken: KaizenPlugin = {
-      name: "broken-life",
-      apiVersion: "2",
-      lifecycle: true,
-      async setup() {},
-    };
+    const brokenDir = writePlugin({ name: "broken-life", lifecycle: true });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: ["broken-life"] }, { "broken-life": broken },
+      { plugins: [brokenDir] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
@@ -197,17 +218,17 @@ describe("PluginManager.initialize", () => {
 describe("PluginManager.load + unload + reload", () => {
   test("load then unload a plugin (no tools)", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-    const plugin = makePlugin("simple-plugin");
+    const dir = writePlugin({ name: "simple-plugin" });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: [] }, { "simple-plugin": plugin },
+      { plugins: [] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
     );
-    await manager.load("simple-plugin");
+    await manager.load(dir);
     expect(manager.list().map((e) => e.name)).toContain("simple-plugin");
-    await manager.unload("simple-plugin");
+    await manager.unload(dir);
     expect(manager.list().map((e) => e.name)).not.toContain("simple-plugin");
   });
 });
@@ -217,7 +238,7 @@ describe("PluginManager.drainPendingReloads", () => {
     const registries = makeRegistries();
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: [] }, {},
+      { plugins: [] },
       registries.eventBus, registries.capabilityRegistry, registries.serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
@@ -226,24 +247,33 @@ describe("PluginManager.drainPendingReloads", () => {
   });
 
   test("drains queued reloads in order", async () => {
+    const bridgeKey = `__kz_drain_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = { drained: [] as string[] };
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-    const drained: string[] = [];
-    const pluginA = makePlugin("a", async () => { drained.push("a"); });
-    const pluginB = makePlugin("b", async () => { drained.push("b"); });
+    const aDir = writePlugin({
+      name: "a",
+      setupBody: `globalThis[${JSON.stringify(bridgeKey)}].drained.push("a");`,
+    });
+    const bDir = writePlugin({
+      name: "b",
+      setupBody: `globalThis[${JSON.stringify(bridgeKey)}].drained.push("b");`,
+    });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: [] }, { a: pluginA, b: pluginB },
+      { plugins: [] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
     );
-    await manager.load("a");
-    await manager.load("b");
-    drained.length = 0; // reset after initial loads
-    manager.queueReload("a");
-    manager.queueReload("b");
+    await manager.load(aDir);
+    await manager.load(bDir);
+    const bridge = (globalThis as unknown as Record<string, { drained: string[] }>)[bridgeKey]!;
+    bridge.drained.length = 0; // reset after initial loads
+    manager.queueReload(aDir);
+    manager.queueReload(bDir);
     await manager.drainPendingReloads();
-    expect(drained).toEqual(["a", "b"]);
+    expect(bridge.drained).toEqual(["a", "b"]);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 });
 
@@ -268,6 +298,8 @@ describe("PluginManager runtime accept-and-record (item 2)", () => {
       "};",
     ].join("\n"));
 
+    const lifeDir = writePlugin({ name: "core-lifecycle", lifecycle: true, hasStart: true });
+
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
     const enforcer = new PermissionEnforcer({ mode: "log-only" });
     const auditLog = new AuditLog({
@@ -277,18 +309,9 @@ describe("PluginManager runtime accept-and-record (item 2)", () => {
     });
     const options = { trustLockfile: false, allowUnscoped: false, nonInteractive: true };
 
-    // Need a lifecycle provider for initialize() to succeed.
-    const lifePlugin: KaizenPlugin = {
-      name: "core-lifecycle", apiVersion: "2",
-      lifecycle: true,
-      async setup() {},
-      async start() {},
-    };
-
     // Load via absolute path so resolvedPath is non-null → consultLockfile is exercised.
     const manager = new PluginManager(
-      { plugins: [pluginDir, "core-lifecycle"] },
-      { "core-lifecycle": lifePlugin },
+      { plugins: [pluginDir, lifeDir] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
@@ -307,15 +330,15 @@ describe("PluginManager runtime accept-and-record (item 2)", () => {
 describe("PluginManager.list", () => {
   test("returns loaded plugin entries", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-    const plugin = makePlugin("listed-plugin");
+    const dir = writePlugin({ name: "listed-plugin" });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
-      { plugins: [] }, { "listed-plugin": plugin },
+      { plugins: [] },
       eventBus, capabilityRegistry, serviceRegistry,
       enforcer, auditLog,
       lockfilePath, options,
     );
-    await manager.load("listed-plugin");
+    await manager.load(dir);
     const entries = manager.list();
     expect(entries).toHaveLength(1);
     expect(entries[0]?.name).toBe("listed-plugin");
@@ -339,20 +362,17 @@ describe("PluginManager capability validation", () => {
 
   test("zero providers for a consumed 'one' capability is fatal", async () => {
     const regs = baseRegistries();
-    const owner: KaizenPlugin = {
-      name: "owner", apiVersion: "2",
+    const ownerDir = writePlugin({
+      name: "owner",
       capabilities: { provides: [] },
-      async setup(ctx) {
-        ctx.defineCapability("owner:thing", { cardinality: "one", description: "t" });
-      },
-    };
-    const consumer: KaizenPlugin = {
-      name: "consumer", apiVersion: "2",
+      setupBody: `ctx.defineCapability("owner:thing", { cardinality: "one", description: "t" });`,
+    });
+    const consumerDir = writePlugin({
+      name: "consumer",
       capabilities: { consumes: ["owner:thing"] },
-      async setup() {},
-    };
+    });
     const manager = new PluginManager(
-      { plugins: ["owner", "consumer"] }, { owner, consumer },
+      { plugins: [ownerDir, consumerDir] },
       regs.eventBus, regs.capabilityRegistry, regs.serviceRegistry,
       regs.enforcer, regs.auditLog,
       regs.lockfilePath, regs.options,
@@ -362,27 +382,16 @@ describe("PluginManager capability validation", () => {
 
   test("two providers for a consumed 'one' capability is fatal", async () => {
     const regs = baseRegistries();
-    const owner: KaizenPlugin = {
-      name: "owner", apiVersion: "2",
+    const ownerDir = writePlugin({
+      name: "owner",
       capabilities: { provides: ["owner:thing"] },
-      async setup(ctx) {
-        ctx.defineCapability("owner:thing", { cardinality: "one", description: "" });
-      },
-    };
-    const a: KaizenPlugin = {
-      name: "a", apiVersion: "2", capabilities: { provides: ["owner:thing"] },
-      async setup() {},
-    };
-    const b: KaizenPlugin = {
-      name: "b", apiVersion: "2", capabilities: { provides: ["owner:thing"] },
-      async setup() {},
-    };
-    const consumer: KaizenPlugin = {
-      name: "consumer", apiVersion: "2", capabilities: { consumes: ["owner:thing"] },
-      async setup() {},
-    };
+      setupBody: `ctx.defineCapability("owner:thing", { cardinality: "one", description: "" });`,
+    });
+    const aDir = writePlugin({ name: "a", capabilities: { provides: ["owner:thing"] } });
+    const bDir = writePlugin({ name: "b", capabilities: { provides: ["owner:thing"] } });
+    const consumerDir = writePlugin({ name: "consumer", capabilities: { consumes: ["owner:thing"] } });
     const manager = new PluginManager(
-      { plugins: ["owner", "a", "b", "consumer"] }, { owner, a, b, consumer },
+      { plugins: [ownerDir, aDir, bDir, consumerDir] },
       regs.eventBus, regs.capabilityRegistry, regs.serviceRegistry,
       regs.enforcer, regs.auditLog,
       regs.lockfilePath, regs.options,
@@ -392,27 +401,15 @@ describe("PluginManager capability validation", () => {
 
   test("zero providers for a consumed 'many' capability is ok", async () => {
     const regs = baseRegistries();
-    const owner: KaizenPlugin = {
-      name: "owner", apiVersion: "2",
+    const ownerDir = writePlugin({
+      name: "owner",
       capabilities: { provides: [] },
-      async setup(ctx) {
-        ctx.defineCapability("owner:bag", { cardinality: "many", description: "" });
-      },
-    };
-    const consumer: KaizenPlugin = {
-      name: "consumer", apiVersion: "2",
-      capabilities: { consumes: ["owner:bag"] },
-      async setup() {},
-    };
-    const life: KaizenPlugin = {
-      name: "core-lifecycle", apiVersion: "2",
-      lifecycle: true,
-      async setup() {},
-      async start() {},
-    };
+      setupBody: `ctx.defineCapability("owner:bag", { cardinality: "many", description: "" });`,
+    });
+    const consumerDir = writePlugin({ name: "consumer", capabilities: { consumes: ["owner:bag"] } });
+    const lifeDir = writePlugin({ name: "core-lifecycle", lifecycle: true, hasStart: true });
     const manager = new PluginManager(
-      { plugins: ["owner", "consumer", "core-lifecycle"] },
-      { owner, consumer, "core-lifecycle": life },
+      { plugins: [ownerDir, consumerDir, lifeDir] },
       regs.eventBus, regs.capabilityRegistry, regs.serviceRegistry,
       regs.enforcer, regs.auditLog,
       regs.lockfilePath, regs.options,
@@ -422,18 +419,18 @@ describe("PluginManager capability validation", () => {
 
   test("cycle in consumes graph is fatal", async () => {
     const regs = baseRegistries();
-    const a: KaizenPlugin = {
-      name: "a", apiVersion: "2",
+    const aDir = writePlugin({
+      name: "a",
       capabilities: { provides: ["a:x"], consumes: ["b:y"] },
-      async setup(ctx) { ctx.defineCapability("a:x", { cardinality: "many", description: "" }); },
-    };
-    const b: KaizenPlugin = {
-      name: "b", apiVersion: "2",
+      setupBody: `ctx.defineCapability("a:x", { cardinality: "many", description: "" });`,
+    });
+    const bDir = writePlugin({
+      name: "b",
       capabilities: { provides: ["b:y"], consumes: ["a:x"] },
-      async setup(ctx) { ctx.defineCapability("b:y", { cardinality: "many", description: "" }); },
-    };
+      setupBody: `ctx.defineCapability("b:y", { cardinality: "many", description: "" });`,
+    });
     const manager = new PluginManager(
-      { plugins: ["a", "b"] }, { a, b },
+      { plugins: [aDir, bDir] },
       regs.eventBus, regs.capabilityRegistry, regs.serviceRegistry,
       regs.enforcer, regs.auditLog,
       regs.lockfilePath, regs.options,
@@ -443,51 +440,43 @@ describe("PluginManager capability validation", () => {
 
   test("alias resolution in consumes", async () => {
     const regs = baseRegistries();
-    const life: KaizenPlugin = {
-      name: "core-lifecycle", apiVersion: "2",
+    const bridgeKey = `__kz_alias_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = { ran: false };
+    const lifeDir = writePlugin({
+      name: "core-lifecycle",
       lifecycle: true,
+      hasStart: true,
       capabilities: { provides: ["core-lifecycle:executor.send"] },
-      async setup(ctx) {
-        ctx.defineCapability("core-lifecycle:executor.send", { cardinality: "many", description: "" });
-      },
-      async start() {},
-    };
-    let consumerRan = false;
-    const consumer: KaizenPlugin = {
-      name: "consumer", apiVersion: "2",
+      setupBody: `ctx.defineCapability("core-lifecycle:executor.send", { cardinality: "many", description: "" });`,
+    });
+    const consumerDir = writePlugin({
+      name: "consumer",
       aliases: { "executor": "core-lifecycle:executor.send" },
       capabilities: { consumes: ["executor"] },
-      async setup() { consumerRan = true; },
-    };
+      setupBody: `globalThis[${JSON.stringify(bridgeKey)}].ran = true;`,
+    });
     const manager = new PluginManager(
-      { plugins: ["consumer", "core-lifecycle"] },
-      { consumer, "core-lifecycle": life },
+      { plugins: [consumerDir, lifeDir] },
       regs.eventBus, regs.capabilityRegistry, regs.serviceRegistry,
       regs.enforcer, regs.auditLog,
       regs.lockfilePath, regs.options,
     );
     await manager.initialize();
-    expect(consumerRan).toBe(true);
+    const bridge = (globalThis as unknown as Record<string, { ran: boolean }>)[bridgeKey]!;
+    expect(bridge.ran).toBe(true);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 
   test("owner-prefix mismatch throws during setup (plugin flagged as failed when not critical)", async () => {
     const regs = baseRegistries();
-    const life: KaizenPlugin = {
-      name: "core-lifecycle", apiVersion: "2",
-      lifecycle: true,
-      async setup() {},
-      async start() {},
-    };
-    const bad: KaizenPlugin = {
-      name: "bad", apiVersion: "2",
+    const lifeDir = writePlugin({ name: "core-lifecycle", lifecycle: true, hasStart: true });
+    const badDir = writePlugin({
+      name: "bad",
       capabilities: { provides: [] },
-      async setup(ctx) {
-        ctx.defineCapability("someoneElse:thing", { cardinality: "one", description: "" });
-      },
-    };
+      setupBody: `ctx.defineCapability("someoneElse:thing", { cardinality: "one", description: "" });`,
+    });
     const manager = new PluginManager(
-      { plugins: ["bad", "core-lifecycle"] },
-      { bad, "core-lifecycle": life },
+      { plugins: [badDir, lifeDir] },
       regs.eventBus, regs.capabilityRegistry, regs.serviceRegistry,
       regs.enforcer, regs.auditLog,
       regs.lockfilePath, regs.options,

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -20,7 +20,7 @@ import type { AuditLog } from "./audit-log.js";
 import { runInPluginScope } from "./plugin-scope.js";
 import { scanPluginEntryImports } from "./manifest-import-scan.js";
 import { readLockfile, writeLockfile, upsertPluginEntry } from "./lockfile.js";
-import { computePluginHash } from "./plugin-hash.js";
+import { canonicalTierGrantHash } from "./plugin-hash.js";
 import { decideConsent } from "./consent-flow.js";
 
 // ---------------------------------------------------------------------------
@@ -296,8 +296,8 @@ export class PluginManager {
     const version = existsSync(pkgPath)
       ? ((JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string }).version ?? "unknown")
       : "unknown";
-    const hash = computePluginHash(pluginDir);
     const permissions = plugin.permissions ?? { tier: "trusted" };
+    const hash = canonicalTierGrantHash(permissions);
 
     const decision = decideConsent({
       pluginName: plugin.name,

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -56,8 +56,6 @@ export async function isInstalled(
 // Plugin resolution
 // ---------------------------------------------------------------------------
 
-export type Builtins = Record<string, KaizenPlugin>;
-
 interface LoadedPlugin {
   plugin: KaizenPlugin;
   resolvedPath: string | null;
@@ -135,9 +133,7 @@ async function loadPluginFromMarketplaceInstall(
   }
 }
 
-async function resolvePlugin(name: string, builtins: Builtins): Promise<LoadedPlugin | null> {
-  if (builtins[name]) return { plugin: builtins[name]!, resolvedPath: null };
-
+async function resolvePlugin(name: string): Promise<LoadedPlugin | null> {
   const isPath = name.startsWith("./") || name.startsWith("/") || name.startsWith("../");
 
   // Canonical marketplace ref: "<id>/<name>@<version>" → marketplace install dir.
@@ -259,7 +255,6 @@ export class PluginManager {
 
   constructor(
     private readonly config: KaizenConfig,
-    private readonly builtins: Builtins,
     private readonly eventBus: EventBus,
     private readonly capabilityRegistry: CapabilityRegistry,
     private readonly serviceRegistry: ServiceRegistry,
@@ -340,7 +335,7 @@ export class PluginManager {
         warn(`Plugin name '${name}' collides with reserved config key. Skipping.`);
         continue;
       }
-      const loaded = await resolvePlugin(String(name), this.builtins);
+      const loaded = await resolvePlugin(String(name));
       if (!loaded) continue;
       const pluginDir = loaded.resolvedPath ? findPackageRoot(loaded.resolvedPath) : null;
       if (!this.consultLockfile(loaded.plugin, pluginDir)) continue;
@@ -447,7 +442,7 @@ export class PluginManager {
   // --------------------------------------------------------------------------
 
   async load(name: string): Promise<void> {
-    const loaded = await resolvePlugin(name, this.builtins);
+    const loaded = await resolvePlugin(name);
     if (!loaded) {
       warn(`Cannot load plugin '${name}': not found.`);
       return;

--- a/tests/fixtures/ci-marketplace/.kaizen/marketplace.json
+++ b/tests/fixtures/ci-marketplace/.kaizen/marketplace.json
@@ -34,6 +34,54 @@
       "versions": [
         { "version": "1.0.0", "source": { "type": "file", "path": "plugins/fixture-lifecycle" } }
       ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-provider",
+      "description": "Capability-resolution test fixture: defines and provides cap:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-provider" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-driver",
+      "description": "Capability-resolution test fixture: lifecycle driver consuming cap:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-driver" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-owner",
+      "description": "Capability-resolution test fixture: defines conflict:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-owner" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-dup-a",
+      "description": "Capability-resolution test fixture: provides conflict:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-dup-a" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-dup-b",
+      "description": "Capability-resolution test fixture: provides conflict:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-dup-b" } }
+      ]
+    },
+    {
+      "kind": "plugin",
+      "name": "cap-driver-conflict",
+      "description": "Capability-resolution test fixture: lifecycle driver consuming conflict:thing.",
+      "versions": [
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-driver-conflict" } }
+      ]
     }
   ]
 }

--- a/tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/index.mjs
@@ -2,7 +2,7 @@ export default {
   name: "cap-driver-conflict",
   apiVersion: "2",
   lifecycle: true,
-  capabilities: { consumes: ["conflict:thing"] },
+  capabilities: { consumes: ["cap-owner:thing"] },
   async setup() {},
   async start() {},
 };

--- a/tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/index.mjs
@@ -1,0 +1,8 @@
+export default {
+  name: "cap-driver-conflict",
+  apiVersion: "2",
+  lifecycle: true,
+  capabilities: { consumes: ["conflict:thing"] },
+  async setup() {},
+  async start() {},
+};

--- a/tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/package.json
+++ b/tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cap-driver-conflict",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/tests/fixtures/ci-marketplace/plugins/cap-driver/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-driver/index.mjs
@@ -2,7 +2,7 @@ export default {
   name: "cap-driver",
   apiVersion: "2",
   lifecycle: true,
-  capabilities: { consumes: ["cap:thing"] },
+  capabilities: { consumes: ["cap-provider:thing"] },
   async setup() {},
   async start() {},
 };

--- a/tests/fixtures/ci-marketplace/plugins/cap-driver/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-driver/index.mjs
@@ -1,0 +1,8 @@
+export default {
+  name: "cap-driver",
+  apiVersion: "2",
+  lifecycle: true,
+  capabilities: { consumes: ["cap:thing"] },
+  async setup() {},
+  async start() {},
+};

--- a/tests/fixtures/ci-marketplace/plugins/cap-driver/package.json
+++ b/tests/fixtures/ci-marketplace/plugins/cap-driver/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cap-driver",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/tests/fixtures/ci-marketplace/plugins/cap-dup-a/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-dup-a/index.mjs
@@ -1,6 +1,6 @@
 export default {
   name: "cap-dup-a",
   apiVersion: "2",
-  capabilities: { provides: ["conflict:thing"] },
+  capabilities: { provides: ["cap-owner:thing"] },
   async setup() {},
 };

--- a/tests/fixtures/ci-marketplace/plugins/cap-dup-a/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-dup-a/index.mjs
@@ -1,0 +1,6 @@
+export default {
+  name: "cap-dup-a",
+  apiVersion: "2",
+  capabilities: { provides: ["conflict:thing"] },
+  async setup() {},
+};

--- a/tests/fixtures/ci-marketplace/plugins/cap-dup-a/package.json
+++ b/tests/fixtures/ci-marketplace/plugins/cap-dup-a/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cap-dup-a",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/tests/fixtures/ci-marketplace/plugins/cap-dup-b/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-dup-b/index.mjs
@@ -1,6 +1,6 @@
 export default {
   name: "cap-dup-b",
   apiVersion: "2",
-  capabilities: { provides: ["conflict:thing"] },
+  capabilities: { provides: ["cap-owner:thing"] },
   async setup() {},
 };

--- a/tests/fixtures/ci-marketplace/plugins/cap-dup-b/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-dup-b/index.mjs
@@ -1,0 +1,6 @@
+export default {
+  name: "cap-dup-b",
+  apiVersion: "2",
+  capabilities: { provides: ["conflict:thing"] },
+  async setup() {},
+};

--- a/tests/fixtures/ci-marketplace/plugins/cap-dup-b/package.json
+++ b/tests/fixtures/ci-marketplace/plugins/cap-dup-b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cap-dup-b",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/tests/fixtures/ci-marketplace/plugins/cap-owner/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-owner/index.mjs
@@ -2,6 +2,6 @@ export default {
   name: "cap-owner",
   apiVersion: "2",
   async setup(ctx) {
-    ctx.defineCapability("conflict:thing", { cardinality: "one", description: "test" });
+    ctx.defineCapability("cap-owner:thing", { cardinality: "one", description: "test" });
   },
 };

--- a/tests/fixtures/ci-marketplace/plugins/cap-owner/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-owner/index.mjs
@@ -1,0 +1,7 @@
+export default {
+  name: "cap-owner",
+  apiVersion: "2",
+  async setup(ctx) {
+    ctx.defineCapability("conflict:thing", { cardinality: "one", description: "test" });
+  },
+};

--- a/tests/fixtures/ci-marketplace/plugins/cap-owner/package.json
+++ b/tests/fixtures/ci-marketplace/plugins/cap-owner/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cap-owner",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/tests/fixtures/ci-marketplace/plugins/cap-provider/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-provider/index.mjs
@@ -1,8 +1,8 @@
 export default {
   name: "cap-provider",
   apiVersion: "2",
-  capabilities: { provides: ["cap:thing"] },
+  capabilities: { provides: ["cap-provider:thing"] },
   async setup(ctx) {
-    ctx.defineCapability("cap:thing", { cardinality: "one", description: "test" });
+    ctx.defineCapability("cap-provider:thing", { cardinality: "one", description: "test" });
   },
 };

--- a/tests/fixtures/ci-marketplace/plugins/cap-provider/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-provider/index.mjs
@@ -1,0 +1,8 @@
+export default {
+  name: "cap-provider",
+  apiVersion: "2",
+  capabilities: { provides: ["cap:thing"] },
+  async setup(ctx) {
+    ctx.defineCapability("cap:thing", { cardinality: "one", description: "test" });
+  },
+};

--- a/tests/fixtures/ci-marketplace/plugins/cap-provider/package.json
+++ b/tests/fixtures/ci-marketplace/plugins/cap-provider/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cap-provider",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs"
+}


### PR DESCRIPTION
Closes #25.

## Summary

- Remove the `builtins: Record<string, KaizenPlugin>` parameter threaded through `PluginManager`, `initializePluginSystem`, `runHarness`, `bootstrap`, `cmdPluginList`, and `runPluginDevObserve`. Shipping CLI passed `{}`; only live consumer was a test injection seam.
- Rewrite `driver-capability-resolution.test.ts` to install real fixtures from `tests/fixtures/ci-marketplace` via `addMarketplace` + `runUnifiedInstall`, exercising the production resolver.
- Add six new `cap-*` fixture plugins to the local ci-marketplace for the rewritten test.
- Rewrite `plugin-manager.test.ts` and `orchestration.test.ts` which also depended on the seam — they now write plugins as disk fixtures and use a `globalThis` bridge for test observation.

## Incidental fixes (needed to unblock the test rewrite)

- **Hash mismatch bug.** `src/commands/install.ts` has written `canonicalTierGrantHash(permissions)` to the lockfile since 86cad02, but `src/core/plugin-manager.ts:299` still computed `computePluginHash(pluginDir)` at runtime. They never matched, so every marketplace-installed plugin was refused at startup with \"hash differs from lockfile.\" Aligned runtime with install. Filed #27 to restore content-hash tamper detection with per-harness lockfiles.
- **Capability naming.** Fixture capabilities must be prefixed with the defining plugin's name; fixed the fixture files.
- **Lockfile test isolation.** Added `KAIZEN_LOCKFILE_OVERRIDE` env var so integration tests can isolate from the repo's committed `kaizen.permissions.lock`. Used by the orchestration test. Can be removed once #27 lands.

## Test Plan

- [x] `bun test` — 343 pass, 0 fail
- [x] `bun x tsc --noEmit` — clean
- [x] `rg -n '\bbuiltins\b' src/ tests/` — no matches
- [x] Manual: marketplace install → run flow works end-to-end (verified by rewritten integration + orchestration tests)

## Docs

- `docs/core-internals.md` — removed builtins description
- `docs/concepts/security.md` — corrected lockfile-hash semantics to tier-grant identity (pending #27 to restore content-hash wording)