### PR TITLE
feat: rename lifecycle → driver (driver-plugin sense)

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -25,7 +25,7 @@ else — the session loop, terminal UI, CLI tools, and the LLM itself — is a p
 │  core-executor-*      wraps LLM / shell / debug           │
 │  core-ui-terminal     stdin/stdout I/O                    │
 │  core-cli             CLI introspection + tool runner     │
-│  core-lifecycle       session loop (lifecycle: true)      │
+│  core-driver          session loop (driver: true)         │
 └───────────────────────────────────────────────────────────┘
 ```
 
@@ -38,7 +38,7 @@ else — the session loop, terminal UI, CLI tools, and the LLM itself — is a p
 3. **Service and capability registries.** `registerService` / `getService` for
    typed DI; `defineCapability` for named provider declarations with cardinality
    rules. Core has no session loop of its own; after initialization it hands
-   control to the single plugin that declared `lifecycle: true`.
+   control to the single plugin that declared `driver: true`.
 
 ## Startup sequence
 
@@ -52,7 +52,7 @@ kaizen run
   │   │   └─ registerService / defineCapability / defineEvent / on
   │   └─ capability validation (cardinality, exactly-one-driver check)
   │
-  ├─ READY → core calls lifecycle.start(ctx)
+  ├─ READY → core calls driver.start(ctx)
   │
   └─ RUNNING (driven by the session-driver plugin)
       ├─ emit session:start
@@ -70,7 +70,7 @@ kaizen run
 
 ## The session driver
 
-Exactly one loaded plugin must declare `lifecycle: true` on its default
+Exactly one loaded plugin must declare `driver: true` on its default
 export. After `bootstrap()` returns, core calls `start()` on that plugin.
 Zero or more than one driver is a fatal startup error. This is the sole
 plugin-to-core contract; everything else (executor implementations, UI
@@ -90,7 +90,7 @@ throws.
 ## Plugin initialization order
 
 Plugins are topologically sorted by their declared dependencies before
-`setup()` is called. A plugin that depends on `core-lifecycle` is guaranteed
+`setup()` is called. A plugin that depends on `core-driver` is guaranteed
 to initialize after it. Event handler registration order follows
 initialization order, so a plugin's `tool:before` handler runs after its
 dependency's handler.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -115,7 +115,7 @@ src/
   commands/
     manage.ts          Management commands (apply, install, plugin *)
   core/
-    index.ts           bootstrap() — wires everything and calls lifecycle.start()
+    index.ts           bootstrap() — wires everything and calls driver.start()
     loader.ts          Plugin resolution, topo-sort, capability validation, setup()
     event-bus.ts       EventBus: defineEvent / on / emit
     capability-registry.ts  CapabilityRegistry: define / validate cardinality

--- a/docs/concepts/harnesses.md
+++ b/docs/concepts/harnesses.md
@@ -65,7 +65,7 @@ reference it by ref instead.
 ```json
 {
   "extends": "official/core-anthropic@0.1.0",
-  "core-lifecycle": {
+  "core-driver": {
     "systemPrompt": "You are a coding assistant."
   }
 }
@@ -115,7 +115,7 @@ The `kaizen.json` lists plugins (by marketplace ref) and their config:
     "official/core-executor-anthropic@0.1.0",
     "official/core-ui-terminal@0.1.0",
     "official/core-cli@0.1.0",
-    "official/core-lifecycle@0.1.0"
+    "official/core-driver@0.1.0"
   ],
   "core-executor-anthropic": {
     "model": "claude-opus-4-6",
@@ -124,7 +124,7 @@ The `kaizen.json` lists plugins (by marketplace ref) and their config:
   "core-cli": {
     "clis": ["gh", "kubectl"]
   },
-  "core-lifecycle": {
+  "core-driver": {
     "systemPrompt": "You are a DevOps assistant."
   }
 }
@@ -199,7 +199,7 @@ you've added.
     "official/core-executor-openai@0.1.0",
     "official/core-ui-terminal@0.1.0",
     "official/core-cli@0.1.0",
-    "official/core-lifecycle@0.1.0"
+    "official/core-driver@0.1.0"
   ],
   "core-executor-openai": {
     "model": "llama3.2",
@@ -231,7 +231,7 @@ you've added.
 }
 ```
 
-`kaizen-plugin-autonomous` provides the `lifecycle` capability and runs
+`kaizen-plugin-autonomous` provides the `driver` capability and runs
 headless — no `core-ui-terminal` needed.
 
 ### Extending an installed harness with local overrides
@@ -239,7 +239,7 @@ headless — no `core-ui-terminal` needed.
 ```json
 {
   "extends": "./base-harness/kaizen.json",
-  "core-lifecycle": {
+  "core-driver": {
     "systemPrompt": "Focus on the payments service."
   },
   "core-cli": {

--- a/docs/concepts/platform.md
+++ b/docs/concepts/platform.md
@@ -46,7 +46,7 @@ kaizen is a **kernel**. Core does exactly three things:
    Core has no session loop, no UI, no tools, no LLM.
 
 After all plugins initialize, core calls `start(ctx)` on the single plugin
-that declared itself the **session driver** (`lifecycle: true`). That plugin
+that declared itself the **session driver** (`driver: true`). That plugin
 owns the session from that point forward. Core never sees another frame.
 
 The unit of sharing is the **harness** — a `kaizen.json` file listing a
@@ -78,7 +78,7 @@ them is out of scope.
   session loop, no UI, no tools, no LLM — all are plugins. Core exposes
   primitives; plugins compose them.
 - **Exactly one session driver.** Exactly one loaded plugin must declare
-  `lifecycle: true`. Zero or more than one is a fatal startup error. This is
+  `driver: true`. Zero or more than one is a fatal startup error. This is
   the sole plugin-to-core contract; everything else is plugin-to-plugin and
   modeled as capabilities.
 - **Security:** destructive command guards and similar policy belong in

--- a/docs/concepts/plugin-model.md
+++ b/docs/concepts/plugin-model.md
@@ -27,7 +27,7 @@ itself:
   and subscribe to events — all during `setup()`. Anything registered after
   `setup()` returns will throw.
 
-A plugin may additionally declare `lifecycle: true` to become the session
+A plugin may additionally declare `driver: true` to become the session
 driver (see below), and may provide a `config` section describing the config
 schema and secret keys it accepts.
 
@@ -110,7 +110,7 @@ Three moments matter for a plugin author:
   follows initialization order (so a consumer's handler runs after its
   dependency's handler). If a handler throws, core logs and continues.
 - **`start(ctx)`** — runs once, on the single session driver (the plugin
-  that declared `lifecycle: true`). Core calls it after `READY`. The driver
+  that declared `driver: true`). Core calls it after `READY`. The driver
   owns the session from that point forward: it reads from UI channels, calls
   the executor, iterates tool calls, emits lifecycle events, and eventually
   closes.

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -44,7 +44,7 @@ permissions: {
   net:    { connect: ["api.example.com:443", "*.internal:*"] },
   env:    ["MY_API_KEY"],
   exec:   { binaries: ["git", "rg"] },
-  events: { subscribe: ["core-lifecycle:*", "session:user_message"] },
+  events: { subscribe: ["core-driver:*", "session:user_message"] },
 },
 ```
 

--- a/docs/core-internals.md
+++ b/docs/core-internals.md
@@ -33,10 +33,10 @@ await bootstrap(kaizenConfig, lockfilePath);
 environment-variable override.
 
 1. Creates `EventBus`, `CapabilityRegistry`, `ServiceRegistry`.
-2. Calls `loadPlugins()` → returns `{ lifecycleProvider, state }`.
-3. Creates a `PluginContext` for the lifecycle provider.
+2. Calls `loadPlugins()` → returns `{ driver, state }`.
+3. Creates a `PluginContext` for the driver plugin.
 4. Sets state to `RUNNING`.
-5. Calls `lifecycleProvider.start(ctx)` — control passes to the lifecycle plugin.
+5. Calls `driver.start(ctx)` — control passes to the driver plugin.
 6. Sets state to `CLOSED` in a `finally` block.
 
 All plugins are resolved from canonical marketplace refs or local paths — the
@@ -96,7 +96,7 @@ returns a non-void value. Handler errors are caught, logged to stderr, and
 execution continues with the next handler.
 
 The return value of `emit()` is an array of every handler's return value,
-including `undefined`. The lifecycle plugin inspects this array to implement
+including `undefined`. The driver plugin inspects this array to implement
 short-circuit logic (e.g. skip `execute()` if any handler returns a `ToolResult`).
 
 Calling `on()` or `defineEvent()` outside the `INITIALIZING` state throws because
@@ -105,7 +105,7 @@ Calling `on()` or `defineEvent()` outside the `INITIALIZING` state throws becaus
 ## CapabilityRegistry (`capability-registry.ts`)
 
 - `define(name, ownerPlugin, spec)` — declares a capability. `name` must be
-  prefixed with the owning plugin's name (e.g. `core-lifecycle:executor`).
+  prefixed with the owning plugin's name (e.g. `core-driver:executor`).
   Duplicate definitions by the same plugin warn; a different plugin claiming an
   already-owned name is a fatal error.
 - `register(name, providerPlugin)` — records that a plugin provides a named

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -89,7 +89,7 @@ through there.
 - **Commits:** [Conventional Commits](https://www.conventionalcommits.org/).
   Allowed types: `feat`, `fix`, `refactor`, `build`, `ci`, `chore`, `docs`,
   `style`, `perf`, `test`. Scope where useful:
-  `feat(core): resolve session driver via lifecycle flag`.
+  `feat(core): resolve session driver via driver flag`.
 - **Tests:** add or update tests for any behavior change. Bugs get a
   regression test.
 - **Docs:** if you change behavior or the plugin/host API, update the relevant

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -85,9 +85,9 @@ const plugin: KaizenPlugin = {
 export default plugin;
 ```
 
-Required fields: `name`, `apiVersion`, `setup`. Optional: `lifecycle`,
+Required fields: `name`, `apiVersion`, `setup`. Optional: `driver`,
 `capabilities`, `aliases`, `permissions` (defaults to `{ tier: "trusted" }`),
-`config`, `start` (only if `lifecycle: true`). Full field table in
+`config`, `start` (only if `driver: true`). Full field table in
 [`reference/plugin-api.md`](../reference/plugin-api.md#kaizenplugin-manifest).
 
 ## Registering tools {#tools}

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -20,7 +20,7 @@ export of an npm package (or workspace package).
 export interface KaizenPlugin {
   name: string;
   apiVersion: string;
-  lifecycle?: boolean;
+  driver?: boolean;
   capabilities?: PluginCapabilities;
   aliases?: Record<string, string>;
   permissions?: PluginPermissions;
@@ -112,7 +112,7 @@ export type PermissionOp =
 
 ## PluginContext (setup argument)
 
-The `ctx` object passed to `setup()` (and to `start()` for lifecycle plugins).
+The `ctx` object passed to `setup()` (and to `start()` for driver plugins).
 
 ```ts
 export interface PluginContext {

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -34,13 +34,13 @@ export interface KaizenPlugin {
 |-------|------|----------|-------------|
 | `name` | `string` | yes | kebab-case. Must match the config namespace key in `kaizen.json`. |
 | `apiVersion` | `string` | yes | semver. Core warns if major differs from `PLUGIN_API_VERSION`. |
-| `lifecycle` | `boolean` | no | If true, this plugin drives the session loop. Core calls `start()` on the one plugin with `lifecycle=true` after bootstrap. Exactly one loaded plugin must declare this — zero or two+ is a fatal startup error. |
+| `driver` | `boolean` | no | If true, this plugin drives the session loop. Core calls `start()` on the one plugin with `driver=true` after bootstrap. Exactly one loaded plugin must declare this — zero or two+ is a fatal startup error. |
 | `capabilities` | `PluginCapabilities` | no | `{ provides?: string[]; consumes?: string[] }`. Declares what this plugin provides and consumes in the capability registry. |
-| `aliases` | `Record<string, string>` | no | Map short or alternative capability names to canonical owner-qualified names. e.g. `{ "ui.input": "core-lifecycle:ui.input" }`. |
+| `aliases` | `Record<string, string>` | no | Map short or alternative capability names to canonical owner-qualified names. e.g. `{ "ui.input": "core-driver:ui.input" }`. |
 | `permissions` | `PluginPermissions` | no | Permission manifest. Defaults to `{ tier: "trusted" }`. See Permissions below. |
 | `config` | `PluginConfigDeclaration` | no | Declares config schema, defaults, and which keys are secrets. |
 | `setup` | `(ctx: PluginContext) => Promise<void>` | yes | Called once during `INITIALIZING`. Register services, declare capabilities, and subscribe to events here. |
-| `start` | `(ctx: PluginContext) => Promise<void>` | no | Only implement if `lifecycle=true`. Core calls this after all plugins initialize. |
+| `start` | `(ctx: PluginContext) => Promise<void>` | no | Only implement if `driver=true`. Core calls this after all plugins initialize. |
 
 ### PluginCapabilities
 
@@ -237,12 +237,12 @@ export type JsonSchema = {
 
 These types are part of the plugin API surface. Executor and UI plugins use
 `ctx.registerService(Token, impl)` plus `ctx.defineCapability(...)` to expose
-their implementations. The driver plugin (e.g. `core-lifecycle`) defines the
+their implementations. The driver plugin (e.g. `core-driver`) defines the
 capability names and `ServiceToken` values it expects and documents them in its
 own README. Core does not enshrine `kaizen.executor`, `kaizen.ui`, or any other
 well-known name.
 
-<!-- TODO: expand once core-lifecycle publishes its tokens and capability names -->
+<!-- TODO: expand once core-driver publishes its tokens and capability names -->
 
 ### Executor
 

--- a/docs/reference/plugin-standards.md
+++ b/docs/reference/plugin-standards.md
@@ -108,7 +108,7 @@ permissions: {
 ### Format and conventions
 
 - [required] Capability names follow the format `<owner-plugin>:<local-name>`
-- [required] `<owner-plugin>` is the kebab-case plugin name (e.g., `my-tool`, `core-lifecycle`)
+- [required] `<owner-plugin>` is the kebab-case plugin name (e.g., `my-tool`, `core-driver`)
 - [required] `<local-name>` uses dot-separated kebab-case for nested concepts (e.g., `tool.handler`, `events.before-turn`)
 - [required] Use existing capabilities from core or other plugins when available; do not duplicate
 - [guideline] Document each provided capability with a `defineCapability()` call that includes a human-readable description
@@ -271,7 +271,7 @@ async setup(ctx) {
   ctx.defineEvent("my-tool:task-completed");
 
   // Subscribe to events from other plugins
-  ctx.on("core-lifecycle:tool:before", async (payload) => {
+  ctx.on("core-driver:tool:before", async (payload) => {
     ctx.log(`Tool execution starting: ${payload?.name}`);
   });
 
@@ -286,7 +286,7 @@ async setup(ctx) {
 permissions: {
   tier: "scoped",
   events: {
-    subscribe: ["core-lifecycle:tool:before", "core-lifecycle:tool:after"]
+    subscribe: ["core-driver:tool:before", "core-driver:tool:after"]
   }
 }
 ```

--- a/docs/superpowers/plans/2026-04-21-lifecycle-to-driver-rename.md
+++ b/docs/superpowers/plans/2026-04-21-lifecycle-to-driver-rename.md
@@ -1,0 +1,691 @@
+# Lifecycle → Driver Rename Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename every driver-plugin-sense use of "lifecycle" to "driver" across types, implementation, tests, and docs — making the manifest flag, variable names, error messages, and plugin name consistent with the "session driver" concept already used in prose.
+
+**Architecture:** Type-first rename — update `KaizenPlugin.lifecycle` → `driver` first, let TypeScript surface all call sites, then fix them in order. Tests that assert on error message strings are updated last. Docs updated in a final batch commit. The CI orchestration test references an external fixture plugin (`fixture-lifecycle`) in `kaizen-official-plugins`; those lines are updated here but CI won't be green until the coordinated plugins PR lands.
+
+**Tech Stack:** TypeScript, Bun (test runner: `bun test`), `tsc --noEmit` for type-check
+
+---
+
+### Task 1: Update `KaizenPlugin.lifecycle` → `driver` in types
+
+**Files:**
+- Modify: `src/types/plugin.ts:312-327`
+
+- [ ] **Step 1: Update the field name and its JSDoc**
+
+  In `src/types/plugin.ts`, replace lines 312–327:
+
+  ```typescript
+  /**
+   * True if this plugin drives the session loop. Core calls start() on the
+   * one plugin with driver=true after bootstrap. Exactly one loaded
+   * plugin must declare this; zero or two+ is a fatal startup error.
+   */
+  driver?: boolean;
+
+  /** What this plugin provides and consumes in the capability registry. */
+  capabilities?: PluginCapabilities;
+
+  /**
+   * Map short or alternative capability names to canonical owner-qualified names.
+   * Resolved when reading the `capabilities` lists above.
+   * e.g. { "ui.input": "core-driver:ui.input" }
+   */
+  aliases?: Record<string, string>;
+  ```
+
+- [ ] **Step 2: Run type-check to see expected errors**
+
+  ```bash
+  bunx tsc --noEmit 2>&1 | grep "lifecycle"
+  ```
+
+  Expected: errors in `src/core/plugin-manager.ts` at the `plugin.lifecycle` and `lifecycleProvider` usages. No other files should error from this change alone.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/types/plugin.ts
+  git commit -m "refactor(types): rename KaizenPlugin.lifecycle flag to driver"
+  ```
+
+---
+
+### Task 2: Fix `plugin-manager.ts` — flag check, variables, error messages
+
+**Files:**
+- Modify: `src/core/plugin-manager.ts:175`, `src/core/plugin-manager.ts:331`, `src/core/plugin-manager.ts:413-437`
+
+- [ ] **Step 1: Update `isCritical` to check `plugin.driver`**
+
+  At line 175, replace:
+  ```typescript
+  if (plugin.lifecycle === true) return true;
+  ```
+  with:
+  ```typescript
+  if (plugin.driver === true) return true;
+  ```
+
+- [ ] **Step 2: Update `initialize()` return type and driver-resolution block**
+
+  At line 331, replace:
+  ```typescript
+  async initialize(): Promise<{ lifecycleProvider: KaizenPlugin }> {
+  ```
+  with:
+  ```typescript
+  async initialize(): Promise<{ driver: KaizenPlugin }> {
+  ```
+
+  Then replace the full driver-resolution block (lines 413–437):
+
+  ```typescript
+  // Resolve driver — the one plugin with `driver: true`.
+  // Core's single cross-plugin contract: call start() on the session driver.
+  const driverNames: string[] = [];
+  for (const [name, entry] of this.plugins) {
+    if (entry.plugin.driver === true && entry.entry.status === "loaded") {
+      driverNames.push(name);
+    }
+  }
+  if (driverNames.length === 0) {
+    fatal("No driver plugin found. A plugin with 'driver: true' must be loaded. Add one to kaizen.json.");
+  }
+  if (driverNames.length > 1) {
+    const quoted = driverNames.map((n) => `'${n}'`).join(", ");
+    fatal(
+      `Multiple driver plugins loaded: ${quoted}. ` +
+      `A harness may have exactly one plugin with 'driver: true'. Remove one from your kaizen.json.`,
+    );
+  }
+  const driverName = driverNames[0]!;
+  const driver = this.plugins.get(driverName)?.plugin;
+  if (!driver || typeof driver.start !== "function") {
+    fatal(`Plugin '${driverName}' declares 'driver: true' but does not export a start() function.`);
+  }
+
+  return { driver: driver! };
+  ```
+
+- [ ] **Step 3: Run type-check — expect errors only in `index.ts` now**
+
+  ```bash
+  bunx tsc --noEmit 2>&1 | grep "lifecycle"
+  ```
+
+  Expected: errors in `src/core/index.ts` only (`lifecycleProvider` no longer exists on the return type).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add src/core/plugin-manager.ts
+  git commit -m "refactor(core): rename lifecycle → driver in plugin-manager"
+  ```
+
+---
+
+### Task 3: Fix `index.ts` — rename `lifecycleProvider` and `lifecycleConfig`
+
+**Files:**
+- Modify: `src/core/index.ts:30`, `src/core/index.ts:71-103`
+
+- [ ] **Step 1: Update `InitializedSystem` interface**
+
+  At line 30, replace:
+  ```typescript
+  lifecycleProvider: Awaited<ReturnType<PluginManager["initialize"]>>["lifecycleProvider"];
+  ```
+  with:
+  ```typescript
+  driver: Awaited<ReturnType<PluginManager["initialize"]>>["driver"];
+  ```
+
+- [ ] **Step 2: Update `initializePluginSystem`**
+
+  At line 71, replace:
+  ```typescript
+  const { lifecycleProvider } = await manager.initialize();
+  return {
+    capabilityRegistry, manager, eventBus, serviceRegistry,
+    enforcer, auditLog, lifecycleProvider,
+  };
+  ```
+  with:
+  ```typescript
+  const { driver } = await manager.initialize();
+  return {
+    capabilityRegistry, manager, eventBus, serviceRegistry,
+    enforcer, auditLog, driver,
+  };
+  ```
+
+- [ ] **Step 3: Update `runHarness`**
+
+  At lines 91–103, replace:
+  ```typescript
+  const {
+    manager, eventBus, capabilityRegistry, serviceRegistry, enforcer, auditLog, lifecycleProvider,
+  } = await initializePluginSystem(kaizenConfig, init);
+
+  const lifecycleConfig =
+    (kaizenConfig[lifecycleProvider.name] as Record<string, unknown> | undefined) ?? {};
+  const secretsCtx = createSecretsContext(new SecretsRegistry(), lifecycleProvider.name, {});
+  const ctx = createPluginContext(
+    lifecycleProvider.name, lifecycleConfig, secretsCtx, eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, () => "RUNNING", manager.getPublicApi(), manager.getLifecycleApi(),
+  );
+
+  try {
+    await runInPluginScope(lifecycleProvider.name, async () => { await lifecycleProvider.start!(ctx); });
+  ```
+  with:
+  ```typescript
+  const {
+    manager, eventBus, capabilityRegistry, serviceRegistry, enforcer, auditLog, driver,
+  } = await initializePluginSystem(kaizenConfig, init);
+
+  const driverConfig =
+    (kaizenConfig[driver.name] as Record<string, unknown> | undefined) ?? {};
+  const secretsCtx = createSecretsContext(new SecretsRegistry(), driver.name, {});
+  const ctx = createPluginContext(
+    driver.name, driverConfig, secretsCtx, eventBus, capabilityRegistry, serviceRegistry,
+    enforcer, () => "RUNNING", manager.getPublicApi(), manager.getLifecycleApi(),
+  );
+
+  try {
+    await runInPluginScope(driver.name, async () => { await driver.start!(ctx); });
+  ```
+
+- [ ] **Step 4: Run type-check — expect clean**
+
+  ```bash
+  bunx tsc --noEmit
+  ```
+
+  Expected: no output (zero errors).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add src/core/index.ts
+  git commit -m "refactor(core): rename lifecycleProvider → driver in index"
+  ```
+
+---
+
+### Task 4: Fix `cli.ts` — default plugin name
+
+**Files:**
+- Modify: `src/cli.ts:69`
+
+- [ ] **Step 1: Update the default plugin list**
+
+  At line 69, replace:
+  ```typescript
+  "official/core-lifecycle@0.1.0",
+  ```
+  with:
+  ```typescript
+  "official/core-driver@0.1.0",
+  ```
+
+- [ ] **Step 2: Run type-check**
+
+  ```bash
+  bunx tsc --noEmit
+  ```
+
+  Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/cli.ts
+  git commit -m "refactor(cli): rename default plugin core-lifecycle → core-driver"
+  ```
+
+---
+
+### Task 5: Fix `plugin-manager.test.ts`
+
+**Files:**
+- Modify: `src/core/plugin-manager.test.ts:76-215`
+
+- [ ] **Step 1: Run the existing tests to confirm which ones fail**
+
+  ```bash
+  bun test src/core/plugin-manager.test.ts 2>&1
+  ```
+
+  Expected failures: all tests in the `PluginManager.initialize` describe block that reference `lifecycle` in fixture code, variable names, or error regex patterns. Tests outside that block should still pass.
+
+- [ ] **Step 2: Update `PluginSpec` interface and `writePlugin`**
+
+  Replace lines 73–107:
+
+  ```typescript
+  interface PluginSpec {
+    name: string;
+    apiVersion?: string;
+    driver?: boolean;
+    capabilities?: { provides?: string[]; consumes?: string[] };
+    aliases?: Record<string, string>;
+    permissions?: unknown;
+    /** Inline body for setup(ctx). Has access to `ctx`. */
+    setupBody?: string;
+    /** If true, include a start() that does nothing. */
+    hasStart?: boolean;
+  }
+
+  function writePlugin(spec: PluginSpec): string {
+    const dir = mkdtempSync(join(tmpdir(), `kz-pm-test-${spec.name}-`));
+    createdDirs.push(dir);
+    writeFileSync(join(dir, "package.json"), JSON.stringify({
+      name: spec.name, version: "1.0.0", type: "module", main: "index.mjs",
+    }));
+    const parts: string[] = [];
+    parts.push(`export default {`);
+    parts.push(`  name: ${JSON.stringify(spec.name)},`);
+    parts.push(`  apiVersion: ${JSON.stringify(spec.apiVersion ?? "2")},`);
+    if (spec.driver) parts.push(`  driver: true,`);
+    if (spec.capabilities) parts.push(`  capabilities: ${JSON.stringify(spec.capabilities)},`);
+    if (spec.aliases) parts.push(`  aliases: ${JSON.stringify(spec.aliases)},`);
+    if (spec.permissions !== undefined) parts.push(`  permissions: ${JSON.stringify(spec.permissions)},`);
+    parts.push(`  async setup(ctx) {`);
+    if (spec.setupBody) parts.push(spec.setupBody);
+    parts.push(`  },`);
+    if (spec.hasStart) parts.push(`  async start() {},`);
+    parts.push(`};`);
+    writeFileSync(join(dir, "index.mjs"), parts.join("\n"));
+    return dir;
+  }
+  ```
+
+- [ ] **Step 3: Update the five tests in `PluginManager.initialize`**
+
+  Replace lines 109–215 with:
+
+  ```typescript
+  describe("PluginManager.initialize", () => {
+    test("calls setup on all plugins and returns driver", async () => {
+      const bridgeKey = `__kz_test_${Date.now()}_${Math.random()}__`;
+      (globalThis as Record<string, unknown>)[bridgeKey] = { calls: [] as string[] };
+      const driverDir = writePlugin({
+        name: "core-driver",
+        driver: true,
+        hasStart: true,
+        setupBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("core-driver");`,
+      });
+
+      const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
+      const config: KaizenConfig = { plugins: [driverDir] };
+      const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+      const manager = new PluginManager(
+        config,
+        eventBus, capabilityRegistry, serviceRegistry,
+        enforcer, auditLog,
+        lockfilePath, options,
+      );
+      const { driver } = await manager.initialize();
+      const bridge = (globalThis as unknown as Record<string, { calls: string[] }>)[bridgeKey]!;
+      expect(bridge.calls).toEqual(["core-driver"]);
+      expect(driver.name).toBe("core-driver");
+      delete (globalThis as Record<string, unknown>)[bridgeKey];
+    });
+
+    test("plugin with driver:true is treated as critical — setup throws are fatal", async () => {
+      const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
+      const driverDir = writePlugin({
+        name: "core-driver",
+        driver: true,
+        hasStart: true,
+        setupBody: `throw new Error("boom");`,
+      });
+      const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+      const manager = new PluginManager(
+        { plugins: [driverDir] },
+        eventBus, capabilityRegistry, serviceRegistry,
+        enforcer, auditLog,
+        lockfilePath, options,
+      );
+      await expect(manager.initialize()).rejects.toThrow(/provides critical capability.*boom/i);
+    });
+
+    test("finds session driver via driver:true flag — no capability required", async () => {
+      const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
+      const driverDir = writePlugin({
+        name: "fixture-driver",
+        driver: true,
+        hasStart: true,
+      });
+      const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+      const manager = new PluginManager(
+        { plugins: [driverDir] },
+        eventBus, capabilityRegistry, serviceRegistry,
+        enforcer, auditLog,
+        lockfilePath, options,
+      );
+      const { driver } = await manager.initialize();
+      expect(driver.name).toBe("fixture-driver");
+    });
+
+    test("fatals when no plugin declares driver:true", async () => {
+      const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
+      const dir = writePlugin({ name: "tool-only" });
+      const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+      const manager = new PluginManager(
+        { plugins: [dir] },
+        eventBus, capabilityRegistry, serviceRegistry,
+        enforcer, auditLog,
+        lockfilePath, options,
+      );
+      await expect(manager.initialize()).rejects.toThrow(/No driver plugin found.*driver: true/);
+    });
+
+    test("fatals with names listed when two plugins declare driver:true", async () => {
+      const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
+      const a = writePlugin({ name: "a-driver", driver: true, hasStart: true });
+      const b = writePlugin({ name: "b-driver", driver: true, hasStart: true });
+      const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+      const manager = new PluginManager(
+        { plugins: [a, b] },
+        eventBus, capabilityRegistry, serviceRegistry,
+        enforcer, auditLog,
+        lockfilePath, options,
+      );
+      await expect(manager.initialize()).rejects.toThrow(
+        /Multiple driver plugins loaded: 'a-driver', 'b-driver'.*exactly one/,
+      );
+    });
+
+    test("fatals when driver plugin has no start() function", async () => {
+      const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
+      // Deliberately omit start().
+      const brokenDir = writePlugin({ name: "broken-driver", driver: true });
+      const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+      const manager = new PluginManager(
+        { plugins: [brokenDir] },
+        eventBus, capabilityRegistry, serviceRegistry,
+        enforcer, auditLog,
+        lockfilePath, options,
+      );
+      await expect(manager.initialize()).rejects.toThrow(
+        /'broken-driver' declares 'driver: true' but does not export a start\(\) function/,
+      );
+    });
+  });
+  ```
+
+- [ ] **Step 4: Run tests — expect all passing**
+
+  ```bash
+  bun test src/core/plugin-manager.test.ts 2>&1
+  ```
+
+  Expected: all tests pass, including the six `PluginManager.initialize` tests.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add src/core/plugin-manager.test.ts
+  git commit -m "test(core): update plugin-manager tests for driver rename"
+  ```
+
+---
+
+### Task 6: Fix event namespace in remaining test files
+
+**Files:**
+- Modify: `src/core/capability-registry.test.ts:7,10,88,93,94`
+- Modify: `src/core/manifest-synthesizer.test.ts:61,63`
+- Modify: `src/core/plugin-hash.test.ts:56,62`
+- Modify: `src/core/permission-enforcer.test.ts:86,87`
+- Modify: `src/core/uac-renderer.test.ts:14,21`
+
+- [ ] **Step 1: Update `capability-registry.test.ts`**
+
+  Replace all four occurrences of `"core-lifecycle:ui.input"` with `"core-driver:ui.input"` and both occurrences of the string `"core-lifecycle"` (the owner argument) with `"core-driver"`:
+
+  ```typescript
+  // Line 7-10: define + getSpec round-trips test
+  r.define("core-driver:ui.input", "core-driver", {
+    cardinality: "many", description: "User input source"
+  });
+  const spec = r.getSpec("core-driver:ui.input");
+
+  // Line 88: resolveName passthrough test
+  expect(r.resolveName("core-driver:ui.input", {})).toBe("core-driver:ui.input");
+
+  // Lines 93-94: resolveName with aliases test
+  const aliases = { "ui.input": "core-driver:ui.input" };
+  expect(r.resolveName("ui.input", aliases)).toBe("core-driver:ui.input");
+  ```
+
+- [ ] **Step 2: Update `manifest-synthesizer.test.ts`**
+
+  Replace both occurrences of `"core-lifecycle:tool:before"` with `"core-driver:tool:before"`:
+
+  ```typescript
+  rec("p1", { kind: "events.subscribe", event: "core-driver:tool:before" }),
+  // ...
+  expect(synthesizeManifest("p1", records).events?.subscribe).toEqual(["core-driver:tool:before"]);
+  ```
+
+- [ ] **Step 3: Update `plugin-hash.test.ts`**
+
+  Replace both occurrences of `"core-lifecycle:tool:before"` with `"core-driver:tool:before"`:
+
+  ```typescript
+  events: { subscribe: ["core-driver:tool:before"] },
+  ```
+  (appears twice — both the input fixture and the expected output)
+
+- [ ] **Step 4: Update `permission-enforcer.test.ts`**
+
+  Replace both occurrences of `"core-lifecycle:tool:before"` with `"core-driver:tool:before"`:
+
+  ```typescript
+  e.register("p1", { tier: "scoped", events: { subscribe: ["core-driver:tool:before", "other:*"] } });
+  expect(() => e.check("p1", { kind: "events.subscribe", event: "core-driver:tool:before" })).not.toThrow();
+  ```
+
+- [ ] **Step 5: Update `uac-renderer.test.ts`**
+
+  Replace both occurrences of `"core-lifecycle:tool:before"` with `"core-driver:tool:before"`:
+
+  ```typescript
+  events: { subscribe: ["core-driver:tool:before"] },
+  // ...
+  expect(out).toContain("core-driver:tool:before");
+  ```
+
+- [ ] **Step 6: Run all unit tests — expect all passing**
+
+  ```bash
+  bun test --exclude "**/*.integration.test.*" 2>&1
+  ```
+
+  Expected: full pass. No lifecycle-related test failures.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add src/core/capability-registry.test.ts src/core/manifest-synthesizer.test.ts \
+          src/core/plugin-hash.test.ts src/core/permission-enforcer.test.ts \
+          src/core/uac-renderer.test.ts
+  git commit -m "test(core): rename core-lifecycle event namespace to core-driver"
+  ```
+
+---
+
+### Task 7: Update orchestration and marketplace tests (coordinated with plugins PR)
+
+> **Note:** These tests reference `fixture-lifecycle` from the `kaizen-official-plugins` CI fixture marketplace. Update them here, but CI will only be green once the coordinated plugins PR (renaming `fixture-lifecycle` → `fixture-driver`) also lands.
+
+**Files:**
+- Modify: `src/core/orchestration.test.ts:32,39-48,99,109-116`
+- Modify: `src/core/harness-marketplace.test.ts:87`
+
+- [ ] **Step 1: Update `orchestration.test.ts`**
+
+  Replace both occurrences of `"ci/fixture-lifecycle@1.0.0"` with `"ci/fixture-driver@1.0.0"` (lines 32 and 99).
+
+  Replace the `EVENTS` array (lines 39–48) — the driver-emitted events rename:
+  ```typescript
+  const EVENTS = [
+    "test:driver:start",
+    "session:start",
+    "session:user_message",
+    "test:executor:send",
+    "session:response",
+    "test:ui:sent",
+    "session:end",
+    "test:driver:end",
+  ];
+  ```
+
+  Replace the `expect(observed).toEqual(...)` assertion (lines 108–117):
+  ```typescript
+  expect(observed).toEqual([
+    "test:driver:start",
+    "session:start",
+    "session:user_message",
+    "test:executor:send",
+    "session:response",
+    "test:ui:sent",
+    "session:end",
+    "test:driver:end",
+  ]);
+  ```
+
+- [ ] **Step 2: Update `harness-marketplace.test.ts`**
+
+  At line 87, replace:
+  ```typescript
+  expect(lockRaw).toContain("fixture-lifecycle");
+  ```
+  with:
+  ```typescript
+  expect(lockRaw).toContain("fixture-driver");
+  ```
+
+- [ ] **Step 3: Run unit tests (non-integration) — expect clean**
+
+  ```bash
+  bun test --exclude "**/*.integration.test.*" 2>&1
+  ```
+
+  Expected: all pass. (Integration tests that hit the CI marketplace will fail until the plugins PR lands — that's expected and acceptable.)
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add src/core/orchestration.test.ts src/core/harness-marketplace.test.ts
+  git commit -m "test(core): update fixture references from fixture-lifecycle to fixture-driver"
+  ```
+
+---
+
+### Task 8: Update docs
+
+**Files:**
+- Modify: `docs/concepts/architecture.md`
+- Modify: `docs/concepts/platform.md`
+- Modify: `docs/concepts/plugin-model.md`
+- Modify: `docs/concepts/harnesses.md`
+- Modify: `docs/concepts/security.md`
+- Modify: `docs/guides/plugin-authoring.md`
+- Modify: `docs/guides/contributing.md`
+- Modify: `docs/core-internals.md`
+
+In each file, apply these substitutions (leave generic lifecycle language untouched):
+
+| Find | Replace |
+|------|---------|
+| `lifecycle: true` (in code blocks / flag references) | `driver: true` |
+| `core-lifecycle` (plugin name) | `core-driver` |
+| `lifecycleProvider` (in prose/code) | `driver` |
+| `"core-lifecycle:*"` (event namespace strings) | `"core-driver:*"` |
+| kaizen.json config key `"core-lifecycle"` | `"core-driver"` |
+
+**Do not change:** "plugin lifecycle", "lifecycle state", "lifecycle hooks", "lifecycle shape", "lifecycle management" — these refer to the generic concept, not the driver plugin.
+
+- [ ] **Step 1: Update `docs/concepts/architecture.md`**
+
+  Change the ASCII diagram label from `core-lifecycle` to `core-driver`. Change `lifecycle: true` to `driver: true`. Leave "lifecycle.start(ctx)" prose as "driver.start(ctx)" only where it refers to the variable name; generic "lifecycle" phrases stay.
+
+- [ ] **Step 2: Update `docs/concepts/platform.md`**
+
+  Change `lifecycle: true` to `driver: true`. The `core-lifecycle` plugin name → `core-driver`. The prose "session driver" wording is already correct; only the flag name and plugin name need updating.
+
+- [ ] **Step 3: Update `docs/concepts/plugin-model.md`**
+
+  Change `lifecycle: true` to `driver: true`. The heading "## Plugin lifecycle" and the sentence "A plugin may additionally declare `driver: true`..." should use `driver`. Keep the `## Plugin lifecycle` section heading as-is (it describes the general plugin lifecycle phases, not the driver concept).
+
+- [ ] **Step 4: Update `docs/concepts/harnesses.md`**
+
+  Change all `"core-lifecycle"` config keys in kaizen.json examples to `"core-driver"`. Change `lifecycle` capability reference to `driver` where it means the plugin kind.
+
+- [ ] **Step 5: Update `docs/concepts/security.md`**
+
+  Change `"core-lifecycle:*"` event subscription example to `"core-driver:*"`.
+
+- [ ] **Step 6: Update `docs/guides/plugin-authoring.md`**
+
+  Change `lifecycle` field reference to `driver`. The sentence "Optional: `lifecycle`, ..." should read "Optional: `driver`, ...".
+
+- [ ] **Step 7: Update `docs/guides/contributing.md`**
+
+  Change the example commit message from `lifecycle flag` to `driver flag`.
+
+- [ ] **Step 8: Update `docs/core-internals.md`**
+
+  Change `lifecycleProvider` variable references to `driver`. Change `lifecycle plugin` to `driver plugin`. Change `lifecycle: true` to `driver: true` in any code examples.
+
+- [ ] **Step 9: Commit**
+
+  ```bash
+  git add docs/concepts/ docs/guides/ docs/core-internals.md
+  git commit -m "docs: rename lifecycle flag and plugin to driver throughout"
+  ```
+
+---
+
+### Task 9: Final verification
+
+- [ ] **Step 1: Full type-check**
+
+  ```bash
+  bunx tsc --noEmit
+  ```
+
+  Expected: no output.
+
+- [ ] **Step 2: Run unit tests**
+
+  ```bash
+  bun test --exclude "**/*.integration.test.*" 2>&1
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 3: Confirm no driver-sense lifecycle references remain in src/**
+
+  ```bash
+  grep -rn "lifecycle" src/ --include="*.ts" | grep -v "node_modules" | grep -v "lifecycle state\|lifecycle hook\|lifecycle shape\|lifecycle management\|any lifecycle\|object lifecycle\|entity lifecycle\|plugin lifecycle"
+  ```
+
+  Expected: no output. Any remaining hits are generic lifecycle language that doesn't need renaming.
+
+- [ ] **Step 4: Confirm no driver-sense lifecycle references remain in docs/**
+
+  ```bash
+  grep -rn "lifecycle: true\|core-lifecycle\|lifecycleProvider\|lifecycleConfig" docs/ | grep -v "superpowers/"
+  ```
+
+  Expected: no output.

--- a/docs/superpowers/specs/2026-04-21-lifecycle-to-driver-rename-design.md
+++ b/docs/superpowers/specs/2026-04-21-lifecycle-to-driver-rename-design.md
@@ -1,0 +1,131 @@
+# Rename `lifecycle` → `driver` (driver-plugin sense)
+
+**Date:** 2026-04-21
+**Issue:** #22
+**Status:** Approved
+
+---
+
+## Context
+
+The platform contract calls the plugin that receives `start()` the **session driver**. However, the manifest flag, internal variables, error messages, plugin name, and much of the docs still use **lifecycle** — a holdover from earlier drafts. This rename brings the code vocabulary into alignment with the concept as it is actually documented.
+
+Generic lifecycle language ("plugin lifecycle", "valid at any lifecycle state") is **not** changed — only driver-plugin-sense usages.
+
+---
+
+## Scope boundary
+
+**Renamed:** anything identifying the one plugin that drives a kaizen session.
+
+**Untouched:**
+- Generic lifecycle terminology in docs and comments
+- `docs/superpowers/` — historical archive, no changes
+- Any other plugin concept
+
+---
+
+## TypeScript changes (`kaizen` repo)
+
+### `src/types/plugin.ts`
+
+| Old | New |
+|-----|-----|
+| `lifecycle?: boolean` on `KaizenPlugin` | `driver?: boolean` |
+| JSDoc on the field | Updated to use "driver" terminology |
+| Example event string `"core-lifecycle:tool:before"` | `"core-driver:tool:before"` |
+
+### `src/core/plugin-manager.ts`
+
+| Old | New |
+|-----|-----|
+| `plugin.lifecycle === true` | `plugin.driver === true` |
+| `lifecyclePluginNames` | `driverNames` |
+| `lifecycleName` | `driverName` |
+| `lifecycleProvider` | `driver` |
+| `initialize(): Promise<{ lifecycleProvider }>` | `initialize(): Promise<{ driver }>` |
+| `"No lifecycle plugin found. A plugin with 'lifecycle: true' must be loaded."` | `"No driver plugin found. A plugin with 'driver: true' must be loaded."` |
+| `"Multiple lifecycle plugins loaded: ..."` | `"Multiple driver plugins loaded: ..."` |
+| `"A harness may have exactly one plugin with 'lifecycle: true'."` | `"A harness may have exactly one plugin with 'driver: true'."` |
+| `"declares 'lifecycle: true' but does not export a start() function"` | `"declares 'driver: true' but does not export a start() function"` |
+
+### `src/core/index.ts`
+
+| Old | New |
+|-----|-----|
+| `lifecycleProvider` (variable, destructuring, all usages) | `driver` |
+| `lifecycleConfig` | `driverConfig` |
+
+### `src/cli.ts`
+
+| Old | New |
+|-----|-----|
+| `"official/core-lifecycle@0.1.0"` | `"official/core-driver@0.1.0"` |
+
+---
+
+## Test changes (`kaizen` repo)
+
+### `src/core/plugin-manager.test.ts`
+
+- Fixture plugin name `"core-lifecycle"` → `"core-driver"`
+- Fixture plugin name `"fixture-lifecycle"` → `"fixture-driver"`
+- Fixture spec field `lifecycle?: boolean` → `driver?: boolean`
+- Variable `lifecycleProvider` → `driver`
+- Error message assertions updated to match new strings
+- Test description strings updated ("lifecycle plugin" → "driver plugin", `lifecycle:true` → `driver:true`)
+
+### `src/core/manifest-synthesizer.test.ts`
+
+- Event string `"core-lifecycle:tool:before"` → `"core-driver:tool:before"`
+
+### `src/core/plugin-hash.test.ts`
+
+- Event string `"core-lifecycle:tool:before"` → `"core-driver:tool:before"`
+
+### Other test files
+
+- `capability-registry.test.ts`, `orchestration.test.ts`, `harness-marketplace.test.ts`, `permission-enforcer.test.ts`, `uac-renderer.test.ts` — search for driver-sense lifecycle usages and update.
+
+---
+
+## Docs changes (`kaizen` repo)
+
+Affected files: `docs/concepts/architecture.md`, `docs/concepts/platform.md`, `docs/concepts/plugin-model.md`, `docs/concepts/harnesses.md`, `docs/concepts/security.md`, `docs/guides/plugin-authoring.md`, `docs/guides/contributing.md`, `docs/core-internals.md`.
+
+Changes:
+- `lifecycle: true` flag references → `driver: true`
+- Plugin name `core-lifecycle` → `core-driver`
+- Variable name `lifecycleProvider` in prose → `driver`
+- Event strings `"core-lifecycle:*"` → `"core-driver:*"`
+- kaizen.json examples updated to use `core-driver` as the config key
+
+Generic lifecycle language ("plugin lifecycle", "lifecycle state", "lifecycle hooks") is left as-is.
+
+---
+
+## `kaizen-official-plugins` repo (coordinated PR)
+
+Merged immediately after the kaizen PR lands.
+
+- Directory `core-lifecycle/` → `core-driver/`
+- Plugin default export: `lifecycle: true` → `driver: true`
+- Plugin `name` field: `"core-lifecycle"` → `"core-driver"`
+- Any event subscriptions referencing `"core-lifecycle:*"` → `"core-driver:*"`
+
+---
+
+## Breaking change
+
+`lifecycle: true` on a plugin's default export stops resolving. Every plugin that used to declare `lifecycle: true` must be updated to `driver: true` before it will be recognized as the session driver, producing a fatal startup error otherwise.
+
+Blast radius is contained: no public release exists and the only consumer is `kaizen-official-plugins`, updated in the coordinated PR.
+
+---
+
+## Order of operations
+
+1. Land #21 (registry refactor) first — independent, no conflicts expected.
+2. Open kaizen rename PR (this spec).
+3. Open `kaizen-official-plugins` PR simultaneously, targeting the kaizen commit that introduces `driver: true`.
+4. Merge kaizen PR, then merge plugins PR.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,7 @@ const DEFAULT_PLUGINS = {
     "official/core-executor-anthropic@0.1.0",
     "official/core-ui-terminal@0.1.0",
     "official/core-cli@0.1.0",
-    "official/core-lifecycle@0.1.0",
+    "official/core-driver@0.1.0",
   ],
   "core-executor-anthropic": {
     model: "claude-opus-4-6",

--- a/src/core/capability-registry.test.ts
+++ b/src/core/capability-registry.test.ts
@@ -4,10 +4,10 @@ import { CapabilityRegistry } from "./capability-registry.js";
 describe("CapabilityRegistry", () => {
   test("define + getSpec round-trips", () => {
     const r = new CapabilityRegistry();
-    r.define("core-lifecycle:ui.input", "core-lifecycle", {
+    r.define("core-driver:ui.input", "core-driver", {
       cardinality: "many", description: "User input source"
     });
-    const spec = r.getSpec("core-lifecycle:ui.input");
+    const spec = r.getSpec("core-driver:ui.input");
     expect(spec?.cardinality).toBe("many");
     expect(spec?.description).toBe("User input source");
   });
@@ -85,13 +85,13 @@ describe("CapabilityRegistry", () => {
 
   test("resolveName: canonical passes through", () => {
     const r = new CapabilityRegistry();
-    expect(r.resolveName("core-lifecycle:ui.input", {})).toBe("core-lifecycle:ui.input");
+    expect(r.resolveName("core-driver:ui.input", {})).toBe("core-driver:ui.input");
   });
 
   test("resolveName: alias resolves", () => {
     const r = new CapabilityRegistry();
-    const aliases = { "ui.input": "core-lifecycle:ui.input" };
-    expect(r.resolveName("ui.input", aliases)).toBe("core-lifecycle:ui.input");
+    const aliases = { "ui.input": "core-driver:ui.input" };
+    expect(r.resolveName("ui.input", aliases)).toBe("core-driver:ui.input");
   });
 
   test("list: returns all defined capabilities", () => {

--- a/src/core/harness-marketplace.test.ts
+++ b/src/core/harness-marketplace.test.ts
@@ -84,7 +84,7 @@ describe("marketplace harness ref → load flow (--harness ci/ci-default@1.0.0)"
     // Contains entries for at least the fixture plugins we just consented to.
     const lockRaw = readFileSync(lockfilePath, "utf8");
     expect(lockRaw).toContain("fixture-events");
-    expect(lockRaw).toContain("fixture-lifecycle");
+    expect(lockRaw).toContain("fixture-driver");
   });
 
   it("preserves permissions.lock across re-materialization of the harness", async () => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,7 +27,7 @@ interface InitializedSystem {
   serviceRegistry: ServiceRegistry;
   enforcer: PermissionEnforcer;
   auditLog: AuditLog;
-  lifecycleProvider: Awaited<ReturnType<PluginManager["initialize"]>>["lifecycleProvider"];
+  driver: Awaited<ReturnType<PluginManager["initialize"]>>["driver"];
 }
 
 export interface InitializePluginSystemOpts {
@@ -68,10 +68,10 @@ export async function initializePluginSystem(
     enforcer, auditLog,
     lockfilePath, { trustLockfile, allowUnscoped, nonInteractive },
   );
-  const { lifecycleProvider } = await manager.initialize();
+  const { driver } = await manager.initialize();
   return {
     capabilityRegistry, manager, eventBus, serviceRegistry,
-    enforcer, auditLog, lifecycleProvider,
+    enforcer, auditLog, driver,
   };
 }
 
@@ -88,19 +88,19 @@ export async function runHarness(opts: RunHarnessOpts): Promise<void> {
     ...(injectedEnforcer !== undefined ? { injectedEnforcer } : {}),
   };
   const {
-    manager, eventBus, capabilityRegistry, serviceRegistry, enforcer, auditLog, lifecycleProvider,
+    manager, eventBus, capabilityRegistry, serviceRegistry, enforcer, auditLog, driver,
   } = await initializePluginSystem(kaizenConfig, init);
 
-  const lifecycleConfig =
-    (kaizenConfig[lifecycleProvider.name] as Record<string, unknown> | undefined) ?? {};
-  const secretsCtx = createSecretsContext(new SecretsRegistry(), lifecycleProvider.name, {});
+  const driverConfig =
+    (kaizenConfig[driver.name] as Record<string, unknown> | undefined) ?? {};
+  const secretsCtx = createSecretsContext(new SecretsRegistry(), driver.name, {});
   const ctx = createPluginContext(
-    lifecycleProvider.name, lifecycleConfig, secretsCtx, eventBus, capabilityRegistry, serviceRegistry,
+    driver.name, driverConfig, secretsCtx, eventBus, capabilityRegistry, serviceRegistry,
     enforcer, () => "RUNNING", manager.getPublicApi(), manager.getLifecycleApi(),
   );
 
   try {
-    await runInPluginScope(lifecycleProvider.name, async () => { await lifecycleProvider.start!(ctx); });
+    await runInPluginScope(driver.name, async () => { await driver.start!(ctx); });
   } finally {
     await auditLog.flush();
   }

--- a/src/core/manifest-synthesizer.test.ts
+++ b/src/core/manifest-synthesizer.test.ts
@@ -58,8 +58,8 @@ describe("synthesizeManifest", () => {
 
   test("events.subscribe collected", () => {
     const records: CheckRecord[] = [
-      rec("p1", { kind: "events.subscribe", event: "core-lifecycle:tool:before" }),
+      rec("p1", { kind: "events.subscribe", event: "core-driver:tool:before" }),
     ];
-    expect(synthesizeManifest("p1", records).events?.subscribe).toEqual(["core-lifecycle:tool:before"]);
+    expect(synthesizeManifest("p1", records).events?.subscribe).toEqual(["core-driver:tool:before"]);
   });
 });

--- a/src/core/orchestration.test.ts
+++ b/src/core/orchestration.test.ts
@@ -29,7 +29,7 @@ describe("core orchestration against ci-marketplace fixtures", () => {
           "ci/fixture-events@1.0.0",
           "ci/fixture-executor@1.0.0",
           "ci/fixture-ui@1.0.0",
-          "ci/fixture-lifecycle@1.0.0",
+          "ci/fixture-driver@1.0.0",
         ],
         marketplaces: [{ id: "ci", url: FIXTURE_MARKETPLACE }],
       },
@@ -37,14 +37,14 @@ describe("core orchestration against ci-marketplace fixtures", () => {
     );
 
     const EVENTS = [
-      "test:lifecycle:start",
+      "test:driver:start",
       "session:start",
       "session:user_message",
       "test:executor:send",
       "session:response",
       "test:ui:sent",
       "session:end",
-      "test:lifecycle:end",
+      "test:driver:end",
     ];
 
     // Write spy plugin to disk; stash observations in globalThis to
@@ -96,7 +96,7 @@ describe("core orchestration against ci-marketplace fixtures", () => {
             spyDir,
             "ci/fixture-executor@1.0.0",
             "ci/fixture-ui@1.0.0",
-            "ci/fixture-lifecycle@1.0.0",
+            "ci/fixture-driver@1.0.0",
           ],
           marketplaces: [{ id: "ci", url: FIXTURE_MARKETPLACE }],
         },
@@ -106,14 +106,14 @@ describe("core orchestration against ci-marketplace fixtures", () => {
       const { observed, payloads } = (globalThis as unknown as Record<string, { observed: string[]; payloads: Record<string, unknown[]> }>)[bridgeKey]!;
 
       expect(observed).toEqual([
-        "test:lifecycle:start",
+        "test:driver:start",
         "session:start",
         "session:user_message",
         "test:executor:send",
         "session:response",
         "test:ui:sent",
         "session:end",
-        "test:lifecycle:end",
+        "test:driver:end",
       ]);
       expect(payloads["test:executor:send"]?.[0]).toMatchObject({ messageCount: 1 });
       expect(payloads["session:response"]?.[0]).toMatchObject({ content: "fixture response" });

--- a/src/core/permission-enforcer.test.ts
+++ b/src/core/permission-enforcer.test.ts
@@ -83,8 +83,8 @@ describe("PermissionEnforcer", () => {
 
   test("scoped tier: events.subscribe patterns", () => {
     const e = new PermissionEnforcer({ mode: "enforce" });
-    e.register("p1", { tier: "scoped", events: { subscribe: ["core-lifecycle:tool:before", "other:*"] } });
-    expect(() => e.check("p1", { kind: "events.subscribe", event: "core-lifecycle:tool:before" })).not.toThrow();
+    e.register("p1", { tier: "scoped", events: { subscribe: ["core-driver:tool:before", "other:*"] } });
+    expect(() => e.check("p1", { kind: "events.subscribe", event: "core-driver:tool:before" })).not.toThrow();
     expect(() => e.check("p1", { kind: "events.subscribe", event: "other:anything" })).not.toThrow();
     expect(() => e.check("p1", { kind: "events.subscribe", event: "third:event" })).toThrow();
   });

--- a/src/core/plugin-hash.test.ts
+++ b/src/core/plugin-hash.test.ts
@@ -53,13 +53,13 @@ describe("canonicalTierGrantHash", () => {
     net: { connect: ["x:1", "y:2"] },
     env: ["HOME"],
     exec: { binaries: ["git"] },
-    events: { subscribe: ["core-lifecycle:tool:before"] },
+    events: { subscribe: ["core-driver:tool:before"] },
   };
 
   it("is stable under key reorder", () => {
     const reordered: PluginPermissions = {
       exec: { binaries: ["git"] },
-      events: { subscribe: ["core-lifecycle:tool:before"] },
+      events: { subscribe: ["core-driver:tool:before"] },
       env: ["HOME"],
       net: { connect: ["x:1", "y:2"] },
       fs: { write: ["c"], read: ["a", "b"] },

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -73,7 +73,7 @@ afterEach(() => {
 interface PluginSpec {
   name: string;
   apiVersion?: string;
-  lifecycle?: boolean;
+  driver?: boolean;
   capabilities?: { provides?: string[]; consumes?: string[] };
   aliases?: Record<string, string>;
   permissions?: unknown;
@@ -93,7 +93,7 @@ function writePlugin(spec: PluginSpec): string {
   parts.push(`export default {`);
   parts.push(`  name: ${JSON.stringify(spec.name)},`);
   parts.push(`  apiVersion: ${JSON.stringify(spec.apiVersion ?? "2")},`);
-  if (spec.lifecycle) parts.push(`  lifecycle: true,`);
+  if (spec.driver) parts.push(`  driver: true,`);
   if (spec.capabilities) parts.push(`  capabilities: ${JSON.stringify(spec.capabilities)},`);
   if (spec.aliases) parts.push(`  aliases: ${JSON.stringify(spec.aliases)},`);
   if (spec.permissions !== undefined) parts.push(`  permissions: ${JSON.stringify(spec.permissions)},`);
@@ -107,14 +107,14 @@ function writePlugin(spec: PluginSpec): string {
 }
 
 describe("PluginManager.initialize", () => {
-  test("calls setup on all plugins and returns lifecycle provider", async () => {
+  test("calls setup on all plugins and returns driver", async () => {
     const bridgeKey = `__kz_test_${Date.now()}_${Math.random()}__`;
     (globalThis as Record<string, unknown>)[bridgeKey] = { calls: [] as string[] };
     const lifeDir = writePlugin({
-      name: "core-lifecycle",
-      lifecycle: true,
+      name: "core-driver",
+      driver: true,
       hasStart: true,
-      setupBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("core-lifecycle");`,
+      setupBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("core-driver");`,
     });
 
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
@@ -128,16 +128,16 @@ describe("PluginManager.initialize", () => {
     );
     const { driver } = await manager.initialize();
     const bridge = (globalThis as unknown as Record<string, { calls: string[] }>)[bridgeKey]!;
-    expect(bridge.calls).toEqual(["core-lifecycle"]);
-    expect(driver.name).toBe("core-lifecycle");
+    expect(bridge.calls).toEqual(["core-driver"]);
+    expect(driver.name).toBe("core-driver");
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 
-  test("plugin with lifecycle:true is treated as critical — setup throws are fatal", async () => {
+  test("plugin with driver:true is treated as critical — setup throws are fatal", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
     const lifeDir = writePlugin({
-      name: "core-lifecycle",
-      lifecycle: true,
+      name: "core-driver",
+      driver: true,
       hasStart: true,
       setupBody: `throw new Error("boom");`,
     });
@@ -151,11 +151,11 @@ describe("PluginManager.initialize", () => {
     await expect(manager.initialize()).rejects.toThrow(/provides critical capability.*boom/i);
   });
 
-  test("finds session driver via lifecycle:true flag — no capability required", async () => {
+  test("finds session driver via driver:true flag — no capability required", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
     const driverDir = writePlugin({
-      name: "fixture-lifecycle",
-      lifecycle: true,
+      name: "fixture-driver",
+      driver: true,
       hasStart: true,
     });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
@@ -166,10 +166,10 @@ describe("PluginManager.initialize", () => {
       lockfilePath, options,
     );
     const { driver } = await manager.initialize();
-    expect(driver.name).toBe("fixture-lifecycle");
+    expect(driver.name).toBe("fixture-driver");
   });
 
-  test("fatals when no plugin declares lifecycle:true", async () => {
+  test("fatals when no plugin declares driver:true", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
     const dir = writePlugin({ name: "tool-only" });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
@@ -179,13 +179,13 @@ describe("PluginManager.initialize", () => {
       enforcer, auditLog,
       lockfilePath, options,
     );
-    await expect(manager.initialize()).rejects.toThrow(/No lifecycle plugin found.*lifecycle: true/);
+    await expect(manager.initialize()).rejects.toThrow(/No driver plugin found.*driver: true/);
   });
 
-  test("fatals with names listed when two plugins declare lifecycle:true", async () => {
+  test("fatals with names listed when two plugins declare driver:true", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
-    const a = writePlugin({ name: "a-life", lifecycle: true, hasStart: true });
-    const b = writePlugin({ name: "b-life", lifecycle: true, hasStart: true });
+    const a = writePlugin({ name: "a-driver", driver: true, hasStart: true });
+    const b = writePlugin({ name: "b-driver", driver: true, hasStart: true });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
       { plugins: [a, b] },
@@ -194,14 +194,14 @@ describe("PluginManager.initialize", () => {
       lockfilePath, options,
     );
     await expect(manager.initialize()).rejects.toThrow(
-      /Multiple lifecycle plugins loaded: 'a-life', 'b-life'.*exactly one/,
+      /Multiple driver plugins loaded: 'a-driver', 'b-driver'.*exactly one/,
     );
   });
 
-  test("fatals when lifecycle plugin has no start() function", async () => {
+  test("fatals when driver plugin has no start() function", async () => {
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
     // Deliberately omit start().
-    const brokenDir = writePlugin({ name: "broken-life", lifecycle: true });
+    const brokenDir = writePlugin({ name: "broken-driver", driver: true });
     const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
     const manager = new PluginManager(
       { plugins: [brokenDir] },
@@ -210,7 +210,7 @@ describe("PluginManager.initialize", () => {
       lockfilePath, options,
     );
     await expect(manager.initialize()).rejects.toThrow(
-      /'broken-life' declares 'lifecycle: true' but does not export a start\(\) function/,
+      /'broken-driver' declares 'driver: true' but does not export a start\(\) function/,
     );
   });
 });
@@ -298,7 +298,7 @@ describe("PluginManager runtime accept-and-record (item 2)", () => {
       "};",
     ].join("\n"));
 
-    const lifeDir = writePlugin({ name: "core-lifecycle", lifecycle: true, hasStart: true });
+    const lifeDir = writePlugin({ name: "core-driver", driver: true, hasStart: true });
 
     const { eventBus, capabilityRegistry, serviceRegistry } = makeRegistries();
     const enforcer = new PermissionEnforcer({ mode: "log-only" });
@@ -407,7 +407,7 @@ describe("PluginManager capability validation", () => {
       setupBody: `ctx.defineCapability("owner:bag", { cardinality: "many", description: "" });`,
     });
     const consumerDir = writePlugin({ name: "consumer", capabilities: { consumes: ["owner:bag"] } });
-    const lifeDir = writePlugin({ name: "core-lifecycle", lifecycle: true, hasStart: true });
+    const lifeDir = writePlugin({ name: "core-driver", driver: true, hasStart: true });
     const manager = new PluginManager(
       { plugins: [ownerDir, consumerDir, lifeDir] },
       regs.eventBus, regs.capabilityRegistry, regs.serviceRegistry,
@@ -443,15 +443,15 @@ describe("PluginManager capability validation", () => {
     const bridgeKey = `__kz_alias_${Date.now()}_${Math.random()}__`;
     (globalThis as Record<string, unknown>)[bridgeKey] = { ran: false };
     const lifeDir = writePlugin({
-      name: "core-lifecycle",
-      lifecycle: true,
+      name: "core-driver",
+      driver: true,
       hasStart: true,
-      capabilities: { provides: ["core-lifecycle:executor.send"] },
-      setupBody: `ctx.defineCapability("core-lifecycle:executor.send", { cardinality: "many", description: "" });`,
+      capabilities: { provides: ["core-driver:executor.send"] },
+      setupBody: `ctx.defineCapability("core-driver:executor.send", { cardinality: "many", description: "" });`,
     });
     const consumerDir = writePlugin({
       name: "consumer",
-      aliases: { "executor": "core-lifecycle:executor.send" },
+      aliases: { "executor": "core-driver:executor.send" },
       capabilities: { consumes: ["executor"] },
       setupBody: `globalThis[${JSON.stringify(bridgeKey)}].ran = true;`,
     });
@@ -469,7 +469,7 @@ describe("PluginManager capability validation", () => {
 
   test("owner-prefix mismatch throws during setup (plugin flagged as failed when not critical)", async () => {
     const regs = baseRegistries();
-    const lifeDir = writePlugin({ name: "core-lifecycle", lifecycle: true, hasStart: true });
+    const lifeDir = writePlugin({ name: "core-driver", driver: true, hasStart: true });
     const badDir = writePlugin({
       name: "bad",
       capabilities: { provides: [] },

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -287,7 +287,7 @@ describe("PluginManager runtime accept-and-record (item 2)", () => {
     const lockfilePath = join(lockDir, "permissions.lock");
 
     writeFileSync(join(pluginDir, "package.json"), JSON.stringify({ name: "ext-trusted", version: "1.0.0", main: "index.js" }));
-    // Plugin file exports a minimal trusted plugin + lifecycle role
+    // Plugin file exports a minimal trusted plugin + driver role
     writeFileSync(join(pluginDir, "index.js"), [
       "exports.default = {",
       "  name: 'ext-trusted',",

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -126,10 +126,10 @@ describe("PluginManager.initialize", () => {
       enforcer, auditLog,
       lockfilePath, options,
     );
-    const { lifecycleProvider } = await manager.initialize();
+    const { driver } = await manager.initialize();
     const bridge = (globalThis as unknown as Record<string, { calls: string[] }>)[bridgeKey]!;
     expect(bridge.calls).toEqual(["core-lifecycle"]);
-    expect(lifecycleProvider.name).toBe("core-lifecycle");
+    expect(driver.name).toBe("core-lifecycle");
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 
@@ -165,8 +165,8 @@ describe("PluginManager.initialize", () => {
       enforcer, auditLog,
       lockfilePath, options,
     );
-    const { lifecycleProvider } = await manager.initialize();
-    expect(lifecycleProvider.name).toBe("fixture-lifecycle");
+    const { driver } = await manager.initialize();
+    expect(driver.name).toBe("fixture-lifecycle");
   });
 
   test("fatals when no plugin declares lifecycle:true", async () => {

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -172,7 +172,7 @@ function resolveCapName(name: string, aliases: Record<string, string>): string {
 }
 
 function isCritical(plugin: KaizenPlugin, reg: CapabilityRegistry): boolean {
-  if (plugin.lifecycle === true) return true;
+  if (plugin.driver === true) return true;
   const aliases = plugin.aliases ?? {};
   for (const raw of plugin.capabilities?.provides ?? []) {
     const cap = resolveCapName(raw, aliases);
@@ -328,7 +328,7 @@ export class PluginManager {
   // Initialization (startup path — replaces loadPlugins)
   // --------------------------------------------------------------------------
 
-  async initialize(): Promise<{ lifecycleProvider: KaizenPlugin }> {
+  async initialize(): Promise<{ driver: KaizenPlugin }> {
     const resolvedPlugins: LoadedPlugin[] = [];
     for (const name of this.config.plugins) {
       if (RESERVED_KEYS.has(name)) {
@@ -410,31 +410,31 @@ export class PluginManager {
       if (!claimedKeys.has(key)) warn(`Unknown config key '${key}'. No plugin claimed it.`);
     }
 
-    // Resolve lifecycle provider — the one plugin with `lifecycle: true`.
+    // Resolve driver — the one plugin with `driver: true`.
     // Core's single cross-plugin contract: call start() on the session driver.
-    const lifecyclePluginNames: string[] = [];
+    const driverNames: string[] = [];
     for (const [name, entry] of this.plugins) {
-      if (entry.plugin.lifecycle === true && entry.entry.status === "loaded") {
-        lifecyclePluginNames.push(name);
+      if (entry.plugin.driver === true && entry.entry.status === "loaded") {
+        driverNames.push(name);
       }
     }
-    if (lifecyclePluginNames.length === 0) {
-      fatal("No lifecycle plugin found. A plugin with 'lifecycle: true' must be loaded. Add one to kaizen.json.");
+    if (driverNames.length === 0) {
+      fatal("No driver plugin found. A plugin with 'driver: true' must be loaded. Add one to kaizen.json.");
     }
-    if (lifecyclePluginNames.length > 1) {
-      const quoted = lifecyclePluginNames.map((n) => `'${n}'`).join(", ");
+    if (driverNames.length > 1) {
+      const quoted = driverNames.map((n) => `'${n}'`).join(", ");
       fatal(
-        `Multiple lifecycle plugins loaded: ${quoted}. ` +
-        `A harness may have exactly one plugin with 'lifecycle: true'. Remove one from your kaizen.json.`,
+        `Multiple driver plugins loaded: ${quoted}. ` +
+        `A harness may have exactly one plugin with 'driver: true'. Remove one from your kaizen.json.`,
       );
     }
-    const lifecycleName = lifecyclePluginNames[0]!;
-    const lifecycleProvider = this.plugins.get(lifecycleName)?.plugin;
-    if (!lifecycleProvider || typeof lifecycleProvider.start !== "function") {
-      fatal(`Plugin '${lifecycleName}' declares 'lifecycle: true' but does not export a start() function.`);
+    const driverName = driverNames[0]!;
+    const driver = this.plugins.get(driverName)?.plugin;
+    if (!driver || typeof driver.start !== "function") {
+      fatal(`Plugin '${driverName}' declares 'driver: true' but does not export a start() function.`);
     }
 
-    return { lifecycleProvider: lifecycleProvider! };
+    return { driver: driver! };
   }
 
   // --------------------------------------------------------------------------

--- a/src/core/uac-renderer.test.ts
+++ b/src/core/uac-renderer.test.ts
@@ -11,14 +11,14 @@ describe("renderScopedUAC", () => {
         tier: "scoped",
         net: { connect: ["api.example.com:443"] },
         env: ["EXAMPLE_API_KEY"],
-        events: { subscribe: ["core-lifecycle:tool:before"] },
+        events: { subscribe: ["core-driver:tool:before"] },
       },
     });
     expect(out).toContain("cool-unknown-plugin@1.2.3");
     expect(out).toContain("SCOPED");
     expect(out).toContain("api.example.com:443");
     expect(out).toContain("EXAMPLE_API_KEY");
-    expect(out).toContain("core-lifecycle:tool:before");
+    expect(out).toContain("core-driver:tool:before");
   });
 
   test("empty grants render as '(none)'", () => {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -283,7 +283,7 @@ export interface PluginPermissions {
   };
 
   events?: {
-    /** Cross-plugin event subscription patterns, e.g. ["core-lifecycle:tool:before"]. */
+    /** Cross-plugin event subscription patterns, e.g. ["core-driver:tool:before"]. */
     subscribe?: string[];
   };
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -311,10 +311,10 @@ export interface KaizenPlugin {
 
   /**
    * True if this plugin drives the session loop. Core calls start() on the
-   * one plugin with lifecycle=true after bootstrap. Exactly one loaded
+   * one plugin with driver=true after bootstrap. Exactly one loaded
    * plugin must declare this; zero or two+ is a fatal startup error.
    */
-  lifecycle?: boolean;
+  driver?: boolean;
 
   /** What this plugin provides and consumes in the capability registry. */
   capabilities?: PluginCapabilities;
@@ -322,7 +322,7 @@ export interface KaizenPlugin {
   /**
    * Map short or alternative capability names to canonical owner-qualified names.
    * Resolved when reading the `capabilities` lists above.
-   * e.g. { "ui.input": "core-lifecycle:ui.input" }
+   * e.g. { "ui.input": "core-driver:ui.input" }
    */
   aliases?: Record<string, string>;
 

--- a/tests/fixtures/ci-marketplace/.kaizen/marketplace.json
+++ b/tests/fixtures/ci-marketplace/.kaizen/marketplace.json
@@ -46,7 +46,7 @@
     {
       "kind": "plugin",
       "name": "cap-driver",
-      "description": "Capability-resolution test fixture: lifecycle driver consuming cap:thing.",
+      "description": "Capability-resolution test fixture: session driver consuming cap:thing.",
       "versions": [
         { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-driver" } }
       ]
@@ -78,7 +78,7 @@
     {
       "kind": "plugin",
       "name": "cap-driver-conflict",
-      "description": "Capability-resolution test fixture: lifecycle driver consuming conflict:thing.",
+      "description": "Capability-resolution test fixture: session driver consuming conflict:thing.",
       "versions": [
         { "version": "1.0.0", "source": { "type": "file", "path": "plugins/cap-driver-conflict" } }
       ]

--- a/tests/fixtures/ci-marketplace/.kaizen/marketplace.json
+++ b/tests/fixtures/ci-marketplace/.kaizen/marketplace.json
@@ -29,10 +29,10 @@
     },
     {
       "kind": "plugin",
-      "name": "fixture-lifecycle",
-      "description": "Minimal lifecycle provider for core orchestration tests.",
+      "name": "fixture-driver",
+      "description": "Minimal driver plugin for core orchestration tests.",
       "versions": [
-        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/fixture-lifecycle" } }
+        { "version": "1.0.0", "source": { "type": "file", "path": "plugins/fixture-driver" } }
       ]
     },
     {

--- a/tests/fixtures/ci-marketplace/harnesses/ci-default/kaizen.json
+++ b/tests/fixtures/ci-marketplace/harnesses/ci-default/kaizen.json
@@ -3,6 +3,6 @@
     "ci/fixture-events@1.0.0",
     "ci/fixture-executor@1.0.0",
     "ci/fixture-ui@1.0.0",
-    "ci/fixture-lifecycle@1.0.0"
+    "ci/fixture-driver@1.0.0"
   ]
 }

--- a/tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-driver-conflict/index.mjs
@@ -1,7 +1,7 @@
 export default {
   name: "cap-driver-conflict",
   apiVersion: "2",
-  lifecycle: true,
+  driver: true,
   capabilities: { consumes: ["cap-owner:thing"] },
   async setup() {},
   async start() {},

--- a/tests/fixtures/ci-marketplace/plugins/cap-driver/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/cap-driver/index.mjs
@@ -1,7 +1,7 @@
 export default {
   name: "cap-driver",
   apiVersion: "2",
-  lifecycle: true,
+  driver: true,
   capabilities: { consumes: ["cap-provider:thing"] },
   async setup() {},
   async start() {},

--- a/tests/fixtures/ci-marketplace/plugins/fixture-driver/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/fixture-driver/index.mjs
@@ -1,5 +1,5 @@
-// Minimal lifecycle provider. Drives exactly one session turn, emits
-// test:lifecycle:start / :end bracketing the work, then returns so
+// Minimal driver plugin. Drives exactly one session turn, emits
+// test:driver:start / :end bracketing the work, then returns so
 // bootstrap() resolves.
 //
 // Post-registry-refactor: core no longer exposes runtime.{ui,executors,tools}.
@@ -9,23 +9,23 @@
 // intentionally absent: a future core-tools broker plugin will own that
 // concept; until then the driver passes an empty tool list to executors.
 export default {
-  name: "fixture-lifecycle",
+  name: "fixture-driver",
   apiVersion: "2",
-  lifecycle: true,
+  driver: true,
   capabilities: {
-    consumes: ["fixture-lifecycle:executor.send", "fixture-lifecycle:ui"],
+    consumes: ["fixture-driver:executor.send", "fixture-driver:ui"],
   },
   async setup(ctx) {
-    ctx.defineCapability("fixture-lifecycle:executor.send", { cardinality: "one", description: "LLM executor" });
-    ctx.defineCapability("fixture-lifecycle:ui", { cardinality: "many", description: "UI provider" });
+    ctx.defineCapability("fixture-driver:executor.send", { cardinality: "one", description: "LLM executor" });
+    ctx.defineCapability("fixture-driver:ui", { cardinality: "many", description: "UI provider" });
   },
   async start(ctx) {
-    await ctx.emit("test:lifecycle:start");
+    await ctx.emit("test:driver:start");
     await ctx.emit("session:start");
 
     const impls = globalThis.__kaizenFixtureImpls ?? {};
-    const ui = impls["fixture-lifecycle:ui"];
-    const executor = impls["fixture-lifecycle:executor.send"];
+    const ui = impls["fixture-driver:ui"];
+    const executor = impls["fixture-driver:executor.send"];
 
     for await (const channel of ui.accept()) {
       const userMsg = await channel.receive();
@@ -41,6 +41,6 @@ export default {
     }
 
     await ctx.emit("session:end");
-    await ctx.emit("test:lifecycle:end");
+    await ctx.emit("test:driver:end");
   },
 };

--- a/tests/fixtures/ci-marketplace/plugins/fixture-driver/package.json
+++ b/tests/fixtures/ci-marketplace/plugins/fixture-driver/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixture-lifecycle",
+  "name": "fixture-driver",
   "version": "1.0.0",
   "type": "module",
   "main": "index.mjs"

--- a/tests/fixtures/ci-marketplace/plugins/fixture-events/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/fixture-events/index.mjs
@@ -1,5 +1,5 @@
 // Minimal fixture mirroring core-events. Pre-defines the six canonical
-// session events so fixture-lifecycle and fixture-executor can emit them.
+// session events so fixture-driver and fixture-executor can emit them.
 export const EVENTS = {
   SESSION_START:  "session:start",
   SESSION_END:    "session:end",
@@ -18,7 +18,7 @@ export default {
     ctx.defineEvent("test:executor:send");
     ctx.defineEvent("test:ui:received");
     ctx.defineEvent("test:ui:sent");
-    ctx.defineEvent("test:lifecycle:start");
-    ctx.defineEvent("test:lifecycle:end");
+    ctx.defineEvent("test:driver:start");
+    ctx.defineEvent("test:driver:end");
   },
 };

--- a/tests/fixtures/ci-marketplace/plugins/fixture-executor/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/fixture-executor/index.mjs
@@ -6,7 +6,7 @@
 export default {
   name: "fixture-executor",
   apiVersion: "2",
-  capabilities: { provides: ["fixture-lifecycle:executor.send"] },
+  capabilities: { provides: ["fixture-driver:executor.send"] },
   async setup(ctx) {
     const impl = {
       async send(messages, tools) {
@@ -18,6 +18,6 @@ export default {
       },
       async *stream() { yield { type: "done" }; },
     };
-    (globalThis.__kaizenFixtureImpls ??= {})["fixture-lifecycle:executor.send"] = impl;
+    (globalThis.__kaizenFixtureImpls ??= {})["fixture-driver:executor.send"] = impl;
   },
 };

--- a/tests/fixtures/ci-marketplace/plugins/fixture-ui/index.mjs
+++ b/tests/fixtures/ci-marketplace/plugins/fixture-ui/index.mjs
@@ -9,7 +9,7 @@
 export default {
   name: "fixture-ui",
   apiVersion: "2",
-  capabilities: { provides: ["fixture-lifecycle:ui"] },
+  capabilities: { provides: ["fixture-driver:ui"] },
   async setup(ctx) {
     const impl = {
       async *accept() {
@@ -33,6 +33,6 @@ export default {
         };
       },
     };
-    (globalThis.__kaizenFixtureImpls ??= {})["fixture-lifecycle:ui"] = impl;
+    (globalThis.__kaizenFixtureImpls ??= {})["fixture-driver:ui"] = impl;
   },
 };


### PR DESCRIPTION
## Summary

- Renames `KaizenPlugin.lifecycle: true` flag to `driver: true` — the manifest field that designates the session driver plugin
- Renames all internal variables (`lifecycleProvider` → `driver`, `lifecycleConfig` → `driverConfig`), error messages, and event namespace (`core-lifecycle:*` → `core-driver:*`) to match
- Updates all tests, CI fixtures, and docs throughout

## Breaking change

Any plugin declaring `lifecycle: true` must be updated to `driver: true`. Zero/multiple driver plugins remain a fatal startup error with updated error messages. A coordinated PR against `kaizen-official-plugins` (renaming `core-lifecycle` → `core-driver` and flipping the flag) should land immediately after this merges.

## Test plan

- [ ] `bun test` — 358/358 pass
- [ ] `bunx tsc --noEmit` — clean
- [ ] Coordinate `kaizen-official-plugins` PR: rename `core-lifecycle/` → `core-driver/`, flip `lifecycle: true` → `driver: true`

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)