### PR TITLE
fix: skip node:* import warnings for unscoped plugins (#40)

### DIFF
--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -292,7 +292,8 @@ Checks (see `src/commands/plugin-validate.ts` for the full list):
   `services.consumes`.
 - Warns on imports of `node:fs`, `node:child_process`, `node:worker_threads`,
   `bun:ffi`, and their unprefixed forms — the runtime enforcer blocks these
-  regardless.
+  regardless. Skipped for `unscoped` tier (those plugins are exempt from import
+  enforcement).
 - `*.test.ts` file present; `README.md` present.
 
 Exit code is `0` on pass (possibly with warnings), `1` on any failure. Common

--- a/src/commands/plugin-validate.test.ts
+++ b/src/commands/plugin-validate.test.ts
@@ -279,6 +279,14 @@ describe("scanImports", () => {
     const results = await scanImports("/nonexistent/path/index.ts");
     expect(results.some((r) => r.status === "warn" && r.message?.includes("Could not parse"))).toBe(true);
   });
+
+  it("does not flag imports for unscoped tier", async () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "index.ts");
+    writeFileSync(filePath, `import fs from "node:fs";\nimport { spawn } from "node:child_process";\nexport default {};\n`);
+    const results = await scanImports(filePath, "unscoped");
+    expect(results.filter((r) => r.status === "warn")).toHaveLength(0);
+  });
 });
 
 // ─── checkFilesPresent ────────────────────────────────────────────────────────

--- a/src/commands/plugin-validate.ts
+++ b/src/commands/plugin-validate.ts
@@ -232,7 +232,19 @@ export async function checkConfigSchema(plugin: Record<string, unknown>): Promis
   return results;
 }
 
-export async function scanImports(filePath: string): Promise<ValidationResult[]> {
+async function loadPluginTier(dir: string, entryRelative: string): Promise<string | undefined> {
+  try {
+    const entryPath = join(dir, entryRelative);
+    const mod = await import(pathToFileURL(entryPath).href) as { default?: unknown };
+    const plugin = (mod.default ?? mod) as Record<string, unknown>;
+    const permissions = plugin.permissions as Record<string, unknown> | undefined;
+    return permissions?.tier as string | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function scanImports(filePath: string, tier?: string): Promise<ValidationResult[]> {
   const results: ValidationResult[] = [];
 
   let src: string;
@@ -259,6 +271,8 @@ export async function scanImports(filePath: string): Promise<ValidationResult[]>
     });
     return results;
   }
+
+  if (tier === "unscoped") return results;
 
   for (const imp of imports) {
     if (FLAGGED_IMPORTS.has(imp)) {
@@ -343,7 +357,8 @@ export async function runPluginValidate(dir: string): Promise<number> {
     if (entryRelative) {
       const entryPath = join(dir, entryRelative);
       if (existsSync(entryPath)) {
-        const importResults = await scanImports(entryPath);
+        const tier = await loadPluginTier(dir, entryRelative);
+        const importResults = await scanImports(entryPath, tier);
         allResults.push(...importResults);
       }
     }


### PR DESCRIPTION
## Summary
- `scanImports` now accepts the plugin's `tier`; returns no warnings when `tier === "unscoped"`
- Caller loads the tier from the manifest and passes it through
- Updated plugin-authoring docs to note the unscoped exemption

Fixes #40.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (353 pass)
- [x] New test: `scanImports` returns no warnings when tier=unscoped even with `node:fs` / `node:child_process` imports
- [x] Existing trusted/scoped warning behavior unchanged