### PR TITLE
fix: repair broken curl|bash install flow

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -101,10 +101,9 @@ bootstrap() {
     return 0
   fi
 
-  local kaizen_bin="${INSTALL_DIR}/${BINARY}"
   local market_url="https://github.com/CraightonH/kaizen-official-plugins.git"
   info "Registering marketplace 'official'..."
-  if "$kaizen_bin" marketplace add "$market_url" --id official; then
+  if kaizen marketplace add "$market_url" --id official; then
     green "  ✓ marketplace 'official' registered"
   else
     red "  ! marketplace add failed; run manually: kaizen marketplace add $market_url --id official"
@@ -113,7 +112,7 @@ bootstrap() {
 
   local default_harness="official/core-shell@1.0.0"
   info "Installing default harness ${default_harness}..."
-  if "$kaizen_bin" install "$default_harness"; then
+  if kaizen install "$default_harness"; then
     green "  ✓ ${default_harness} installed"
   else
     red "  ! harness install failed; run manually: kaizen install $default_harness"
@@ -185,6 +184,11 @@ main() {
   fi
 
   green "  ✓ Installed ${BINARY} → ${INSTALL_DIR}/${BINARY}"
+
+  case ":$PATH:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *) red "  ! ${INSTALL_DIR} is not on PATH — add it to your shell profile so 'kaizen' resolves." ;;
+  esac
 
   local global_config="${KAIZEN_HOME}/kaizen.json"
   if [ ! -f "$global_config" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -101,9 +101,10 @@ bootstrap() {
     return 0
   fi
 
+  local kaizen_bin="${INSTALL_DIR}/${BINARY}"
   local market_url="https://github.com/CraightonH/kaizen-official-plugins.git"
   info "Registering marketplace 'official'..."
-  if kaizen marketplace add "$market_url" --id official; then
+  if "$kaizen_bin" marketplace add "$market_url" --id official; then
     green "  ✓ marketplace 'official' registered"
   else
     red "  ! marketplace add failed; run manually: kaizen marketplace add $market_url --id official"
@@ -112,7 +113,7 @@ bootstrap() {
 
   local default_harness="official/core-shell@1.0.0"
   info "Installing default harness ${default_harness}..."
-  if kaizen install "$default_harness"; then
+  if "$kaizen_bin" install "$default_harness"; then
     green "  ✓ ${default_harness} installed"
   else
     red "  ! harness install failed; run manually: kaizen install $default_harness"
@@ -162,7 +163,7 @@ main() {
 
   local tmpdir
   tmpdir="$(mktemp -d)"
-  trap 'rm -rf "$tmpdir"' EXIT
+  trap 'rm -rf "${tmpdir:-}"' EXIT
 
   info "Downloading ${asset_name}..."
   download "${base_url}/${asset_name}" "${tmpdir}/${asset_name}"
@@ -211,6 +212,6 @@ main() {
 
 # Only run main if the script is executed directly, not sourced. Lets tests
 # source the file to unit-test individual helpers.
-if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+if [ "${BASH_SOURCE[0]:-$0}" = "${0}" ]; then
   main "$@"
 fi

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,45 @@ const DEFAULT_PLUGINS = {
 };
 
 // ---------------------------------------------------------------------------
+// Subcommand: kaizen --help | -h | help
+// ---------------------------------------------------------------------------
+
+if (subcommand === "--help" || subcommand === "-h" || subcommand === "help" || (subcommand === undefined && (rawArgs.includes("--help") || rawArgs.includes("-h")))) {
+  console.log(`kaizen — platform for composable LLM harnesses
+
+Usage:
+  kaizen --harness <ref> [prompt]       run a harness (prompts for consent first run)
+  kaizen run [prompt]                   run the active harness
+  kaizen <subcommand> [args]
+
+Subcommands:
+  init [--global]                       scaffold kaizen.json (project or ~/.kaizen/)
+  install <ref> [--allow-unscoped]      install a plugin or harness
+  uninstall <ref> [--purge]             uninstall a plugin
+  update [<ref>]                        update plugins
+  plugin {list|consent|review|audit|dev|create|validate}
+  marketplace {add|list|remove|update|browse|create|validate}
+  capability {list|show <name>}
+  config {show|get|set|set-secret}
+
+Flags:
+  --harness <ref>                       harness ref (marketplace/name@version)
+  --config <path>                       alternate kaizen.json path
+  --trust-lockfile                      reuse existing lockfile; no prompts
+  --non-interactive                     refuse any prompt-requiring consent
+  --allow-unscoped                      permit non-interactive UNSCOPED consent
+  --allow-destructive                   enable destructive CLI tools
+  --help, -h                            show this help
+
+Environment:
+  KAIZEN_HOME                           state dir (default ~/.kaizen)
+  KAIZEN_SANDBOX_MODE=log-only          permission enforcer logs instead of throws
+
+See docs/concepts/harnesses.md for harness configuration.`);
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
 // Subcommand: kaizen init [--global]
 // ---------------------------------------------------------------------------
 
@@ -264,8 +303,12 @@ if (subcommand === "install") {
   const rest = rawArgs.slice(1);
   const ref = rest.find((a) => !a.startsWith("--"));
   if (!ref) { console.error("usage: kaizen install <ref> [--allow-unscoped] [--non-interactive]"); process.exit(2); }
-  const harnessJsonPath = resolveHarnessJsonPath({});
-  const lockfilePath = deriveLockfilePath(harnessJsonPath);
+  // Harness installs don't need an active harness context; plugin installs do.
+  // Defer resolution so `kaizen install <harness-ref>` works from a bare setup.
+  let lockfilePath = "";
+  try {
+    lockfilePath = deriveLockfilePath(resolveHarnessJsonPath({}));
+  } catch { /* resolved lazily inside runUnifiedInstall only for plugin installs */ }
   const { runUnifiedInstall } = await import("./commands/install.js");
   const code = await runUnifiedInstall({
     ref,


### PR DESCRIPTION
## Summary

Dogfooded the README install instructions against the v0.1.0 GitHub release. Five bugs blocked the flow end-to-end; this PR fixes all of them.

### scripts/install.sh
- `BASH_SOURCE[0]: unbound variable` under `curl | bash` (set -u) — fixed with `${BASH_SOURCE[0]:-$0}`.
- Bootstrap invoked `kaizen` via `PATH`, but `INSTALL_DIR` may not be on PATH → `command not found`. Fixed by calling `\"${INSTALL_DIR}/${BINARY}\"` directly.
- `tmpdir: unbound variable` in the `EXIT` trap after `main()` returned (local var out of scope). Fixed with `${tmpdir:-}`.

### src/cli.ts
- `kaizen install <harness-ref>` required an active harness context, making first-time bootstrap impossible (chicken-and-egg). Fixed by resolving the lockfile path lazily — harness installs don't need one.
- `kaizen --help` / `-h` / `help` errored with `kaizen requires a named harness`. Added a top-level help subcommand that prints usage and exits 0.

## Test plan

- [x] `bun test` — 358 pass, 0 fail
- [x] Reproduced original `curl | bash` failure against public v0.1.0
- [x] Verified full flow end-to-end with fixed binary: download → checksum → install → `init --global` → `marketplace add official` → `install official/core-shell@1.0.0`
- [x] `kaizen --help`, `-h`, `help` all print usage and exit 0
- [ ] Cut a v0.1.1 release after merge so the public install URL works