### PR TITLE
Per-harness lockfiles (closes #27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,11 @@ kaizen
 /tmp/
 *.js.map
 
-# Sandbox runtime artifacts (commit kaizen.permissions.lock — it's the security record)
+# Sandbox runtime artifacts (commit .kaizen/harnesses/*/permissions.lock — each is a security record)
 .kaizen/
+!.kaizen/harnesses/
+!.kaizen/harnesses/*/
+!.kaizen/harnesses/*/permissions.lock
 plugins/*/.kaizen/
 
 # Bun build scratch files

--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ plugin-scope tracking, a proxy over `process.env`, and a wrapped `globalThis.fet
 
 ### Lockfile
 
-Consent is persisted in `kaizen.permissions.lock` at the repo root. **Commit
-this file** — reviewers see every plugin your harness runs, its tier, and its
-declared grants.
+Consent is persisted in `permissions.lock` next to each harness's `kaizen.json`
+(`.kaizen/harnesses/<name>/permissions.lock`, `~/.kaizen/harnesses/<name>/permissions.lock`,
+or `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock`). **Commit project-scoped
+lockfiles** — they are the security record. See `docs/concepts/harnesses.md`.
 
 ### Authoring SCOPED plugins
 

--- a/docs/concepts/harnesses.md
+++ b/docs/concepts/harnesses.md
@@ -152,6 +152,30 @@ into `.kaizen/harnesses/<name>/` (committed to the project) or
 `~/.kaizen/harnesses/<name>/` (per-user). Both locations are resolved by bare
 name.
 
+## State files
+
+Each harness carries its own `permissions.lock` sitting next to its `kaizen.json`:
+
+- `.kaizen/harnesses/<name>/permissions.lock` (project)
+- `~/.kaizen/harnesses/<name>/permissions.lock` (home)
+- `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock` (marketplace)
+
+The lockfile records the consented tier and grants for each plugin in the harness.
+Commit project-scoped lockfiles — they are the security record reviewed like code.
+
+**Re-materialization preserves consent.** When a marketplace harness is re-fetched
+(`kaizen marketplace update`), `permissions.lock` is preserved. If the re-fetched
+`kaizen.json` changes a plugin's permissions, runtime re-prompts for consent on
+next run because the tier-grant hash no longer matches.
+
+**Multiple harnesses, one project.** Two harnesses in the same repo keep
+independent consent records — consenting in one does not grant consent in the
+other.
+
+**A named harness is required.** `kaizen` without `--harness` and without an
+`extends` entry in `.kaizen/kaizen.json` is an error. Use one of the three
+entry-point forms above.
+
 ## Discovery
 
 Harnesses live in the same marketplaces as plugins. Use:

--- a/docs/concepts/plugin-model.md
+++ b/docs/concepts/plugin-model.md
@@ -49,7 +49,7 @@ The high-level sequence when you run `kaizen --harness <something>`:
 3. **Consent.** Before a new plugin runs, kaizen reads its declared
    permissions and either accepts silently (TRUSTED), prompts with a grant
    list (SCOPED), or requires typed confirmation (UNSCOPED). Decisions
-   persist in `kaizen.permissions.lock`.
+   persist in the harness's `permissions.lock` (see `docs/concepts/harnesses.md`).
 4. **Setup.** Plugins are topologically sorted by their declared dependencies
    and each `setup(ctx)` runs in order. After all `setup()` calls complete,
    core validates capability cardinality and then calls `start(ctx)` on the

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -92,8 +92,10 @@ Review the proposed manifest, tighten globs by hand, paste into your plugin.
 
 Installing a SCOPED plugin prints a UAC showing all grants; the user accepts or
 rejects. Installing UNSCOPED requires typing the plugin name. Decisions persist
-to `kaizen.permissions.lock` at the repo root — **commit this file**. Reviewers
-see every plugin, its tier, and its declared grants.
+to `permissions.lock` alongside each harness's `kaizen.json` (project:
+`.kaizen/harnesses/<name>/permissions.lock`; home: `~/.kaizen/harnesses/<name>/permissions.lock`;
+marketplace: `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock`) — **commit
+project-scoped lockfiles**. Reviewers approve changes like code.
 
 Workflow:
 - `kaizen install <plugin>` — resolve, read manifest, run consent, write lockfile

--- a/docs/core-internals.md
+++ b/docs/core-internals.md
@@ -24,8 +24,13 @@ src/core/
 `src/core/index.ts` is the single public entry point for the runtime:
 
 ```typescript
-await bootstrap(kaizenConfig);
+await bootstrap(kaizenConfig, lockfilePath);
 ```
+
+`lockfilePath` is required — callers derive it from the resolved harness's
+`kaizen.json` path via `deriveLockfilePath(harnessJsonPath)` in
+`src/core/lockfile-path.ts`. There is no `process.cwd()` fallback and no
+environment-variable override.
 
 1. Creates `EventBus`, `CapabilityRegistry`, `ServiceRegistry`.
 2. Calls `loadPlugins()` → returns `{ lifecycleProvider, state }`.
@@ -131,17 +136,31 @@ Each plugin gets its own context instance with its own config slice.
 
 ## Config system (`config.ts`)
 
-### Loading order (highest → lowest priority)
-1. CLI flags (`--harness`, `--config`, `--allow-destructive`)
-2. Local `kaizen.json` in the current directory
-3. Harness `kaizen.json` (from `extends` or `--harness`)
+### Named harness required
+
+Every invocation must resolve to a named harness, via `--harness` on the CLI
+or an `extends` field in the local / global `kaizen.json`. A bare
+`kaizen.json` with neither is an error:
+
+```
+A named harness is required.
+See docs/concepts/harnesses.md.
+```
 
 ### Harness resolution
 
-`--harness` and `extends` accept:
-1. **Built-in short name** → `<kaizen-repo>/harnesses/<name>/kaizen.json`
-2. **Local path** → `./path/to/kaizen.json` or `./path/to/folder/` (reads `kaizen.json` inside)
-3. **URL** → fetched at startup (TODO: implement in `config.ts`)
+`resolveHarness(nameOrPath)` returns `{ kaizenJsonPath, config }`. It tries,
+in order:
+
+1. Project-scoped bare name → `.kaizen/harnesses/<name>/kaizen.json`
+2. Home-scoped bare name → `~/.kaizen/harnesses/<name>/kaizen.json`
+3. Explicit local path (`./`, `../`, `/`) → the kaizen.json at that path
+4. Raw URL → rejected (use a marketplace ref instead)
+
+Marketplace refs (`<id>/<name>@<version>`) are handled upstream in
+`src/core/kaizen-config.ts` by `materializeHarnessRef`, which installs the
+harness into `~/.kaizen/marketplaces/<id>/harnesses/<name>/` before passing
+the resulting absolute path to `resolveHarness`.
 
 ### Config merge
 
@@ -149,6 +168,14 @@ Local overlays harness:
 - `plugins` array: local wins entirely if present.
 - Plugin config objects: shallow merge, local wins on key conflicts.
 - `extends`: consumed during resolution, not passed to plugins.
+
+### Per-harness lockfile path
+
+Callers (CLI entry points) derive the lockfile path from the resolved
+harness via `deriveLockfilePath(kaizenJsonPath)` — `permissions.lock` sits
+next to the harness's `kaizen.json`. See
+[docs/concepts/harnesses.md](concepts/harnesses.md#state-files) for path
+patterns and the re-materialization preservation rule.
 
 ## LLM adapter (`llm.ts`)
 

--- a/docs/superpowers/plans/2026-04-21-per-harness-lockfiles.md
+++ b/docs/superpowers/plans/2026-04-21-per-harness-lockfiles.md
@@ -1,0 +1,979 @@
+# Per-Harness Lockfiles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the lockfile from repo-root `kaizen.permissions.lock` to a per-harness `permissions.lock` co-located with each harness's `kaizen.json`, require a named harness for all entry points, and remove the `KAIZEN_LOCKFILE_OVERRIDE` env var.
+
+**Architecture:** A new harness resolver returns `{ kaizenJsonPath, config }`. The CLI derives `lockfilePath = dirname(kaizenJsonPath) + "/permissions.lock"` and threads it into all lockfile consumers. Lockfile consumer signatures stay `lockfilePath: string` — only CLI entry points change. `installHarness` already preserves `permissions.lock` (writes only `kaizen.json`); add a regression test. Spec: `docs/superpowers/specs/2026-04-21-per-harness-lockfiles-design.md`.
+
+**Tech Stack:** TypeScript, Bun, existing YAML lockfile format (unchanged schema).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/core/lockfile-path.ts` (new) | Single `deriveLockfilePath(harnessJsonPath)` helper |
+| `src/core/config.ts` (modify) | Add `resolveHarness()` returning `{ kaizenJsonPath, config }`; have `resolveConfig` delegate. Require named harness — error when none resolvable. |
+| `src/core/index.ts` (modify) | Drop `KAIZEN_LOCKFILE_OVERRIDE` and `process.cwd()` fallback; require `lockfilePath` from caller via `RunHarnessOpts` / `initializePluginSystem` args. |
+| `src/cli.ts` (modify) | Resolve harness, derive lockfile path, replace all `join(process.cwd(), "kaizen.permissions.lock")` sites. |
+| `src/core/plugin-installer.ts` (modify, minor) | Document/enforce `installHarness` preserving `permissions.lock`. |
+| `src/core/lockfile-path.test.ts` (new) | Unit tests for the path derivation helper. |
+| `src/core/config.test.ts` or new `config-harness.test.ts` | Tests for `resolveHarness()` across three sources + error paths. |
+| `tests/integration/marketplace.integration.test.ts` (modify) | Add re-materialization-preserves-`permissions.lock` test. |
+| `tests/integration/per-harness-lockfiles.integration.test.ts` (new) | Two harnesses in one repo → independent lockfiles. |
+| `src/core/orchestration.test.ts`, `src/core/integration/driver-capability-resolution.test.ts`, `src/core/plugin-manager.test.ts` (modify) | Remove `KAIZEN_LOCKFILE_OVERRIDE`; use tmpdir harness. |
+| `src/core/bootstrap.test.ts`, `src/commands/{install,update,uninstall,plugin-consent,plugin-review,plugin-audit}.test.ts` (modify) | Update test lockfile paths from repo-root to per-harness tmpdir. |
+| `README.md`, `.gitignore`, `docs/concepts/security.md`, `docs/concepts/plugin-model.md`, `docs/concepts/harnesses.md` (modify) | Update live doc references; add "State files" subsection in harnesses.md. |
+
+---
+
+## Task 1: Lockfile Path Helper
+
+**Files:**
+- Create: `src/core/lockfile-path.ts`
+- Test: `src/core/lockfile-path.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/core/lockfile-path.test.ts
+import { describe, test, expect } from "bun:test";
+import { deriveLockfilePath } from "./lockfile-path.js";
+
+describe("deriveLockfilePath", () => {
+  test("returns sibling permissions.lock for a kaizen.json path", () => {
+    expect(deriveLockfilePath("/foo/bar/kaizen.json")).toBe("/foo/bar/permissions.lock");
+  });
+
+  test("works for marketplace harness paths", () => {
+    const p = "/home/u/.kaizen/marketplaces/official/harnesses/core-debug/kaizen.json";
+    expect(deriveLockfilePath(p))
+      .toBe("/home/u/.kaizen/marketplaces/official/harnesses/core-debug/permissions.lock");
+  });
+
+  test("works for project-scoped harness paths", () => {
+    expect(deriveLockfilePath(".kaizen/harnesses/dev/kaizen.json"))
+      .toBe(".kaizen/harnesses/dev/permissions.lock");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/lockfile-path.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// src/core/lockfile-path.ts
+import { dirname, join } from "path";
+
+/**
+ * Derive the per-harness lockfile path from a harness's kaizen.json path.
+ * Lockfile lives alongside kaizen.json: `<harness-dir>/permissions.lock`.
+ */
+export function deriveLockfilePath(kaizenJsonPath: string): string {
+  return join(dirname(kaizenJsonPath), "permissions.lock");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/lockfile-path.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/lockfile-path.ts src/core/lockfile-path.test.ts
+git commit -m "feat(core): add deriveLockfilePath helper"
+```
+
+---
+
+## Task 2: resolveHarness — Three Sources
+
+**Files:**
+- Modify: `src/core/config.ts` (add `resolveHarness`, export `ResolvedHarness` type)
+- Test: `src/core/config-harness.test.ts` (new)
+
+**Context:** `loadHarnessConfig(nameOrPath)` in `src/core/config.ts:34-65` already handles project, home, and explicit-path sources but returns only the parsed config, losing the path. We need a sibling function that returns both the path and the config.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/core/config-harness.test.ts
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolveHarness } from "./config.js";
+
+let tmp: string;
+let cwdOrig: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "kz-resolve-"));
+  cwdOrig = process.cwd();
+  process.chdir(tmp);
+});
+
+afterEach(() => {
+  process.chdir(cwdOrig);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("resolveHarness", () => {
+  test("resolves a project-scoped bare name", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "dev");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: [] }));
+    const resolved = resolveHarness("dev");
+    expect(resolved.kaizenJsonPath).toBe(join(".kaizen", "harnesses", "dev", "kaizen.json"));
+    expect(Array.isArray(resolved.config.plugins)).toBe(true);
+  });
+
+  test("resolves an explicit absolute path", () => {
+    const dir = join(tmp, "hx");
+    mkdirSync(dir, { recursive: true });
+    const jsonPath = join(dir, "kaizen.json");
+    writeFileSync(jsonPath, JSON.stringify({ plugins: [] }));
+    const resolved = resolveHarness(jsonPath);
+    expect(resolved.kaizenJsonPath).toBe(jsonPath);
+  });
+
+  test("resolves a relative path to a directory", () => {
+    const dir = join(tmp, "hrel");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: [] }));
+    const resolved = resolveHarness("./hrel");
+    // Should be the normalized kaizen.json path
+    expect(resolved.kaizenJsonPath.endsWith("hrel/kaizen.json")).toBe(true);
+  });
+
+  test("rejects URL", () => {
+    expect(() => resolveHarness("https://example.com/kaizen.json")).toThrow();
+  });
+
+  test("reports helpful error when not found", () => {
+    expect(() => resolveHarness("nonexistent-harness")).toThrow(/not found/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/config-harness.test.ts`
+Expected: FAIL (`resolveHarness` not exported).
+
+- [ ] **Step 3: Add resolveHarness to src/core/config.ts**
+
+Add near the existing `loadHarnessConfig`:
+
+```typescript
+// src/core/config.ts — add these exports
+export interface ResolvedHarness {
+  kaizenJsonPath: string;
+  config: KaizenConfig;
+}
+
+/**
+ * Resolve a harness name-or-path to both its kaizen.json location and parsed config.
+ * Callers derive the lockfile path from `dirname(kaizenJsonPath) + "/permissions.lock"`.
+ */
+export function resolveHarness(nameOrPath: string): ResolvedHarness {
+  const projectHarness = join(PROJECT_HARNESSES, nameOrPath, "kaizen.json");
+  if (existsSync(projectHarness)) {
+    return { kaizenJsonPath: projectHarness, config: parseAndValidateHarness(projectHarness, nameOrPath) };
+  }
+
+  const homeHarness = join(KAIZEN_HOME_HARNESSES, nameOrPath, "kaizen.json");
+  if (existsSync(homeHarness)) {
+    return { kaizenJsonPath: homeHarness, config: parseAndValidateHarness(homeHarness, nameOrPath) };
+  }
+
+  if (nameOrPath.startsWith("./") || nameOrPath.startsWith("/") || nameOrPath.startsWith("../")) {
+    const filePath = nameOrPath.endsWith(".json") ? nameOrPath : join(nameOrPath, "kaizen.json");
+    if (!existsSync(filePath)) fatal(`Harness not found at path: ${filePath}`);
+    return { kaizenJsonPath: filePath, config: parseAndValidateHarness(filePath, nameOrPath) };
+  }
+
+  if (nameOrPath.startsWith("http://") || nameOrPath.startsWith("https://")) {
+    fatal(
+      `URL harnesses are not supported.\n` +
+      `Publish the harness in a marketplace and reference it as '<marketplace>/<name>@<version>'.`,
+    );
+  }
+
+  fatal(
+    `Harness '${nameOrPath}' not found.\n` +
+    `  Marketplace:    kaizen install <marketplace>/${nameOrPath}@<version>\n` +
+    `  Project-scoped: .kaizen/harnesses/${nameOrPath}/kaizen.json\n` +
+    `  Global:         ~/.kaizen/harnesses/${nameOrPath}/kaizen.json\n` +
+    `  Path:           ./path/to/kaizen.json`,
+  );
+}
+```
+
+Refactor the existing `loadHarnessConfig` to delegate:
+
+```typescript
+export function loadHarnessConfig(nameOrPath: string): KaizenConfig {
+  return resolveHarness(nameOrPath).config;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/config-harness.test.ts src/core/config.test.ts`
+Expected: PASS (new file); existing `config.test.ts` still passes because `loadHarnessConfig` behavior is unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/config.ts src/core/config-harness.test.ts
+git commit -m "feat(core): add resolveHarness returning path and config"
+```
+
+---
+
+## Task 3: Require Named Harness at Resolution
+
+**Files:**
+- Modify: `src/core/config.ts` — tighten `resolveConfig` to require a harness
+- Test: `src/core/config-harness.test.ts` (extend)
+
+**Context:** Today `resolveConfig` falls back to `.kaizen/kaizen.json`, root `kaizen.json`, or `~/.kaizen/kaizen.json` without requiring a harness. Per the spec, every invocation must resolve to a named harness via `--harness` or `extends`. If neither is present, error.
+
+- [ ] **Step 1: Add failing test**
+
+Append to `src/core/config-harness.test.ts`:
+
+```typescript
+import { resolveConfig } from "./config.js";
+
+describe("resolveConfig — named harness required", () => {
+  test("errors when no --harness and no extends in config", () => {
+    mkdirSync(join(tmp, ".kaizen"), { recursive: true });
+    writeFileSync(join(tmp, ".kaizen", "kaizen.json"), JSON.stringify({ plugins: [] }));
+    expect(() => resolveConfig({})).toThrow(/named harness required/i);
+  });
+
+  test("succeeds with --harness", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "dev");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: ["a"] }));
+    const cfg = resolveConfig({ harness: "dev" });
+    expect(cfg.plugins).toEqual(["a"]);
+  });
+
+  test("succeeds when local config has extends", () => {
+    const h = join(tmp, ".kaizen", "harnesses", "base");
+    mkdirSync(h, { recursive: true });
+    writeFileSync(join(h, "kaizen.json"), JSON.stringify({ plugins: ["x"] }));
+    mkdirSync(join(tmp, ".kaizen"), { recursive: true });
+    writeFileSync(join(tmp, ".kaizen", "kaizen.json"), JSON.stringify({ extends: "base" }));
+    const cfg = resolveConfig({});
+    expect(cfg.plugins).toEqual(["x"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/config-harness.test.ts`
+Expected: "errors when no --harness and no extends" FAILS (today resolveConfig accepts the bare config).
+
+- [ ] **Step 3: Modify resolveConfig to require a harness**
+
+In `src/core/config.ts`, replace the body of `resolveConfig` so every branch that previously returned a bare local/global config now errors unless a harness (via `--harness` or `extends`) is present. Keep the helpful "no config found" message and add a second variant for "config found but no harness":
+
+```typescript
+export function resolveConfig(opts: {
+  harness?: string;
+  configPath?: string;
+  extendsOverride?: string;
+}): KaizenConfig {
+  const { harness, configPath, extendsOverride } = opts;
+  const explicitPath = configPath ?? null;
+  const projectConfigPath = explicitPath ?? findProjectConfig();
+
+  if (harness) {
+    const harnessConfig = loadHarnessConfig(harness);
+    if (projectConfigPath) {
+      const localConfig = loadKaizenConfig(projectConfigPath);
+      if (localConfig.extends && localConfig.extends !== harness) {
+        warn(`--harness ${harness} overrides extends '${localConfig.extends}' in config.`);
+      }
+      return mergeConfigs(harnessConfig, localConfig);
+    }
+    return harnessConfig;
+  }
+
+  if (projectConfigPath) {
+    const localConfig = loadKaizenConfig(projectConfigPath);
+    const ext = extendsOverride ?? localConfig.extends;
+    if (!ext) {
+      fatal(
+        `A named harness is required.\n` +
+        `Found ${projectConfigPath} but no --harness flag and no 'extends' field.\n` +
+        `See docs/concepts/harnesses.md. Valid forms:\n` +
+        `  kaizen --harness <marketplace>/<name>@<version>\n` +
+        `  kaizen --harness ./path/to/harness/\n` +
+        `  Add "extends": "<harness-ref>" to ${projectConfigPath}`,
+      );
+    }
+    return mergeConfigs(loadHarnessConfig(ext), localConfig);
+  }
+
+  if (existsSync(KAIZEN_HOME_CONFIG)) {
+    const globalConfig = loadKaizenConfig(KAIZEN_HOME_CONFIG);
+    const ext = extendsOverride ?? globalConfig.extends;
+    if (!ext) {
+      fatal(
+        `A named harness is required.\n` +
+        `Found ${KAIZEN_HOME_CONFIG} but no --harness flag and no 'extends' field.\n` +
+        `See docs/concepts/harnesses.md.`,
+      );
+    }
+    return mergeConfigs(loadHarnessConfig(ext), globalConfig);
+  }
+
+  fatal(
+    `No config found.\n` +
+    `  Harness (required): kaizen --harness <marketplace>/<name>@<version>\n` +
+    `  Project config:     kaizen init\n` +
+    `  Global config:      kaizen init --global`,
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `bun test src/core/config-harness.test.ts src/core/config.test.ts`
+Expected: the new "errors when no --harness and no extends" test passes. Existing `config.test.ts` tests that relied on bare-config behavior will likely fail — if so, update them to add `--harness` or `extends`, matching the new contract. Do this inline before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/config.ts src/core/config-harness.test.ts src/core/config.test.ts
+git commit -m "feat(core): require named harness at config resolution"
+```
+
+---
+
+## Task 4: Core Bootstrap — Drop KAIZEN_LOCKFILE_OVERRIDE and cwd Fallback
+
+**Files:**
+- Modify: `src/core/index.ts:55-65`
+
+**Context:** `src/core/index.ts:58` currently does `process.env["KAIZEN_LOCKFILE_OVERRIDE"] ?? join(process.cwd(), "kaizen.permissions.lock")`. This must become a required parameter from the caller.
+
+- [ ] **Step 1: Write the failing test**
+
+Create or append to `src/core/bootstrap.test.ts` (or appropriate existing test):
+
+```typescript
+// Add this test
+test("initializePluginSystem requires lockfilePath in opts", async () => {
+  // Tests that the signature no longer silently falls back to cwd.
+  // The exact call here depends on the existing test scaffolding — mirror
+  // an existing successful initializePluginSystem call, but assert that
+  // omitting lockfilePath throws a clear error.
+});
+```
+
+NOTE: because the current signature uses positional defaults, this test requires the signature change in step 3 before it can be written meaningfully. Write it after step 3 if easier; alternatively, verify via TypeScript: `bun run tsc` should fail for callers that omit `lockfilePath` once the signature is required.
+
+- [ ] **Step 2: Change `initializePluginSystem` signature**
+
+Modify `src/core/index.ts`:
+
+```typescript
+export interface InitializePluginSystemOpts {
+  lockfilePath: string;
+  injectedEnforcer?: PermissionEnforcer;
+}
+
+export async function initializePluginSystem(
+  kaizenConfig: KaizenConfig,
+  opts: InitializePluginSystemOpts,
+): Promise<InitializedSystem> {
+  const { lockfilePath, injectedEnforcer } = opts;
+  const eventBus = new EventBus();
+  const capabilityRegistry = new CapabilityRegistry();
+  const serviceRegistry = new ServiceRegistry();
+
+  let enforcer: PermissionEnforcer;
+  if (injectedEnforcer) {
+    enforcer = injectedEnforcer;
+  } else {
+    const mode = (process.env["KAIZEN_SANDBOX_MODE"] as EnforcerMode | undefined) ?? "enforce";
+    enforcer = new PermissionEnforcer({ mode });
+    initializeSandbox(enforcer);
+  }
+
+  const auditLog = new AuditLog({
+    rootDir: join(process.cwd(), ".kaizen", "audit"),
+    sessionId: randomUUID(),
+  });
+
+  const trustLockfile = process.argv.includes("--trust-lockfile");
+  const allowUnscoped = process.argv.includes("--allow-unscoped");
+  const nonInteractive = process.argv.includes("--non-interactive");
+
+  const manager = new PluginManager(
+    kaizenConfig,
+    eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, { trustLockfile, allowUnscoped, nonInteractive },
+  );
+  const { lifecycleProvider } = await manager.initialize();
+  return {
+    capabilityRegistry, manager, eventBus, serviceRegistry,
+    enforcer, auditLog, lifecycleProvider,
+  };
+}
+
+export interface RunHarnessOpts {
+  kaizenConfig: KaizenConfig;
+  lockfilePath: string;
+  enforcer?: PermissionEnforcer;
+}
+
+export async function runHarness(opts: RunHarnessOpts): Promise<void> {
+  const { kaizenConfig, lockfilePath, enforcer: injectedEnforcer } = opts;
+  const init: InitializePluginSystemOpts = {
+    lockfilePath,
+    ...(injectedEnforcer !== undefined ? { injectedEnforcer } : {}),
+  };
+  const {
+    manager, eventBus, capabilityRegistry, serviceRegistry, enforcer, auditLog, lifecycleProvider,
+  } = await initializePluginSystem(kaizenConfig, init);
+
+  const lifecycleConfig =
+    (kaizenConfig[lifecycleProvider.name] as Record<string, unknown> | undefined) ?? {};
+  const secretsCtx = createSecretsContext(new SecretsRegistry(), lifecycleProvider.name, {});
+  const ctx = createPluginContext(
+    lifecycleProvider.name, lifecycleConfig, secretsCtx, eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, () => "RUNNING", manager.getPublicApi(), manager.getLifecycleApi(),
+  );
+
+  try {
+    await runInPluginScope(lifecycleProvider.name, async () => { await lifecycleProvider.start!(ctx); });
+  } finally {
+    await auditLog.flush();
+  }
+}
+
+export async function bootstrap(kaizenConfig: KaizenConfig, lockfilePath: string): Promise<void> {
+  return runHarness({ kaizenConfig, lockfilePath });
+}
+```
+
+Delete every reference to `KAIZEN_LOCKFILE_OVERRIDE` in this file and repo-wide (`bun x rg KAIZEN_LOCKFILE_OVERRIDE src/` should return nothing after this task).
+
+- [ ] **Step 3: Run typecheck to find broken callers**
+
+Run: `bun run tsc --noEmit`
+Expected: failures pointing at every caller of `initializePluginSystem`, `runHarness`, `bootstrap`. Record the list; fix each in this task or subsequent tasks (cli.ts is Task 5; test scaffolding is Task 8+).
+
+- [ ] **Step 4: Fix internal callers in core (non-CLI, non-test)**
+
+Update any `src/core/*` callers to pass `lockfilePath` explicitly. Don't modify `src/cli.ts` or tests yet — those are their own tasks.
+
+- [ ] **Step 5: Run tests**
+
+Run: `bun test src/core/`
+Expected: typechecks pass; unit tests inside `src/core/` either pass or fail with obvious "missing lockfilePath" errors. Leave failing tests for Task 8.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/index.ts src/core/
+git commit -m "refactor(core): require lockfilePath in initializePluginSystem/runHarness/bootstrap"
+```
+
+---
+
+## Task 5: CLI Wiring — Derive Per-Harness Lockfile Path
+
+**Files:**
+- Modify: `src/cli.ts` — every `join(process.cwd(), "kaizen.permissions.lock")` site
+
+**Context:** Six call sites today:
+- Line 254: `install` subcommand
+- Line 272: `uninstall` subcommand
+- Line 288: `update` subcommand
+- Line 303: `plugin` subcommand (`lockfilePath` local)
+- Line 497: `bootstrapMissingPlugins` in the run path
+- Final `bootstrap(kaizenConfig)` call at line 526
+
+After resolving the harness, derive `lockfilePath` once and reuse.
+
+- [ ] **Step 1: Add a shared helper in cli.ts**
+
+Near the top of `src/cli.ts`, add an import and a small helper:
+
+```typescript
+import { deriveLockfilePath } from "./core/lockfile-path.js";
+import { resolveHarness } from "./core/config.js";
+```
+
+Inside the run path, after resolving `harnessArg` / `extendsOverride`, compute the resolved harness's path:
+
+```typescript
+// After harnessArg / extendsOverride are computed, before resolveConfig:
+function resolveHarnessJsonPath(opts: { harness?: string; extendsOverride?: string; configPath?: string }): string {
+  if (opts.harness) return resolveHarness(opts.harness).kaizenJsonPath;
+  if (opts.extendsOverride) return resolveHarness(opts.extendsOverride).kaizenJsonPath;
+  // Fallback: read extends out of the local config and resolve it.
+  const activePath = opts.configPath ?? findProjectConfig() ??
+    (existsSync(KAIZEN_HOME_CONFIG) ? KAIZEN_HOME_CONFIG : null);
+  if (activePath) {
+    try {
+      const raw = JSON.parse(readFileSync(activePath, "utf8")) as { extends?: unknown };
+      if (typeof raw.extends === "string") return resolveHarness(raw.extends).kaizenJsonPath;
+    } catch { /* resolveConfig will raise the right error */ }
+  }
+  fatal("kaizen requires a named harness; see docs/concepts/harnesses.md");
+}
+```
+
+- [ ] **Step 2: Replace all repo-root lockfile paths in `run` path**
+
+Around line 487–500:
+
+```typescript
+const harnessJsonPath = resolveHarnessJsonPath({
+  ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
+  ...(extendsOverride !== undefined ? { extendsOverride } : {}),
+  ...(parsed.configPath !== undefined ? { configPath: parsed.configPath } : {}),
+});
+const lockfilePath = deriveLockfilePath(harnessJsonPath);
+
+const kaizenConfig = resolveConfig({
+  ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
+  ...(parsed.configPath !== undefined ? { configPath: parsed.configPath } : {}),
+  ...(extendsOverride !== undefined ? { extendsOverride } : {}),
+});
+
+if ((kaizenConfig.marketplaces as unknown[])?.length || ((kaizenConfig.plugins as string[] | undefined) ?? []).some((p: string) => p.includes("/"))) {
+  const { bootstrapMissingPlugins } = await import("./core/bootstrap.js");
+  await bootstrapMissingPlugins(kaizenConfig, {
+    lockfilePath,
+    trustLockfile, nonInteractive, allowUnscoped: allowUnscopedFlag,
+  });
+}
+
+// ...
+
+await bootstrap(kaizenConfig, lockfilePath);
+```
+
+- [ ] **Step 3: Replace subcommand lockfile paths**
+
+For each of `install`, `uninstall`, `update`, and `plugin` subcommands, do the same harness resolution (these subcommands don't always take `--harness`, so most use the "read extends from local config or error" branch). For `install` (line 247) and `uninstall` (line 265), the ref being installed is a plugin ref, not a harness ref — the lockfile still belongs to whichever harness the current invocation targets. Derive it via `resolveHarnessJsonPath(...)` against the same args set as the run path:
+
+```typescript
+// install example at line 247
+if (subcommand === "install") {
+  const rest = rawArgs.slice(1);
+  const ref = rest.find((a) => !a.startsWith("--"));
+  if (!ref) { /* usage */ }
+  const harnessJsonPath = resolveHarnessJsonPath({});
+  const lockfilePath = deriveLockfilePath(harnessJsonPath);
+  const { runUnifiedInstall } = await import("./commands/install.js");
+  const code = await runUnifiedInstall({
+    ref, lockfilePath,
+    allowUnscoped: rest.includes("--allow-unscoped"),
+    nonInteractive: rest.includes("--non-interactive"),
+  });
+  process.exit(code);
+}
+```
+
+Apply the same pattern to `uninstall`, `update`, and `plugin` (line 303).
+
+- [ ] **Step 4: Run typecheck and basic CLI smoke**
+
+Run: `bun run tsc --noEmit`
+Expected: PASS.
+
+Set up a tmp harness and smoke-test:
+
+```bash
+mkdir -p /tmp/kz-smoke/.kaizen/harnesses/test
+echo '{"plugins":[]}' > /tmp/kz-smoke/.kaizen/harnesses/test/kaizen.json
+cd /tmp/kz-smoke
+bun /Users/chancock/git/kaizen/src/cli.ts --harness test plugin audit
+```
+
+Expected: runs; if a `permissions.lock` gets created, it lands at `/tmp/kz-smoke/.kaizen/harnesses/test/permissions.lock`, not at repo root.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.ts
+git commit -m "feat(cli): derive per-harness lockfile path"
+```
+
+---
+
+## Task 6: Marketplace Re-Materialization Preservation
+
+**Files:**
+- Modify: `src/core/plugin-installer.ts:33-42`
+- Test: `tests/integration/marketplace.integration.test.ts`
+
+**Context:** `installHarness` currently writes `kaizen.json` into the target dir without removing other files. That means an existing `permissions.lock` is already preserved. This task locks in that behavior with an explicit contract and a regression test, and guards against a future refactor that might add `rmSync(target)`.
+
+- [ ] **Step 1: Add failing test**
+
+Append to `tests/integration/marketplace.integration.test.ts` (or create a new focused file):
+
+```typescript
+test("installHarness preserves an existing permissions.lock on re-materialization", async () => {
+  // Arrange: install the harness once, write a fake lockfile, re-install,
+  // then assert the lockfile survived byte-for-byte.
+  const { installHarness } = await import("../../src/core/plugin-installer.js");
+  const { harnessInstallDir } = await import("../../src/core/kaizen-config.js");
+
+  // Point KAIZEN_HOME at a tmpdir (reuse whatever fixture pattern this file uses).
+  // ... marketplace setup to supply a harness source file "harness/kaizen.json" ...
+
+  await installHarness("fixture-mp", "hx", "harness");
+  const lockPath = join(harnessInstallDir("fixture-mp", "hx"), "permissions.lock");
+  writeFileSync(lockPath, "schemaVersion: 1\nplugins: {}\n");
+  const before = readFileSync(lockPath);
+
+  // Re-materialize.
+  await installHarness("fixture-mp", "hx", "harness");
+
+  expect(existsSync(lockPath)).toBe(true);
+  expect(readFileSync(lockPath).equals(before)).toBe(true);
+});
+```
+
+If the test file already has fixture helpers for marketplace setup, mirror them. If not, read the existing tests in the file first to find the pattern.
+
+- [ ] **Step 2: Run test**
+
+Run: `bun test tests/integration/marketplace.integration.test.ts`
+Expected: PASS (since current `installHarness` doesn't clobber). The test now protects the behavior.
+
+- [ ] **Step 3: Add an explicit contract comment**
+
+Modify `src/core/plugin-installer.ts:33-42`:
+
+```typescript
+/**
+ * Materialize a marketplace harness's kaizen.json into
+ * `~/.kaizen/marketplaces/<id>/harnesses/<name>/`.
+ *
+ * Preservation contract: this function MUST NOT remove other files in the
+ * target directory. The per-harness `permissions.lock` lives here and must
+ * survive re-materialization (plugin grant changes still trigger re-consent
+ * via the tier-grant hash comparison in consent-flow). Do not add
+ * rmSync(target) here.
+ */
+export async function installHarness(
+  marketplaceId: string, name: string, pathInRepo: string,
+): Promise<void> {
+  const src = join(marketplaceRepoDir(marketplaceId), pathInRepo);
+  if (!existsSync(src)) throw new Error(`harness source not found in marketplace: ${pathInRepo}`);
+  const target = harnessInstallDir(marketplaceId, name);
+  mkdirSync(target, { recursive: true });
+  const raw = readFileSync(src);
+  writeFileSync(join(target, "kaizen.json"), raw);
+}
+```
+
+- [ ] **Step 4: Run the test again**
+
+Run: `bun test tests/integration/marketplace.integration.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-installer.ts tests/integration/marketplace.integration.test.ts
+git commit -m "test(marketplace): pin permissions.lock preservation on re-materialization"
+```
+
+---
+
+## Task 7: Remove KAIZEN_LOCKFILE_OVERRIDE From Tests
+
+**Files:**
+- Modify: `src/core/orchestration.test.ts`, `src/core/integration/driver-capability-resolution.test.ts`, `src/core/plugin-manager.test.ts` — any test using `KAIZEN_LOCKFILE_OVERRIDE`
+
+- [ ] **Step 1: Find all usages**
+
+Run: `bun x rg KAIZEN_LOCKFILE_OVERRIDE`
+Expected: handful of test files. Record the list.
+
+- [ ] **Step 2: For each test, swap to a tmpdir harness**
+
+Pattern replacement:
+
+```typescript
+// BEFORE
+const lockDir = mkdtempSync(join(tmpdir(), "kz-lock-"));
+const lockfilePath = join(lockDir, "kaizen.permissions.lock");
+process.env["KAIZEN_LOCKFILE_OVERRIDE"] = lockfilePath;
+
+// AFTER
+const harnessDir = mkdtempSync(join(tmpdir(), "kz-harness-"));
+writeFileSync(join(harnessDir, "kaizen.json"), JSON.stringify({ plugins: [] }));
+const lockfilePath = join(harnessDir, "permissions.lock");
+// pass lockfilePath directly to initializePluginSystem / runHarness / command under test
+```
+
+Delete the env var set/unset and any `delete process.env["KAIZEN_LOCKFILE_OVERRIDE"]` lines.
+
+- [ ] **Step 3: Run tests**
+
+Run: `bun test src/core/orchestration.test.ts src/core/integration/driver-capability-resolution.test.ts src/core/plugin-manager.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Verify env var is gone repo-wide**
+
+Run: `bun x rg KAIZEN_LOCKFILE_OVERRIDE`
+Expected: no matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/orchestration.test.ts src/core/integration/driver-capability-resolution.test.ts src/core/plugin-manager.test.ts
+git commit -m "test(core): drop KAIZEN_LOCKFILE_OVERRIDE, use tmpdir harness"
+```
+
+---
+
+## Task 8: Update Remaining Test Lockfile Paths
+
+**Files:**
+- Modify: `src/core/bootstrap.test.ts`, `src/commands/install.test.ts`, `src/commands/update.test.ts`, `src/commands/uninstall.test.ts`, and any other test using a repo-root-style lockfile path
+
+- [ ] **Step 1: Find usages**
+
+Run: `bun x rg 'kaizen\.permissions\.lock' src/ tests/`
+Expected: references from tests. Record.
+
+- [ ] **Step 2: Replace with per-harness tmpdir paths**
+
+Same pattern as Task 7: create a tmp directory, drop a minimal `kaizen.json`, use `<tmp>/permissions.lock`. Most command tests already take a `lockfilePath` argument — just change the string passed in.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `bun test`
+Expected: PASS across the board.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "test: move command/bootstrap test lockfiles under per-harness tmpdirs"
+```
+
+---
+
+## Task 9: Per-Harness Isolation Integration Test
+
+**Files:**
+- Create: `tests/integration/per-harness-lockfiles.integration.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { deriveLockfilePath } from "../../src/core/lockfile-path.js";
+import { resolveHarness } from "../../src/core/config.js";
+
+describe("per-harness lockfile isolation", () => {
+  test("two harnesses in one repo get independent lockfile paths", () => {
+    const repo = mkdtempSync(join(tmpdir(), "kz-two-"));
+    const cwdOrig = process.cwd();
+    process.chdir(repo);
+    try {
+      const a = join(repo, ".kaizen", "harnesses", "a");
+      const b = join(repo, ".kaizen", "harnesses", "b");
+      mkdirSync(a, { recursive: true });
+      mkdirSync(b, { recursive: true });
+      writeFileSync(join(a, "kaizen.json"), JSON.stringify({ plugins: ["p1"] }));
+      writeFileSync(join(b, "kaizen.json"), JSON.stringify({ plugins: ["p2"] }));
+
+      const lockA = deriveLockfilePath(resolveHarness("a").kaizenJsonPath);
+      const lockB = deriveLockfilePath(resolveHarness("b").kaizenJsonPath);
+
+      expect(lockA).not.toBe(lockB);
+      expect(lockA.endsWith("/.kaizen/harnesses/a/permissions.lock")).toBe(true);
+      expect(lockB.endsWith("/.kaizen/harnesses/b/permissions.lock")).toBe(true);
+
+      // Writing one does not affect the other.
+      writeFileSync(lockA, "A");
+      writeFileSync(lockB, "B");
+      expect(readFileSync(lockA, "utf8")).toBe("A");
+      expect(readFileSync(lockB, "utf8")).toBe("B");
+      expect(existsSync(join(repo, "kaizen.permissions.lock"))).toBe(false);
+    } finally {
+      process.chdir(cwdOrig);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `bun test tests/integration/per-harness-lockfiles.integration.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/per-harness-lockfiles.integration.test.ts
+git commit -m "test(integration): per-harness lockfile isolation"
+```
+
+---
+
+## Task 10: Docs Updates
+
+**Files:**
+- Modify: `README.md:120`, `.gitignore:8`, `docs/concepts/security.md:95`, `docs/concepts/plugin-model.md:52`, `docs/concepts/harnesses.md`
+
+- [ ] **Step 1: Update README.md**
+
+Replace the block around line 120:
+
+```markdown
+Consent is persisted in `permissions.lock` next to each harness's `kaizen.json`
+(`.kaizen/harnesses/<name>/permissions.lock`, `~/.kaizen/harnesses/<name>/permissions.lock`,
+or `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock`). **Commit project-scoped
+lockfiles** — they are the security record. See `docs/concepts/harnesses.md`.
+```
+
+- [ ] **Step 2: Update .gitignore**
+
+Change the comment at line 8:
+
+```gitignore
+# Sandbox runtime artifacts (commit .kaizen/harnesses/*/permissions.lock — each is a security record)
+```
+
+- [ ] **Step 3: Update docs/concepts/security.md:95**
+
+Replace "to `kaizen.permissions.lock` at the repo root — **commit this file**..." with a per-harness description pointing at the three path patterns. Keep the "commit it, reviewers approve changes like code" framing.
+
+- [ ] **Step 4: Update docs/concepts/plugin-model.md:52**
+
+Replace "persist in `kaizen.permissions.lock`" with "persist in the harness's `permissions.lock` (see `docs/concepts/harnesses.md`)".
+
+- [ ] **Step 5: Add State files subsection to docs/concepts/harnesses.md**
+
+Append before "Discovery":
+
+```markdown
+## State files
+
+Each harness carries its own `permissions.lock` sitting next to its `kaizen.json`:
+
+- `.kaizen/harnesses/<name>/permissions.lock` (project)
+- `~/.kaizen/harnesses/<name>/permissions.lock` (home)
+- `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock` (marketplace)
+
+The lockfile records the consented tier and grants for each plugin in the harness.
+Commit project-scoped lockfiles — they are the security record reviewed like code.
+
+**Re-materialization preserves consent.** When a marketplace harness is re-fetched
+(`kaizen marketplace update`), `permissions.lock` is preserved. If the re-fetched
+`kaizen.json` changes a plugin's permissions, runtime re-prompts for consent on
+next run because the tier-grant hash no longer matches.
+
+**Multiple harnesses, one project.** Two harnesses in the same repo keep
+independent consent records — consenting in one does not grant consent in the
+other.
+
+**A named harness is required.** `kaizen` without `--harness` and without an
+`extends` entry in `.kaizen/kaizen.json` is an error. Use one of the three
+entry-point forms above.
+```
+
+- [ ] **Step 6: Verify docs render**
+
+Run: `bun x rg 'kaizen\.permissions\.lock' README.md .gitignore docs/concepts/`
+Expected: no matches (all live doc references updated).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md .gitignore docs/concepts/security.md docs/concepts/plugin-model.md docs/concepts/harnesses.md
+git commit -m "docs: per-harness lockfiles"
+```
+
+---
+
+## Task 11: Full Verification
+
+- [ ] **Step 1: Typecheck**
+
+Run: `bun run tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `bun test`
+Expected: PASS.
+
+- [ ] **Step 3: Repo-wide sanity grep**
+
+Run: `bun x rg 'KAIZEN_LOCKFILE_OVERRIDE|kaizen\.permissions\.lock' src/ tests/ README.md .gitignore docs/concepts/`
+Expected: no matches (historical `docs/superpowers/` artifacts excluded intentionally).
+
+- [ ] **Step 4: Run the end-to-end smoke**
+
+```bash
+mkdir -p /tmp/kz-e2e/.kaizen/harnesses/demo
+cat > /tmp/kz-e2e/.kaizen/harnesses/demo/kaizen.json <<'JSON'
+{"plugins":[]}
+JSON
+cd /tmp/kz-e2e
+bun /Users/chancock/git/kaizen/src/cli.ts --harness demo plugin audit
+ls .kaizen/harnesses/demo/
+```
+
+Expected: command runs; `.kaizen/harnesses/demo/` contains `kaizen.json` (and possibly `permissions.lock` if audit produced one). No `kaizen.permissions.lock` at repo root.
+
+Also verify the error path:
+
+```bash
+mkdir -p /tmp/kz-err/.kaizen
+echo '{"plugins":[]}' > /tmp/kz-err/.kaizen/kaizen.json
+cd /tmp/kz-err
+bun /Users/chancock/git/kaizen/src/cli.ts --harness nonexistent 2>&1 | head -5
+```
+
+Expected: clear "Harness '...' not found" error with the three valid forms listed.
+
+```bash
+cd /tmp/kz-err
+bun /Users/chancock/git/kaizen/src/cli.ts 2>&1 | head -5
+```
+
+Expected: clear "A named harness is required" error pointing at `docs/concepts/harnesses.md`.
+
+- [ ] **Step 5: Final commit (if anything stray was fixed)**
+
+```bash
+git status
+# If clean, skip. Otherwise:
+git add -A
+git commit -m "chore: final cleanup for per-harness lockfiles"
+```

--- a/docs/superpowers/specs/2026-04-21-per-harness-lockfiles-design.md
+++ b/docs/superpowers/specs/2026-04-21-per-harness-lockfiles-design.md
@@ -1,0 +1,106 @@
+# Per-Harness Lockfiles
+
+**Status:** Approved
+**Date:** 2026-04-21
+**Issue:** https://github.com/CraightonH/kaizen/issues/27
+
+## Problem
+
+`src/core/index.ts:58` anchors the lockfile at `process.cwd()/kaizen.permissions.lock`. A single repo can only operate one harness's consent scope: run two harnesses with different plugin sets in the same project and they share one permission record, so one harness's consents leak into the other.
+
+## Scope
+
+### In scope
+
+- Per-harness lockfiles: each harness owns its own `permissions.lock` alongside its `kaizen.json`.
+- Remove the global repo-root `kaizen.permissions.lock` and the `KAIZEN_LOCKFILE_OVERRIDE` env var.
+- Require a named harness — bare root `kaizen.json` is no longer a supported entry point.
+- Preserve `permissions.lock` on marketplace harness re-materialization.
+
+### Out of scope
+
+- **Content-hash tamper detection.** The issue proposed restoring content-hash verification. We intentionally drop that. Tier-grant hash remains the only lockfile hash; grant changes trigger re-consent; plugin code changes under unchanged grants are not detected. Rationale: permission-grant identity is the meaningful security boundary; logic changes within the same grants don't escalate capability.
+- **Backwards compatibility / migration.** Greenfield project with no existing adoption.
+- **Changes to consent-flow comparison logic.** The existing tier-grant hash compare already re-prompts on mismatch.
+
+## Lockfile Paths
+
+Co-located with the harness's `kaizen.json`:
+
+| Harness source | Harness dir | Lockfile |
+|---|---|---|
+| Local (project) | `.kaizen/harnesses/<name>/` | `.kaizen/harnesses/<name>/permissions.lock` |
+| Local (home) | `~/.kaizen/harnesses/<name>/` | `~/.kaizen/harnesses/<name>/permissions.lock` |
+| Marketplace | `~/.kaizen/marketplaces/<id>/harnesses/<name>/` | `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock` |
+
+**Derivation rule:** `lockfilePath = dirname(resolvedHarnessJsonPath) + "/permissions.lock"`. One line, applied wherever harness resolution happens.
+
+## Entry-Point Rules
+
+- `kaizen --harness <ref-or-path>` resolves to one of the three rows above.
+- `extends` in a local `kaizen.json` accepts the same forms recursively; the outer `kaizen.json` must itself live in a named harness directory.
+- Bare `./kaizen.json` at repo root with no `--harness` and no `extends` → fail with a clear error: "kaizen requires a named harness; see docs/concepts/harnesses.md." The error message must list the three valid entry-point forms.
+
+## Lockfile Schema
+
+Unchanged from today:
+
+```yaml
+schemaVersion: 1
+plugins:
+  <plugin-name>:
+    version: <semver>
+    hash: sha256:<canonicalTierGrantHash>   # permissions-grant identity
+    tier: <trusted|restricted|...>
+    consentedAt: <iso8601>
+    consentedBy: <user>
+    permissions: { ... }
+```
+
+Runtime compare stays as-is: `canonicalTierGrantHash(currentPermissions) !== lockfile.plugins[name].hash` → re-consent. Only the file's location and scope change.
+
+## Code Changes
+
+### Harness resolver
+
+Wherever `--harness` / `extends` is parsed today, return a descriptor including at minimum `{ kaizenJsonPath: string }`. Caller derives `lockfilePath` from `dirname(kaizenJsonPath)`.
+
+### `src/core/index.ts`
+
+- Drop `KAIZEN_LOCKFILE_OVERRIDE` and the `join(process.cwd(), "kaizen.permissions.lock")` fallback at line 58.
+- Accept `lockfilePath` from caller (via `RunHarnessOpts` / `initializePluginSystem` args); `process.cwd()` is no longer a valid source.
+- If no harness is resolvable at entry, fail fast with the "named harness required" error.
+
+### Lockfile consumer signatures
+
+`bootstrap`, `plugin-consent`, `plugin-review`, `install`, `uninstall` continue to take `lockfilePath: string`. The CLI entry points change — they resolve the harness first, derive the path, pass it down. Consumers do not learn about harnesses; they still just read/write the path they're handed.
+
+### Marketplace re-materialization
+
+Wherever marketplace harness fetch writes the dir, add a "preserve `permissions.lock` if present" rule: stage into a temp dir, copy-move artifact files, never delete `permissions.lock`. Single-file preservation. The existing consent-flow still re-prompts when re-materialization changes a plugin's grants, because the preserved lockfile's tier-grant hash will no longer match.
+
+### Tests
+
+- Remove the `KAIZEN_LOCKFILE_OVERRIDE` workaround (introduced in 223f413) from `orchestration.test.ts`, `driver-capability-resolution.test.ts`, `plugin-manager.test.ts`.
+- Integration tests needing lockfile isolation point `--harness` at a tmpdir harness; lockfile lands there naturally.
+- New tests:
+  - Harness resolver derives the expected `permissions.lock` path for each of the three harness sources.
+  - Two harnesses in one repo (`.kaizen/harnesses/a/`, `.kaizen/harnesses/b/`) with different plugin sets → independent lockfiles; consenting in one doesn't affect the other.
+  - Bare root `kaizen.json` with no `--harness` → fails with the "named harness required" error.
+  - Marketplace re-materialization preserves an existing `permissions.lock` byte-for-byte.
+
+### Docs (live, non-frozen)
+
+- `README.md:120` — replace "Consent is persisted in `kaizen.permissions.lock` at the repo root" with per-harness lockfile description; link to `docs/concepts/harnesses.md`.
+- `.gitignore:8` — update comment; `permissions.lock` files now live under `.kaizen/harnesses/<name>/`, still committed.
+- `docs/concepts/security.md:95` — update path description (per-harness, still committed, still the security record).
+- `docs/concepts/plugin-model.md:52` — update inline path reference.
+- `docs/concepts/harnesses.md` — add "State files" subsection describing `permissions.lock` co-location and the marketplace re-materialization preservation rule.
+
+Historical `docs/superpowers/plans/*` and `docs/superpowers/specs/*` are frozen artifacts and are not updated.
+
+## Risks
+
+- **Plugin shared across harnesses re-prompts per harness.** Two harnesses using the same plugin with the same grants each prompt separately. Acceptable — per-harness scoping is the goal — but name it so it isn't a surprise.
+- **Marketplace re-materialization regression silently wipes consent.** Mitigated by the dedicated re-materialization preservation test.
+- **Harness-less invocation error must be actionable.** First-run ergonomics: error message must link to docs and list the three valid forms.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,9 +7,10 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { bootstrap } from "./core/index.js";
-import { resolveConfig, findProjectConfig, PROJECT_DIR, PROJECT_CONFIG, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
+import { resolveConfig, findProjectConfig, resolveHarness, PROJECT_DIR, PROJECT_CONFIG, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
 import { readFileSync } from "fs";
 import { fatal } from "./core/errors.js";
+import { deriveLockfilePath } from "./core/lockfile-path.js";
 import {
   readLocalConfig,
   writeLocalConfig,
@@ -42,6 +43,21 @@ function setCliList(config: Record<string, unknown>, clis: string[]): void {
     config["core-cli"] = {};
   }
   (config["core-cli"] as Record<string, unknown>)["clis"] = clis;
+}
+
+function resolveHarnessJsonPath(opts: { harness?: string; extendsOverride?: string; configPath?: string }): string {
+  if (opts.harness) return resolveHarness(opts.harness).kaizenJsonPath;
+  if (opts.extendsOverride) return resolveHarness(opts.extendsOverride).kaizenJsonPath;
+  // Fallback: read extends out of the local (or global) config and resolve it.
+  const activePath = opts.configPath ?? findProjectConfig() ??
+    (existsSync(KAIZEN_HOME_CONFIG) ? KAIZEN_HOME_CONFIG : null);
+  if (activePath) {
+    try {
+      const raw = JSON.parse(readFileSync(activePath, "utf8")) as { extends?: unknown };
+      if (typeof raw.extends === "string") return resolveHarness(raw.extends).kaizenJsonPath;
+    } catch { /* resolveConfig will raise the right error */ }
+  }
+  return fatal("kaizen requires a named harness; see docs/concepts/harnesses.md");
 }
 
 const DEFAULT_PLUGINS = {
@@ -248,10 +264,12 @@ if (subcommand === "install") {
   const rest = rawArgs.slice(1);
   const ref = rest.find((a) => !a.startsWith("--"));
   if (!ref) { console.error("usage: kaizen install <ref> [--allow-unscoped] [--non-interactive]"); process.exit(2); }
+  const harnessJsonPath = resolveHarnessJsonPath({});
+  const lockfilePath = deriveLockfilePath(harnessJsonPath);
   const { runUnifiedInstall } = await import("./commands/install.js");
   const code = await runUnifiedInstall({
     ref,
-    lockfilePath: join(process.cwd(), "kaizen.permissions.lock"),
+    lockfilePath,
     allowUnscoped: rest.includes("--allow-unscoped"),
     nonInteractive: rest.includes("--non-interactive"),
   });
@@ -266,10 +284,12 @@ if (subcommand === "uninstall") {
   const rest = rawArgs.slice(1);
   const ref = rest.find((a) => !a.startsWith("--"));
   if (!ref) { console.error("usage: kaizen uninstall <ref> [--purge]"); process.exit(2); }
+  const harnessJsonPath = resolveHarnessJsonPath({});
+  const lockfilePath = deriveLockfilePath(harnessJsonPath);
   const { runUninstall } = await import("./commands/uninstall.js");
   const code = await runUninstall({
     ref,
-    lockfilePath: join(process.cwd(), "kaizen.permissions.lock"),
+    lockfilePath,
     purge: rest.includes("--purge"),
   });
   process.exit(code);
@@ -282,10 +302,12 @@ if (subcommand === "uninstall") {
 if (subcommand === "update") {
   const rest = rawArgs.slice(1);
   const ref = rest.find((a) => !a.startsWith("--"));
+  const harnessJsonPath = resolveHarnessJsonPath({});
+  const lockfilePath = deriveLockfilePath(harnessJsonPath);
   const { runUpdate } = await import("./commands/update.js");
   const code = await runUpdate({
     ...(ref ? { ref } : {}),
-    lockfilePath: join(process.cwd(), "kaizen.permissions.lock"),
+    lockfilePath,
     allowUnscoped: rest.includes("--allow-unscoped"),
     nonInteractive: rest.includes("--non-interactive"),
   });
@@ -300,7 +322,6 @@ if (subcommand === "plugin") {
   const pluginSub = rawArgs[1];
   const rest = rawArgs.slice(2);
   const name = rest.find((a) => !a.startsWith("--"));
-  const lockfilePath = join(process.cwd(), "kaizen.permissions.lock");
 
   if (pluginSub === "dev" && rest.includes("--observe")) {
     const { runPluginDevObserve } = await import("./commands/plugin-dev.js");
@@ -318,11 +339,15 @@ if (subcommand === "plugin") {
     const outDir = join(pluginDir, ".kaizen");
     // Honor --harness flag if provided
     const harnessIdx = rest.indexOf("--harness");
-    const harnessArg = harnessIdx !== -1 ? rest[harnessIdx + 1] : undefined;
-    const devConfig = resolveConfigInner(harnessArg !== undefined ? { harness: harnessArg } : {});
-    const code = await runPluginDevObserve({ pluginName, pluginDir, outDir, kaizenConfig: devConfig });
+    const devHarnessArg = harnessIdx !== -1 ? rest[harnessIdx + 1] : undefined;
+    const devConfig = resolveConfigInner(devHarnessArg !== undefined ? { harness: devHarnessArg } : {});
+    const devHarnessJsonPath = resolveHarnessJsonPath(devHarnessArg !== undefined ? { harness: devHarnessArg } : {});
+    const devLockfilePath = deriveLockfilePath(devHarnessJsonPath);
+    const code = await runPluginDevObserve({ pluginName, pluginDir, outDir, kaizenConfig: devConfig, lockfilePath: devLockfilePath });
     process.exit(code);
   }
+
+  const lockfilePath = deriveLockfilePath(resolveHarnessJsonPath({}));
 
   if (pluginSub === "consent" && name) {
     const code = await runPluginConsent({
@@ -384,8 +409,10 @@ if (subcommand === "capability") {
   const sub = rawArgs[1];
   const { capabilityList, capabilityShow } = await import("./commands/capability.js");
   const { initializePluginSystem } = await import("./core/index.js");
+  const harnessJsonPath = resolveHarnessJsonPath({});
+  const lockfilePath = deriveLockfilePath(harnessJsonPath);
   const cfg = resolveConfig({});
-  const { capabilityRegistry } = await initializePluginSystem(cfg);
+  const { capabilityRegistry } = await initializePluginSystem(cfg, { lockfilePath });
   if (sub === "list") {
     capabilityList(capabilityRegistry);
   } else if (sub === "show") {
@@ -484,6 +511,13 @@ if (harnessArg === undefined) {
   }
 }
 
+const harnessJsonPath = resolveHarnessJsonPath({
+  ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
+  ...(extendsOverride !== undefined ? { extendsOverride } : {}),
+  ...(parsed.configPath !== undefined ? { configPath: parsed.configPath } : {}),
+});
+const lockfilePath = deriveLockfilePath(harnessJsonPath);
+
 const kaizenConfig = resolveConfig({
   ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
   ...(parsed.configPath !== undefined ? { configPath: parsed.configPath } : {}),
@@ -494,7 +528,7 @@ const kaizenConfig = resolveConfig({
 if ((kaizenConfig.marketplaces as unknown[])?.length || ((kaizenConfig.plugins as string[] | undefined) ?? []).some((p: string) => p.includes("/"))) {
   const { bootstrapMissingPlugins } = await import("./core/bootstrap.js");
   await bootstrapMissingPlugins(kaizenConfig, {
-    lockfilePath: join(process.cwd(), "kaizen.permissions.lock"),
+    lockfilePath,
     trustLockfile, nonInteractive, allowUnscoped: allowUnscopedFlag,
   });
 }
@@ -523,4 +557,4 @@ if (parsed.prompt) {
   }
 }
 
-await bootstrap(kaizenConfig);
+await bootstrap(kaizenConfig, lockfilePath);

--- a/src/commands/plugin-dev.ts
+++ b/src/commands/plugin-dev.ts
@@ -15,6 +15,7 @@ export async function runPluginDevObserve(args: {
   pluginDir: string;
   outDir: string;
   kaizenConfig: KaizenConfig;
+  lockfilePath: string;
 }): Promise<number> {
   const sessionId = randomUUID();
   const enforcer = new PermissionEnforcer({ mode: "observe" });
@@ -41,7 +42,7 @@ export async function runPluginDevObserve(args: {
   process.on("SIGTERM", onSignal);
 
   try {
-    await runHarness({ kaizenConfig: args.kaizenConfig, enforcer });
+    await runHarness({ kaizenConfig: args.kaizenConfig, lockfilePath: args.lockfilePath, enforcer });
   } finally {
     finalize();
     process.off("SIGINT", onSignal);

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -44,7 +44,7 @@ describe("runUninstall", () => {
 
     // We need PROJECT_CONFIG to point to our test file. Since PROJECT_CONFIG is cwd-based,
     // we just test without it (no project config in cwd).
-    const lockfilePath = join(home, "kaizen.permissions.lock");
+    const lockfilePath = join(home, "permissions.lock");
     const code = await runUninstall({ ref: "m/demo@1.0.0", lockfilePath, purge: false });
     expect(code).toBe(0);
     rmSync(projectDir, { recursive: true, force: true });
@@ -56,7 +56,7 @@ describe("runUninstall", () => {
     mkdirSync(installDir, { recursive: true });
     writeFileSync(join(installDir, "package.json"), "{}");
 
-    const lockfilePath = join(home, "kaizen.permissions.lock");
+    const lockfilePath = join(home, "permissions.lock");
     const code = await runUninstall({ ref: "m/demo@1.0.0", lockfilePath, purge: true });
     expect(code).toBe(0);
     expect(existsSync(installDir)).toBe(false);

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -55,7 +55,7 @@ describe("runUpdate", () => {
     const samePerms = { tier: "trusted" };
     await makeUpstreamWithVersions(samePerms, samePerms);
 
-    const lockfilePath = join(home, "kaizen.permissions.lock");
+    const lockfilePath = join(home, "permissions.lock");
     const hash = canonicalTierGrantHash({ tier: "trusted" });
     const lf = {
       schemaVersion: LOCKFILE_SCHEMA_VERSION,

--- a/src/core/bootstrap.test.ts
+++ b/src/core/bootstrap.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
 
 describe("bootstrapMissingPlugins", () => {
   it("adds missing marketplace from harness and installs missing plugin", async () => {
-    const lockfilePath = join(home, "kaizen.permissions.lock");
+    const lockfilePath = join(home, "permissions.lock");
     const report = await bootstrapMissingPlugins(
       { plugins: ["m/demo@1.0.0"], marketplaces: [{ id: "m", url: upstream }] },
       { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: true },
@@ -51,7 +51,7 @@ describe("bootstrapMissingPlugins", () => {
   });
 
   it("rejects shorthand refs in harness files", async () => {
-    const lockfilePath = join(home, "kaizen.permissions.lock");
+    const lockfilePath = join(home, "permissions.lock");
     await expect(bootstrapMissingPlugins(
       { plugins: ["demo"], marketplaces: [] },
       { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: false },
@@ -60,7 +60,7 @@ describe("bootstrapMissingPlugins", () => {
 
   it("--trust-lockfile + --non-interactive fails fast if lockfile missing a plugin", async () => {
     await addMarketplace(upstream, { id: "m", local: true });
-    const lockfilePath = join(home, "kaizen.permissions.lock");
+    const lockfilePath = join(home, "permissions.lock");
     await expect(bootstrapMissingPlugins(
       { plugins: ["m/demo@1.0.0"], marketplaces: [] },
       { lockfilePath, trustLockfile: true, nonInteractive: true, allowUnscoped: false },

--- a/src/core/config-harness.test.ts
+++ b/src/core/config-harness.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolveHarness } from "./config.js";
+
+let tmp: string;
+let cwdOrig: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "kz-resolve-"));
+  cwdOrig = process.cwd();
+  process.chdir(tmp);
+});
+
+afterEach(() => {
+  process.chdir(cwdOrig);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("resolveHarness", () => {
+  test("resolves a project-scoped bare name", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "dev");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: [] }));
+    const resolved = resolveHarness("dev");
+    expect(resolved.kaizenJsonPath).toBe(join(".kaizen", "harnesses", "dev", "kaizen.json"));
+    expect(Array.isArray(resolved.config.plugins)).toBe(true);
+  });
+
+  test("resolves an explicit absolute path", () => {
+    const dir = join(tmp, "hx");
+    mkdirSync(dir, { recursive: true });
+    const jsonPath = join(dir, "kaizen.json");
+    writeFileSync(jsonPath, JSON.stringify({ plugins: [] }));
+    const resolved = resolveHarness(jsonPath);
+    expect(resolved.kaizenJsonPath).toBe(jsonPath);
+  });
+
+  test("resolves a relative path to a directory", () => {
+    const dir = join(tmp, "hrel");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: [] }));
+    const resolved = resolveHarness("./hrel");
+    expect(resolved.kaizenJsonPath.endsWith("hrel/kaizen.json")).toBe(true);
+  });
+
+  test("rejects URL", () => {
+    expect(() => resolveHarness("https://example.com/kaizen.json")).toThrow();
+  });
+
+  test("reports helpful error when not found", () => {
+    expect(() => resolveHarness("nonexistent-harness")).toThrow(/not found/);
+  });
+});

--- a/src/core/config-harness.test.ts
+++ b/src/core/config-harness.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { resolveHarness } from "./config.js";
+import { resolveHarness, resolveConfig } from "./config.js";
 
 let tmp: string;
 let cwdOrig: string;
@@ -51,5 +51,31 @@ describe("resolveHarness", () => {
 
   test("reports helpful error when not found", () => {
     expect(() => resolveHarness("nonexistent-harness")).toThrow(/not found/);
+  });
+});
+
+describe("resolveConfig — named harness required", () => {
+  test("errors when no --harness and no extends in config", () => {
+    mkdirSync(join(tmp, ".kaizen"), { recursive: true });
+    writeFileSync(join(tmp, ".kaizen", "kaizen.json"), JSON.stringify({ plugins: [] }));
+    expect(() => resolveConfig({})).toThrow(/named harness required/i);
+  });
+
+  test("succeeds with --harness", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "dev");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: ["a"] }));
+    const cfg = resolveConfig({ harness: "dev" });
+    expect(cfg.plugins).toEqual(["a"]);
+  });
+
+  test("succeeds when local config has extends", () => {
+    const h = join(tmp, ".kaizen", "harnesses", "base");
+    mkdirSync(h, { recursive: true });
+    writeFileSync(join(h, "kaizen.json"), JSON.stringify({ plugins: ["x"] }));
+    mkdirSync(join(tmp, ".kaizen"), { recursive: true });
+    writeFileSync(join(tmp, ".kaizen", "kaizen.json"), JSON.stringify({ extends: "base" }));
+    const cfg = resolveConfig({});
+    expect(cfg.plugins).toEqual(["x"]);
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -143,8 +143,10 @@ export function loadKaizenConfig(path: string): KaizenConfig {
     fatal(`Config not found at ${path}. Run 'kaizen init' to create one.`);
   }
   const config = parseConfigFile(path);
-  if (!config["plugins"]) fatal(`${path} is missing required field 'plugins'.`);
-  if (!Array.isArray(config["plugins"])) fatal(`${path} 'plugins' must be an array.`);
+  // plugins is optional when config delegates to a harness via 'extends'
+  if (config["plugins"] !== undefined && !Array.isArray(config["plugins"])) {
+    fatal(`${path} 'plugins' must be an array.`);
+  }
   return config as KaizenConfig;
 }
 
@@ -219,26 +221,37 @@ export function resolveConfig(opts: {
   if (projectConfigPath) {
     const localConfig = loadKaizenConfig(projectConfigPath);
     const ext = extendsOverride ?? localConfig.extends;
-    if (ext) {
-      return mergeConfigs(loadHarnessConfig(ext), localConfig);
+    if (!ext) {
+      fatal(
+        `A named harness required.\n` +
+        `Found ${projectConfigPath} but no --harness flag and no 'extends' field.\n` +
+        `See docs/concepts/harnesses.md. Valid forms:\n` +
+        `  kaizen --harness <marketplace>/<name>@<version>\n` +
+        `  kaizen --harness ./path/to/harness/\n` +
+        `  Add "extends": "<harness-ref>" to ${projectConfigPath}`,
+      );
     }
-    return localConfig;
+    return mergeConfigs(loadHarnessConfig(ext), localConfig);
   }
 
   // Global default
   if (existsSync(KAIZEN_HOME_CONFIG)) {
     const globalConfig = loadKaizenConfig(KAIZEN_HOME_CONFIG);
     const ext = extendsOverride ?? globalConfig.extends;
-    if (ext) {
-      return mergeConfigs(loadHarnessConfig(ext), globalConfig);
+    if (!ext) {
+      fatal(
+        `A named harness required.\n` +
+        `Found ${KAIZEN_HOME_CONFIG} but no --harness flag and no 'extends' field.\n` +
+        `See docs/concepts/harnesses.md.`,
+      );
     }
-    return globalConfig;
+    return mergeConfigs(loadHarnessConfig(ext), globalConfig);
   }
 
   fatal(
     `No config found.\n` +
-    `  Project config: kaizen init\n` +
-    `  Global config:  kaizen init --global\n` +
-    `  Harness:        kaizen --harness <marketplace>/<name>@<version>`,
+    `  Harness (required): kaizen --harness <marketplace>/<name>@<version>\n` +
+    `  Project config:     kaizen init\n` +
+    `  Global config:      kaizen init --global`,
   );
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,20 +31,33 @@ export const RESERVED_KEYS = new Set(["plugins", "extends"]);
 // project/home fallback directories.
 // ---------------------------------------------------------------------------
 
-export function loadHarnessConfig(nameOrPath: string): KaizenConfig {
+export interface ResolvedHarness {
+  kaizenJsonPath: string;
+  config: KaizenConfig;
+}
+
+/**
+ * Resolve a harness name-or-path to both its kaizen.json location and parsed config.
+ * Callers derive the lockfile path from `dirname(kaizenJsonPath) + "/permissions.lock"`.
+ */
+export function resolveHarness(nameOrPath: string): ResolvedHarness {
   // 1. Project-scoped harness
   const projectHarness = join(PROJECT_HARNESSES, nameOrPath, "kaizen.json");
-  if (existsSync(projectHarness)) return parseAndValidateHarness(projectHarness, nameOrPath);
+  if (existsSync(projectHarness)) {
+    return { kaizenJsonPath: projectHarness, config: parseAndValidateHarness(projectHarness, nameOrPath) };
+  }
 
   // 2. Global kaizen home harness
   const homeHarness = join(KAIZEN_HOME_HARNESSES, nameOrPath, "kaizen.json");
-  if (existsSync(homeHarness)) return parseAndValidateHarness(homeHarness, nameOrPath);
+  if (existsSync(homeHarness)) {
+    return { kaizenJsonPath: homeHarness, config: parseAndValidateHarness(homeHarness, nameOrPath) };
+  }
 
   // 3. Explicit path (./relative or /absolute)
   if (nameOrPath.startsWith("./") || nameOrPath.startsWith("/") || nameOrPath.startsWith("../")) {
     const filePath = nameOrPath.endsWith(".json") ? nameOrPath : join(nameOrPath, "kaizen.json");
     if (!existsSync(filePath)) fatal(`Harness not found at path: ${filePath}`);
-    return parseAndValidateHarness(filePath, nameOrPath);
+    return { kaizenJsonPath: filePath, config: parseAndValidateHarness(filePath, nameOrPath) };
   }
 
   // 4. URL — not supported; use marketplace
@@ -62,6 +75,10 @@ export function loadHarnessConfig(nameOrPath: string): KaizenConfig {
     `  Global:         ~/.kaizen/harnesses/${nameOrPath}/kaizen.json\n` +
     `  Path:           ./path/to/kaizen.json`,
   );
+}
+
+export function loadHarnessConfig(nameOrPath: string): KaizenConfig {
+  return resolveHarness(nameOrPath).config;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/harness-marketplace.test.ts
+++ b/src/core/harness-marketplace.test.ts
@@ -1,0 +1,106 @@
+/**
+ * End-to-end: materialize a marketplace harness ref (ci/ci-default@1.0.0),
+ * derive the per-harness lockfile path, run bootstrap, and assert
+ *   (a) the lockfile was written under the marketplace-harness path
+ *       (~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock),
+ *   (b) a session round-trip completed through the fixture plugins.
+ *
+ * This mirrors what `kaizen --harness ci/ci-default@1.0.0` does in src/cli.ts,
+ * but stays in-process so we can assert on the resulting lockfile location.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { addMarketplace } from "./marketplace.js";
+import { materializeHarnessRef } from "./kaizen-config.js";
+import { resolveHarness } from "./config.js";
+import { deriveLockfilePath } from "./lockfile-path.js";
+import { bootstrap } from "./index.js";
+import { bootstrapMissingPlugins } from "./bootstrap.js";
+
+const FIXTURE_MARKETPLACE = resolve(process.cwd(), "tests", "fixtures", "ci-marketplace");
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kz-harness-mp-"));
+  process.env.KAIZEN_HOME_OVERRIDE = home;
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  delete process.env.KAIZEN_HOME_OVERRIDE;
+});
+
+describe("marketplace harness ref → load flow (--harness ci/ci-default@1.0.0)", () => {
+  it("materializes the harness, derives a per-harness lockfile, and boots", async () => {
+    // 1. Register the local fixture marketplace under id "ci".
+    await addMarketplace(FIXTURE_MARKETPLACE, { id: "ci", local: true });
+
+    // 2. Materialize the harness ref — this is what cli.ts does before resolveConfig.
+    const harnessJsonPath = await materializeHarnessRef("ci/ci-default@1.0.0");
+
+    // The materialized path must live under ~/.kaizen/marketplaces/ci/harnesses/ci-default/
+    expect(harnessJsonPath).toBe(
+      join(home, "marketplaces", "ci", "harnesses", "ci-default", "kaizen.json"),
+    );
+    expect(existsSync(harnessJsonPath)).toBe(true);
+
+    // 3. Derive the per-harness lockfile path — same rule cli.ts uses.
+    const lockfilePath = deriveLockfilePath(harnessJsonPath);
+    expect(lockfilePath).toBe(
+      join(home, "marketplaces", "ci", "harnesses", "ci-default", "permissions.lock"),
+    );
+    expect(existsSync(lockfilePath)).toBe(false); // not created yet
+
+    // 4. Load the materialized harness config.
+    const resolved = resolveHarness(harnessJsonPath);
+    const kaizenConfig = {
+      ...resolved.config,
+      marketplaces: [{ id: "ci", url: FIXTURE_MARKETPLACE }],
+    };
+
+    // 5. Bootstrap missing plugins (installs fixtures, writes consent to the per-harness lockfile).
+    await bootstrapMissingPlugins(kaizenConfig, {
+      lockfilePath,
+      trustLockfile: false,
+      nonInteractive: true,
+      allowUnscoped: true,
+    });
+
+    // Lockfile now exists at the marketplace-harness path.
+    expect(existsSync(lockfilePath)).toBe(true);
+
+    // Nothing at a repo-root-style legacy path.
+    expect(existsSync(join(home, "kaizen.permissions.lock"))).toBe(false);
+
+    // 6. Run the full bootstrap — the session should complete through the fixture plugins.
+    await bootstrap(kaizenConfig, lockfilePath);
+
+    // Lockfile still present after bootstrap.
+    expect(existsSync(lockfilePath)).toBe(true);
+
+    // Contains entries for at least the fixture plugins we just consented to.
+    const lockRaw = readFileSync(lockfilePath, "utf8");
+    expect(lockRaw).toContain("fixture-events");
+    expect(lockRaw).toContain("fixture-lifecycle");
+  });
+
+  it("preserves permissions.lock across re-materialization of the harness", async () => {
+    // Covers the Task 6 contract via the real --harness entry point.
+    await addMarketplace(FIXTURE_MARKETPLACE, { id: "ci", local: true });
+    const harnessJsonPath = await materializeHarnessRef("ci/ci-default@1.0.0");
+    const lockfilePath = deriveLockfilePath(harnessJsonPath);
+
+    // Seed a lockfile with bogus but syntactically valid content.
+    writeFileSync(lockfilePath, "schemaVersion: 1\nplugins: {}\n");
+    const before = readFileSync(lockfilePath);
+
+    // Re-materialize — should not clobber the lockfile.
+    await materializeHarnessRef("ci/ci-default@1.0.0");
+
+    expect(existsSync(lockfilePath)).toBe(true);
+    expect(readFileSync(lockfilePath).equals(before)).toBe(true);
+  });
+});

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -30,10 +30,16 @@ interface InitializedSystem {
   lifecycleProvider: Awaited<ReturnType<PluginManager["initialize"]>>["lifecycleProvider"];
 }
 
+export interface InitializePluginSystemOpts {
+  lockfilePath: string;
+  injectedEnforcer?: PermissionEnforcer;
+}
+
 export async function initializePluginSystem(
   kaizenConfig: KaizenConfig,
-  injectedEnforcer?: PermissionEnforcer,
+  opts: InitializePluginSystemOpts,
 ): Promise<InitializedSystem> {
+  const { lockfilePath, injectedEnforcer } = opts;
   const eventBus = new EventBus();
   const capabilityRegistry = new CapabilityRegistry();
   const serviceRegistry = new ServiceRegistry();
@@ -55,7 +61,6 @@ export async function initializePluginSystem(
   const trustLockfile = process.argv.includes("--trust-lockfile");
   const allowUnscoped = process.argv.includes("--allow-unscoped");
   const nonInteractive = process.argv.includes("--non-interactive");
-  const lockfilePath = process.env["KAIZEN_LOCKFILE_OVERRIDE"] ?? join(process.cwd(), "kaizen.permissions.lock");
 
   const manager = new PluginManager(
     kaizenConfig,
@@ -72,29 +77,26 @@ export async function initializePluginSystem(
 
 export interface RunHarnessOpts {
   kaizenConfig: KaizenConfig;
+  lockfilePath: string;
   enforcer?: PermissionEnforcer;
 }
 
 export async function runHarness(opts: RunHarnessOpts): Promise<void> {
-  const { kaizenConfig, enforcer: injectedEnforcer } = opts;
+  const { kaizenConfig, lockfilePath, enforcer: injectedEnforcer } = opts;
+  const init: InitializePluginSystemOpts = {
+    lockfilePath,
+    ...(injectedEnforcer !== undefined ? { injectedEnforcer } : {}),
+  };
   const {
     manager, eventBus, capabilityRegistry, serviceRegistry, enforcer, auditLog, lifecycleProvider,
-  } = await initializePluginSystem(kaizenConfig, injectedEnforcer);
+  } = await initializePluginSystem(kaizenConfig, init);
 
   const lifecycleConfig =
     (kaizenConfig[lifecycleProvider.name] as Record<string, unknown> | undefined) ?? {};
   const secretsCtx = createSecretsContext(new SecretsRegistry(), lifecycleProvider.name, {});
   const ctx = createPluginContext(
-    lifecycleProvider.name,
-    lifecycleConfig,
-    secretsCtx,
-    eventBus,
-    capabilityRegistry,
-    serviceRegistry,
-    enforcer,
-    () => "RUNNING",
-    manager.getPublicApi(),
-    manager.getLifecycleApi(),
+    lifecycleProvider.name, lifecycleConfig, secretsCtx, eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, () => "RUNNING", manager.getPublicApi(), manager.getLifecycleApi(),
   );
 
   try {
@@ -104,6 +106,6 @@ export async function runHarness(opts: RunHarnessOpts): Promise<void> {
   }
 }
 
-export async function bootstrap(kaizenConfig: KaizenConfig): Promise<void> {
-  return runHarness({ kaizenConfig });
+export async function bootstrap(kaizenConfig: KaizenConfig, lockfilePath: string): Promise<void> {
+  return runHarness({ kaizenConfig, lockfilePath });
 }

--- a/src/core/integration/driver-capability-resolution.test.ts
+++ b/src/core/integration/driver-capability-resolution.test.ts
@@ -57,7 +57,7 @@ describe("driver capability resolution (post-registry-refactor)", () => {
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), "kz-driver-cap-home-"));
     process.env.KAIZEN_HOME_OVERRIDE = home;
-    lockfilePath = join(mkdtempSync(join(tmpdir(), "kz-driver-cap-lock-")), "kaizen.permissions.lock");
+    lockfilePath = join(mkdtempSync(join(tmpdir(), "kz-driver-cap-lock-")), "permissions.lock");
   });
 
   afterEach(() => {

--- a/src/core/lockfile-path.test.ts
+++ b/src/core/lockfile-path.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "bun:test";
+import { deriveLockfilePath } from "./lockfile-path.js";
+
+describe("deriveLockfilePath", () => {
+  test("returns sibling permissions.lock for a kaizen.json path", () => {
+    expect(deriveLockfilePath("/foo/bar/kaizen.json")).toBe("/foo/bar/permissions.lock");
+  });
+
+  test("works for marketplace harness paths", () => {
+    const p = "/home/u/.kaizen/marketplaces/official/harnesses/core-debug/kaizen.json";
+    expect(deriveLockfilePath(p))
+      .toBe("/home/u/.kaizen/marketplaces/official/harnesses/core-debug/permissions.lock");
+  });
+
+  test("works for project-scoped harness paths", () => {
+    expect(deriveLockfilePath(".kaizen/harnesses/dev/kaizen.json"))
+      .toBe(".kaizen/harnesses/dev/permissions.lock");
+  });
+});

--- a/src/core/lockfile-path.ts
+++ b/src/core/lockfile-path.ts
@@ -1,0 +1,9 @@
+import { dirname, join } from "path";
+
+/**
+ * Derive the per-harness lockfile path from a harness's kaizen.json path.
+ * Lockfile lives alongside kaizen.json: `<harness-dir>/permissions.lock`.
+ */
+export function deriveLockfilePath(kaizenJsonPath: string): string {
+  return join(dirname(kaizenJsonPath), "permissions.lock");
+}

--- a/src/core/lockfile.test.ts
+++ b/src/core/lockfile.test.ts
@@ -11,7 +11,7 @@ describe("lockfile", () => {
 
   test("read missing file returns empty lockfile", () => {
     dir = mkdtempSync(join(tmpdir(), "kaizen-lock-"));
-    const lf = readLockfile(join(dir, "kaizen.permissions.lock"));
+    const lf = readLockfile(join(dir, "permissions.lock"));
     expect(lf.schemaVersion).toBe(1);
     expect(lf.plugins).toEqual({});
   });

--- a/src/core/orchestration.test.ts
+++ b/src/core/orchestration.test.ts
@@ -74,8 +74,8 @@ describe("core orchestration against ci-marketplace fixtures", () => {
     ].join("\n"));
 
     // Pre-consent the scoped spy plugin by seeding an isolated lockfile.
-    // KAIZEN_LOCKFILE_OVERRIDE redirects bootstrap() away from cwd's lockfile,
-    // so this test never touches the repo's committed kaizen.permissions.lock.
+    // Pass testLockfile directly to bootstrap() so this test never touches
+    // the repo's committed kaizen.permissions.lock.
     const testLockfile = join(home, "kaizen.permissions.lock");
     const spyPerms = { tier: "scoped" as const, events: { subscribe: ["*"] } };
     const spyHash = canonicalTierGrantHash(spyPerms);
@@ -88,18 +88,20 @@ describe("core orchestration against ci-marketplace fixtures", () => {
       permissions: { events: { subscribe: ["*"] } },
     });
     writeLockfile(testLockfile, seeded);
-    process.env.KAIZEN_LOCKFILE_OVERRIDE = testLockfile;
     try {
-      await bootstrap({
-        plugins: [
-          "ci/fixture-events@1.0.0",
-          spyDir,
-          "ci/fixture-executor@1.0.0",
-          "ci/fixture-ui@1.0.0",
-          "ci/fixture-lifecycle@1.0.0",
-        ],
-        marketplaces: [{ id: "ci", url: FIXTURE_MARKETPLACE }],
-      });
+      await bootstrap(
+        {
+          plugins: [
+            "ci/fixture-events@1.0.0",
+            spyDir,
+            "ci/fixture-executor@1.0.0",
+            "ci/fixture-ui@1.0.0",
+            "ci/fixture-lifecycle@1.0.0",
+          ],
+          marketplaces: [{ id: "ci", url: FIXTURE_MARKETPLACE }],
+        },
+        testLockfile,
+      );
 
       const { observed, payloads } = (globalThis as unknown as Record<string, { observed: string[]; payloads: Record<string, unknown[]> }>)[bridgeKey]!;
 
@@ -116,7 +118,6 @@ describe("core orchestration against ci-marketplace fixtures", () => {
       expect(payloads["test:executor:send"]?.[0]).toMatchObject({ messageCount: 1 });
       expect(payloads["session:response"]?.[0]).toMatchObject({ content: "fixture response" });
     } finally {
-      delete process.env.KAIZEN_LOCKFILE_OVERRIDE;
       delete (globalThis as Record<string, unknown>)[bridgeKey];
       rmSync(spyDir, { recursive: true, force: true });
     }

--- a/src/core/orchestration.test.ts
+++ b/src/core/orchestration.test.ts
@@ -22,7 +22,7 @@ afterEach(() => {
 
 describe("core orchestration against ci-marketplace fixtures", () => {
   it("boots plugins, runs one session turn, tears down cleanly", async () => {
-    const lockfilePath = join(home, "kaizen.permissions.lock");
+    const lockfilePath = join(home, "permissions.lock");
     await bootstrapMissingPlugins(
       {
         plugins: [
@@ -75,8 +75,8 @@ describe("core orchestration against ci-marketplace fixtures", () => {
 
     // Pre-consent the scoped spy plugin by seeding an isolated lockfile.
     // Pass testLockfile directly to bootstrap() so this test never touches
-    // the repo's committed kaizen.permissions.lock.
-    const testLockfile = join(home, "kaizen.permissions.lock");
+    // the repo's committed permissions.lock.
+    const testLockfile = join(home, "permissions.lock");
     const spyPerms = { tier: "scoped" as const, events: { subscribe: ["*"] } };
     const spyHash = canonicalTierGrantHash(spyPerms);
     const seeded = upsertPluginEntry({ schemaVersion: 1, plugins: {} }, "spy", {

--- a/src/core/plugin-installer.ts
+++ b/src/core/plugin-installer.ts
@@ -30,6 +30,16 @@ export async function installPlugin(
   }
 }
 
+/**
+ * Materialize a marketplace harness's kaizen.json into
+ * `~/.kaizen/marketplaces/<id>/harnesses/<name>/`.
+ *
+ * Preservation contract: this function MUST NOT remove other files in the
+ * target directory. The per-harness `permissions.lock` lives here and must
+ * survive re-materialization. Plugin grant changes still trigger re-consent
+ * via the tier-grant hash comparison in consent-flow. Do not add
+ * rmSync(target) here.
+ */
 export async function installHarness(
   marketplaceId: string, name: string, pathInRepo: string,
 ): Promise<void> {

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -54,7 +54,7 @@ function makeSandboxStubs() {
     sessionId: "test",
     enabled: false,
   });
-  const lockfilePath = join(mkdtempSync(join(tmpdir(), "kaizen-test-lock-")), "kaizen.permissions.lock");
+  const lockfilePath = join(mkdtempSync(join(tmpdir(), "kaizen-test-lock-")), "permissions.lock");
   const options = { trustLockfile: false, allowUnscoped: false, nonInteractive: true };
   return { enforcer, auditLog, lockfilePath, options };
 }
@@ -284,7 +284,7 @@ describe("PluginManager runtime accept-and-record (item 2)", () => {
     // must not write the lockfile even when decideConsent returns that decision.
     const pluginDir = mkdtempSync(join(tmpdir(), "kaizen-test-ext-plugin-"));
     const lockDir = mkdtempSync(join(tmpdir(), "kaizen-test-lock-"));
-    const lockfilePath = join(lockDir, "kaizen.permissions.lock");
+    const lockfilePath = join(lockDir, "permissions.lock");
 
     writeFileSync(join(pluginDir, "package.json"), JSON.stringify({ name: "ext-trusted", version: "1.0.0", main: "index.js" }));
     // Plugin file exports a minimal trusted plugin + lifecycle role

--- a/tests/fixtures/ci-marketplace/.kaizen/marketplace.json
+++ b/tests/fixtures/ci-marketplace/.kaizen/marketplace.json
@@ -82,6 +82,14 @@
       "versions": [
         { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-driver-conflict" } }
       ]
+    },
+    {
+      "kind": "harness",
+      "name": "ci-default",
+      "description": "Default CI harness bundling the four core fixture plugins.",
+      "versions": [
+        { "version": "1.0.0", "path": "harnesses/ci-default/kaizen.json" }
+      ]
     }
   ]
 }

--- a/tests/fixtures/ci-marketplace/harnesses/ci-default/kaizen.json
+++ b/tests/fixtures/ci-marketplace/harnesses/ci-default/kaizen.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "ci/fixture-events@1.0.0",
+    "ci/fixture-executor@1.0.0",
+    "ci/fixture-ui@1.0.0",
+    "ci/fixture-lifecycle@1.0.0"
+  ]
+}

--- a/tests/integration/marketplace.integration.test.ts
+++ b/tests/integration/marketplace.integration.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { $ } from "bun";
 import { addMarketplace } from "../../src/core/marketplace.js";
 import { runUnifiedInstall } from "../../src/commands/install.js";
 import { runUninstall } from "../../src/commands/uninstall.js";
-import { pluginInstallDir } from "../../src/core/kaizen-config.js";
+import { pluginInstallDir, harnessInstallDir } from "../../src/core/kaizen-config.js";
+import { installHarness } from "../../src/core/plugin-installer.js";
 
 describe("integration: local git marketplace, file-source plugin", () => {
   let home: string; let upstream: string; let project: string;
@@ -36,6 +37,33 @@ describe("integration: local git marketplace, file-source plugin", () => {
     rmSync(upstream, { recursive: true, force: true });
     rmSync(project, { recursive: true, force: true });
     delete process.env.KAIZEN_HOME_OVERRIDE;
+  });
+
+  it("installHarness preserves an existing permissions.lock on re-materialization", async () => {
+    await addMarketplace(upstream, { id: "local" });
+
+    // Create a harness source file in the upstream repo
+    const harnessPath = "harnesses/demo-harness/kaizen.json";
+    mkdirSync(join(upstream, "harnesses", "demo-harness"), { recursive: true });
+    writeFileSync(join(upstream, harnessPath), JSON.stringify({ name: "demo-harness", version: "1.0.0" }));
+    await $`git -c user.email=t@t -c user.name=t add .`.cwd(upstream);
+    await $`git -c user.email=t@t -c user.name=t commit -qm harness`.cwd(upstream);
+
+    // First install
+    await installHarness("local", "demo-harness", harnessPath);
+
+    // Simulate a permissions.lock written after initial consent
+    const lockPath = join(harnessInstallDir("local", "demo-harness"), "permissions.lock");
+    const lockContent = "schemaVersion: 1\nplugins: {}\n";
+    writeFileSync(lockPath, lockContent);
+    const before = readFileSync(lockPath);
+
+    // Re-materialize (second install)
+    await installHarness("local", "demo-harness", harnessPath);
+
+    // Lock must survive byte-for-byte
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath).equals(before)).toBe(true);
   });
 
   it("add → install → uninstall --purge", async () => {

--- a/tests/integration/marketplace.integration.test.ts
+++ b/tests/integration/marketplace.integration.test.ts
@@ -68,7 +68,7 @@ describe("integration: local git marketplace, file-source plugin", () => {
 
   it("add → install → uninstall --purge", async () => {
     await addMarketplace(upstream, { id: "local" });
-    const lock = join(project, "kaizen.permissions.lock");
+    const lock = join(project, "permissions.lock");
 
     const code = await runUnifiedInstall({
       ref: "local/demo@1.0.0", lockfilePath: lock,

--- a/tests/integration/per-harness-lockfiles.integration.test.ts
+++ b/tests/integration/per-harness-lockfiles.integration.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { deriveLockfilePath } from "../../src/core/lockfile-path.js";
+import { resolveHarness } from "../../src/core/config.js";
+
+describe("per-harness lockfile isolation", () => {
+  test("two harnesses in one repo get independent lockfile paths", () => {
+    const repo = mkdtempSync(join(tmpdir(), "kz-two-"));
+    const cwdOrig = process.cwd();
+    process.chdir(repo);
+    try {
+      const a = join(repo, ".kaizen", "harnesses", "a");
+      const b = join(repo, ".kaizen", "harnesses", "b");
+      mkdirSync(a, { recursive: true });
+      mkdirSync(b, { recursive: true });
+      writeFileSync(join(a, "kaizen.json"), JSON.stringify({ plugins: ["p1"] }));
+      writeFileSync(join(b, "kaizen.json"), JSON.stringify({ plugins: ["p2"] }));
+
+      const lockA = deriveLockfilePath(resolveHarness("a").kaizenJsonPath);
+      const lockB = deriveLockfilePath(resolveHarness("b").kaizenJsonPath);
+
+      expect(lockA).not.toBe(lockB);
+      expect(lockA.includes(".kaizen/harnesses/a/permissions.lock")).toBe(true);
+      expect(lockB.includes(".kaizen/harnesses/b/permissions.lock")).toBe(true);
+
+      writeFileSync(lockA, "A");
+      writeFileSync(lockB, "B");
+      expect(readFileSync(lockA, "utf8")).toBe("A");
+      expect(readFileSync(lockB, "utf8")).toBe("B");
+      expect(existsSync(join(repo, "kaizen.permissions.lock"))).toBe(false);
+    } finally {
+      process.chdir(cwdOrig);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Lockfile moves from repo-root `kaizen.permissions.lock` to per-harness `permissions.lock` co-located with each harness's `kaizen.json`. Two harnesses in one repo now keep independent consent records.
- Every invocation must resolve to a named harness (`--harness` or `extends`). Bare `kaizen.json` with neither is now a clear error.
- `KAIZEN_LOCKFILE_OVERRIDE` and the `process.cwd()` fallback are removed; `bootstrap` / `runHarness` / `initializePluginSystem` require `lockfilePath` explicitly. CLI derives it once from the resolved harness via `deriveLockfilePath`.
- Content-hash tamper detection intentionally **not** restored — tier-grant hash remains the sole lockfile hash. Spec: `docs/superpowers/specs/2026-04-21-per-harness-lockfiles-design.md`.
- End-to-end coverage via a new `ci-default` harness in `tests/fixtures/ci-marketplace/` + `src/core/harness-marketplace.test.ts` exercising `materializeHarnessRef → deriveLockfilePath → bootstrap`.

## Test Plan

- [x] `bun run tsc --noEmit` clean
- [x] `bun test` — 358/358 pass
- [x] `rg 'kaizen\.permissions\.lock|KAIZEN_LOCKFILE_OVERRIDE'` — no matches outside frozen `docs/superpowers/` artifacts
- [x] CLI smoke: `kaizen --harness <name>` lands lockfile at `.kaizen/harnesses/<name>/permissions.lock`, not repo root
- [x] Error paths: bare config → "named harness required"; unknown harness → "not found" with three entry-point forms
- [x] Marketplace re-materialization preserves existing `permissions.lock`