### PR TITLE
fix: don't require active harness for commands that don't need one

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,11 +20,25 @@ import { runPluginConsent } from "./commands/plugin-consent.js";
 import { runPluginReview } from "./commands/plugin-review.js";
 import { runPluginAudit } from "./commands/plugin-audit.js";
 import { registerHostApi } from "./core/host-api-register.js";
+import { KaizenError } from "./core/errors.js";
 
 // Register the `kaizen/types` virtual module for plugin imports.
 // Must run before any dynamic plugin import (bootstrap, plugin dev,
 // capability list, tests, etc.).
 registerHostApi();
+
+// Top-level error handling: KaizenError is a user-facing error; print the
+// message and exit 1 without a stack trace. Anything else is a bug and
+// gets the full stack.
+function handleFatal(err: unknown): never {
+  if (err instanceof KaizenError) {
+    console.error(`error: ${err.message}`);
+    process.exit(1);
+  }
+  throw err;
+}
+process.on("uncaughtException", handleFatal);
+process.on("unhandledRejection", handleFatal);
 
 // ---------------------------------------------------------------------------
 // Arg parsing
@@ -57,7 +71,10 @@ function resolveHarnessJsonPath(opts: { harness?: string; extendsOverride?: stri
       if (typeof raw.extends === "string") return resolveHarness(raw.extends).kaizenJsonPath;
     } catch { /* resolveConfig will raise the right error */ }
   }
-  return fatal("kaizen requires a named harness; see docs/concepts/harnesses.md");
+  return fatal(
+    `this command requires an active harness. Pass --harness <marketplace>/<name>@<version>, ` +
+    `or set 'extends' in kaizen.json. See docs/concepts/harnesses.md.`,
+  );
 }
 
 const DEFAULT_PLUGINS = {
@@ -390,7 +407,9 @@ if (subcommand === "plugin") {
     process.exit(code);
   }
 
-  const lockfilePath = deriveLockfilePath(resolveHarnessJsonPath({}));
+  // list/create/validate don't need an active harness; consent/review/audit do.
+  const needsHarness = pluginSub === "consent" || pluginSub === "review" || pluginSub === "audit";
+  const lockfilePath = needsHarness ? deriveLockfilePath(resolveHarnessJsonPath({})) : "";
 
   if (pluginSub === "consent" && name) {
     const code = await runPluginConsent({


### PR DESCRIPTION
## Summary

Audit of \`src/cli.ts\` subcommand dispatch. Several subcommands called \`resolveHarnessJsonPath({})\` unconditionally before dispatching, so commands that never touch the harness (like \`kaizen plugin list\`) would bomb with a raw Bun stack trace on \"kaizen requires a named harness\".

### Changes

- **\`plugin\` dispatch**: only resolve the lockfile path for \`consent\`, \`review\`, and \`audit\` — the three subcommands that actually need it. \`list\`, \`create\`, \`validate\` no longer require an active harness.
- **Top-level error handler**: catch \`KaizenError\` at \`uncaughtException\` / \`unhandledRejection\` and print a one-line \`error: <msg>\` before exiting 1. Non-Kaizen errors still surface with full stack (they're bugs).
- **Harness-required error message**: rephrased from \"kaizen requires a named harness; see docs/concepts/harnesses.md\" to an actionable sentence that tells the user to pass \`--harness\` or set \`extends\` in \`kaizen.json\`.

### Commands verified
- ✅ No-harness: \`plugin list\`, \`plugin create\`, \`plugin validate\`, \`init\`, \`add\`, \`remove\`, \`list\`, \`config *\`, \`marketplace *\`, \`--help\`
- ✅ Harness-required: \`uninstall\`, \`update\`, \`plugin consent/review/audit\`, \`plugin dev --observe\`, \`capability *\`, default run — all print the new clean error when no harness is active.
- ✅ Earlier fix still works: \`kaizen install <harness-ref>\` bootstraps from bare setup.

## Test plan

- [x] \`bun test\` — 358 pass
- [x] Smoke-tested every subcommand against a bare \`~/.kaizen\` with no \`extends\`