### PR TITLE
fix: robust marketplace update; surface git errors; clarify sudo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,25 @@ stack. From source, run `scripts/dev-setup.sh` against a sibling checkout — se
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/CraightonH/kaizen/master/scripts/install.sh | bash
+sudo -v && curl -fsSL https://raw.githubusercontent.com/CraightonH/kaizen/master/scripts/install.sh | bash
 ```
 
 The script detects your platform (macOS/Linux, x64/arm64), downloads the
 matching release binary from GitHub, verifies its checksum, installs it to
 `/usr/local/bin/kaizen`, and seeds the `official` marketplace under
 `$KAIZEN_HOME` (default `~/.kaizen`).
+
+`sudo -v` caches your credentials so the script's one `sudo mv` into
+`/usr/local/bin` (root-owned) doesn't stall on a prompt it can't read from
+the curl pipe. Everything else runs as your normal user, and `kaizen`
+itself never needs sudo after install.
+
+To install without root, override `INSTALL_DIR` to a user-writable directory
+on your `PATH`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CraightonH/kaizen/master/scripts/install.sh | INSTALL_DIR=$HOME/.local/bin bash
+```
 
 Environment overrides:
 

--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -34,7 +34,13 @@ export async function addMarketplace(url: string, opts: AddMarketplaceOpts = {})
     if (!existsSync(url)) throw new Error(`local marketplace path not found: ${url}`);
     symlinkSync(url, repoDir);
   } else {
-    await $`git clone --depth=1 ${url} ${repoDir}`.quiet();
+    try {
+      await $`git clone --depth=1 ${url} ${repoDir}`.quiet();
+    } catch (e) {
+      const proc = e as { stderr?: Buffer | string; exitCode?: number };
+      const stderr = proc.stderr ? proc.stderr.toString().trim() : "";
+      throw new Error(`git clone failed (exit ${proc.exitCode ?? "?"})${stderr ? ":\n" + stderr : ""}`);
+    }
   }
 
   const cat = await readCatalog(id);
@@ -46,17 +52,31 @@ export async function addMarketplace(url: string, opts: AddMarketplaceOpts = {})
 }
 
 export async function pullMarketplace(id: string): Promise<void> {
-  const repoDir = marketplaceRepoDir(id);
-  if (!existsSync(repoDir)) throw new Error(`marketplace '${id}' is not added`);
-  if (lstatSync(repoDir).isSymbolicLink()) return; // no-op for local dev
-  await $`git -C ${repoDir} pull --depth=1 --ff-only`.quiet();
-
   const cfg = await loadKaizenGlobalConfig();
   const ref = cfg.marketplaces?.find((m) => m.id === id);
-  if (ref) {
-    ref.updatedAt = new Date().toISOString();
-    await saveKaizenGlobalConfig(cfg);
+  if (!ref) throw new Error(`marketplace '${id}' is not added`);
+
+  const repoDir = marketplaceRepoDir(id);
+  if (existsSync(repoDir) && lstatSync(repoDir).isSymbolicLink()) {
+    return; // local dev symlink — nothing to refresh
   }
+
+  // The clone is treated as ephemeral cache: wipe and re-clone so we never
+  // get stuck on diverged history, force-pushes, or shallow-fetch quirks.
+  rmSync(repoDir, { recursive: true, force: true });
+  try {
+    await $`git clone --depth=1 ${ref.url} ${repoDir}`.quiet();
+  } catch (e) {
+    const proc = e as { stderr?: Buffer | string; exitCode?: number };
+    const stderr = proc.stderr ? proc.stderr.toString().trim() : "";
+    throw new Error(`git clone failed (exit ${proc.exitCode ?? "?"})${stderr ? ":\n" + stderr : ""}`);
+  }
+
+  const cat = await readCatalog(id);
+  validateCatalog(cat);
+
+  ref.updatedAt = new Date().toISOString();
+  await saveKaizenGlobalConfig(cfg);
 }
 
 export async function removeMarketplace(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

- **`pullMarketplace` is now idempotent against history rewrites.** The clone is treated as an ephemeral cache: wipe `repoDir` and re-clone every time. `--ff-only` + shallow pulls fail with exit 128 when the remote diverges (rewrite/force-push/rebase), and the marketplace has no user-authored state locally anyway, so there's nothing to preserve.
- **Git failures now surface stderr.** Previously `exit code 128` was all users saw because `$\`...\`.quiet()` swallowed stderr. Both `addMarketplace` and `pullMarketplace` now include git's actual message in the thrown error.
- **README install docs.** Prefix with `sudo -v` so credentials are cached before the `curl | bash` pipe hits the script's `sudo mv` into `/usr/local/bin` (the pipe can't prompt). Document `INSTALL_DIR` override for sudo-less installs.

## Test plan

- [x] `bun test` — 358 pass, 0 fail
- [x] Reproduced original `kaizen marketplace update official` failure (exit 128 after upstream rewrite)
- [x] Verified new behavior: update succeeds, plugin tree reflects latest remote