### PR TITLE
feat: non-interactive flags for plugin create (#38, #41)

### DIFF
--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -30,14 +30,57 @@ kaizen plugin create <target-dir>
 
 Interactive prompts cover: plugin name, description, permission tier
 (`trusted` / `scoped` / `unscoped`), scoped grants (`fs`, `net`, `env`, `exec`,
-`events`), `provides` / `consumes` services, and optional config keys
-(including which are secrets).
+`events`), `provides` / `consumes` services, whether the plugin is a session
+driver, and optional config keys (including which are secrets).
 
 Add `--defaults` to skip prompts and scaffold a minimal `trusted` plugin:
 
 ```sh
 kaizen plugin create ./my-plugin --defaults
 ```
+
+Every prompt also has a corresponding flag, so the command can run fully
+non-interactively (for agents, CI, or bulk scaffolding). When stdin is not a
+TTY, or any scaffold flag is passed, prompts are skipped entirely and unset
+fields fall back to defaults:
+
+```sh
+kaizen plugin create ./my-plugin \
+  --name my-plugin \
+  --description "does a thing" \
+  --tier scoped \
+  --grant fs,net \
+  --provides my-plugin:api \
+  --driver
+```
+
+Flags:
+
+| Flag                   | Purpose                                                    |
+|------------------------|------------------------------------------------------------|
+| `--name`               | Plugin name (default: basename of target path)             |
+| `--description`        | Description text                                           |
+| `--tier`               | `trusted` \| `scoped` \| `unscoped` (default `trusted`)     |
+| `--grant`              | One or more of `fs,net,env,exec,events`. Repeatable and/or comma-separated. |
+| `--provides`           | Service name; repeatable and/or comma-separated.           |
+| `--consumes`           | Service name; repeatable and/or comma-separated.           |
+| `--driver`             | Scaffold a session driver (adds `driver:true` and a `start(ctx)` stub). |
+| `--config-keys-json`   | Inline JSON array of ConfigKey objects.                    |
+| `--config-keys-file`   | Path to a JSON file with a ConfigKey array.                |
+| `--defaults`           | Use defaults for all fields; skip prompts.                 |
+
+ConfigKey shape (applies to both `--config-keys-json` and `--config-keys-file`):
+
+```json
+[
+  { "name": "api_key", "type": "string", "required": true,  "secret": true },
+  { "name": "port",    "type": "number", "required": false, "secret": false }
+]
+```
+
+`type` must be `string` or `number`. Kaizen validates this structure but does
+not validate the semantic correctness of the resulting config schema — that is
+the plugin author's responsibility.
 
 The generator writes:
 

--- a/docs/superpowers/plans/2026-04-23-plugin-create-non-interactive.md
+++ b/docs/superpowers/plans/2026-04-23-plugin-create-non-interactive.md
@@ -1,0 +1,1063 @@
+# Non-interactive `kaizen plugin create` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every scaffold input for `kaizen plugin create` settable via CLI flag, auto-detect non-interactive environments, and add first-class support for scaffolding session drivers (#38, #41).
+
+**Architecture:** Add a `PluginCreateOpts.flags` field that `runPluginCreate` prefers over prompts. Parse flags in `src/cli.ts` via `node:util`'s `parseArgs` (zero deps). Add a `buildConfigFromFlags()` helper that validates + fills defaults. Mode selection is automatic: `--defaults` → defaults path; TTY + no scaffold flags → interactive; otherwise → non-interactive. Add `driver: boolean` to `PluginScaffoldConfig` and update the generators + interactive prompt.
+
+**Tech Stack:** TypeScript, Bun, `node:util` `parseArgs`, `bun:test`.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-plugin-create-non-interactive-design.md`
+
+**Branch:** `feat/plugin-create-non-interactive-38` (already created; spec committed)
+
+---
+
+## File Structure
+
+- **Modify** `src/commands/plugin-create.ts` — add `driver` field; generator updates; `buildConfigFromFlags()`; mode-selection in `runPluginCreate`; interactive driver prompt.
+- **Modify** `src/cli.ts` — `parseArgs` for `plugin create`; build `opts` from parsed flags.
+- **Modify** `src/commands/plugin-create.test.ts` — unit tests for generator changes, `buildConfigFromFlags`, end-to-end non-interactive flows.
+- **Modify** `docs/guides/plugin-authoring.md` — document non-interactive usage.
+
+---
+
+## Task 1: Add `driver` field to scaffold config + default path
+
+**Files:**
+- Modify: `src/commands/plugin-create.ts`
+- Test: `src/commands/plugin-create.test.ts`
+
+- [ ] **Step 1: Add test for `driver: false` in defaults mode**
+
+Append to the `describe("defaults mode", ...)` block in `src/commands/plugin-create.test.ts`:
+
+```ts
+    it("defaults do not produce a driver manifest", async () => {
+      await runPluginCreate(targetPath, { defaults: true });
+      const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+      expect(src).not.toContain("driver: true");
+      expect(src).not.toContain("async start(ctx)");
+    });
+```
+
+- [ ] **Step 2: Run test, expect PASS (baseline — current output already has no driver)**
+
+Run: `bun test src/commands/plugin-create.test.ts -t "defaults do not produce a driver manifest"`
+Expected: PASS
+
+- [ ] **Step 3: Add `driver` to `PluginScaffoldConfig` and defaults init**
+
+In `src/commands/plugin-create.ts`, update the interface (around lines 16-25):
+
+```ts
+export interface PluginScaffoldConfig {
+  name: string;
+  description: string;
+  tier: "trusted" | "scoped" | "unscoped";
+  grants: Array<"fs" | "net" | "env" | "exec" | "events">;
+  provides: string[];
+  consumes: string[];
+  hasConfig: boolean;
+  configKeys: ConfigKey[];
+  driver: boolean;
+}
+```
+
+Update the `--defaults` path in `runPluginCreate` (around line 398-409):
+
+```ts
+  if (opts.defaults) {
+    cfg = {
+      name: basename(targetPath),
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: false,
+    };
+  } else {
+```
+
+Update the `promptConfig` return (end of function, around line 379) to include `driver: false` for now (Task 3 adds the prompt):
+
+```ts
+  return { name, description, tier, grants, provides, consumes, hasConfig, configKeys, driver: false };
+```
+
+- [ ] **Step 4: Run typecheck and full test suite**
+
+Run: `bun run typecheck && bun test src/commands/plugin-create.test.ts`
+Expected: typecheck clean; all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/plugin-create.ts src/commands/plugin-create.test.ts
+git commit -m "feat(plugin-create): add driver field to scaffold config"
+```
+
+---
+
+## Task 2: Generator support for `driver: true`
+
+**Files:**
+- Modify: `src/commands/plugin-create.ts`
+- Test: `src/commands/plugin-create.test.ts`
+
+- [ ] **Step 1: Write failing tests for driver generator output**
+
+Append to `src/commands/plugin-create.test.ts` (new `describe` block at end of file, before the closing):
+
+```ts
+describe("driver generator", () => {
+  let tmpBase: string;
+  let targetPath: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "kaizen-create-"));
+    targetPath = join(tmpBase, "my-driver");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("emits driver: true and start(ctx) in index.ts when driver flag is set", async () => {
+    const { generateIndexTs } = await import("./plugin-create.js");
+    const src = generateIndexTs({
+      name: "my-driver",
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: true,
+    });
+    expect(src).toContain("driver: true,");
+    expect(src).toContain("async start(ctx)");
+    expect(src).toContain(`ctx.log("driver started")`);
+  });
+
+  it("generated test asserts driver: true when driver flag is set", async () => {
+    const { generateIndexTestTs } = await import("./plugin-create.js");
+    const src = generateIndexTestTs({
+      name: "my-driver",
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: true,
+    });
+    expect(src).toContain(`expect(plugin.driver).toBe(true)`);
+  });
+
+  it("non-driver generation is unchanged", async () => {
+    const { generateIndexTs, generateIndexTestTs } = await import("./plugin-create.js");
+    const cfg = {
+      name: "p",
+      description: "",
+      tier: "trusted" as const,
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: false,
+    };
+    expect(generateIndexTs(cfg)).not.toContain("driver:");
+    expect(generateIndexTs(cfg)).not.toContain("async start(ctx)");
+    expect(generateIndexTestTs(cfg)).not.toContain("plugin.driver");
+  });
+});
+```
+
+Also make sure the existing `generateIndexTs` / `generateIndexTestTs` are exported. Check `src/commands/plugin-create.ts` — these are already `export function`. If not exported, add `export` keyword.
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+Run: `bun test src/commands/plugin-create.test.ts -t "driver generator"`
+Expected: FAIL — current generator does not emit `driver:` or `start(ctx)`.
+
+- [ ] **Step 3: Update `generateIndexTs` to emit driver manifest + start method**
+
+In `src/commands/plugin-create.ts`, in `generateIndexTs` (around line 144-171), change the `lines` construction so that:
+
+1. If `cfg.driver` is true, insert `  driver: true,` right after the `name:` / `apiVersion:` lines and before `permissions:`.
+2. If `cfg.driver` is true, append a `start(ctx)` method after the `setup` method.
+
+Replace the `lines` construction (the block starting `const lines: string[] = [`) with:
+
+```ts
+  const lines: string[] = [
+    `import type { KaizenPlugin } from "kaizen/types";`,
+    ``,
+    `const plugin: KaizenPlugin = {`,
+    `  name: "${cfg.name}",`,
+    `  apiVersion: "2.0.0",`,
+  ];
+
+  if (cfg.driver) {
+    lines.push(`  driver: true,`);
+  }
+
+  lines.push(
+    `  permissions: {`,
+    ...permissionsLines,
+    `  },`,
+    `  services: {`,
+    ...capsLines,
+    `  },`,
+  );
+
+  if (configBlock) {
+    lines.push(configBlock);
+  }
+
+  lines.push(
+    ``,
+    `  async setup(ctx) {`,
+    ...setupLines,
+    `  },`,
+  );
+
+  if (cfg.driver) {
+    lines.push(
+      ``,
+      `  async start(ctx) {`,
+      `    // TODO: implement session loop`,
+      `    ctx.log("driver started");`,
+      `  },`,
+    );
+  }
+
+  lines.push(
+    `};`,
+    ``,
+    `export default plugin;`,
+    ``
+  );
+
+  return lines.join("\n");
+```
+
+- [ ] **Step 4: Update `generateIndexTestTs` to emit driver assertion**
+
+In `src/commands/plugin-create.ts`, in `generateIndexTestTs` (around line 226-239), add a driver assertion block. Replace the closing `describe(...)` construction with:
+
+```ts
+    `describe("${cfg.name}", () => {`,
+    `  it("has correct metadata", () => {`,
+    `    expect(plugin.name).toBe("${cfg.name}");`,
+    `    expect(plugin.apiVersion).toBe("2.0.0");`,
+    `  });`,
+    ``,
+    ...(cfg.driver
+      ? [
+          `  it("declares driver: true", () => {`,
+          `    expect(plugin.driver).toBe(true);`,
+          `  });`,
+          ``,
+        ]
+      : []),
+    `  it("setup runs without error", async () => {`,
+    `    const ctx = makeCtx();`,
+    `    await plugin.setup(ctx);`,
+    `    expect(ctx.log).toHaveBeenCalled();`,
+    `  });`,
+    `});`,
+    ``,
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+Run: `bun test src/commands/plugin-create.test.ts && bun run typecheck`
+Expected: all pass, typecheck clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/plugin-create.ts src/commands/plugin-create.test.ts
+git commit -m "feat(plugin-create): generate driver:true + start(ctx) stub"
+```
+
+---
+
+## Task 3: Interactive prompt for `driver`
+
+**Files:**
+- Modify: `src/commands/plugin-create.ts`
+
+No new test: the interactive prompt path is not covered by existing tests; consistent with the current test surface, we add behavior here and rely on manual verification + the non-interactive tests in Task 6 for `driver` flag coverage.
+
+- [ ] **Step 1: Add the driver prompt in `promptConfig`**
+
+In `src/commands/plugin-create.ts`, in `promptConfig` (around line 356-358, between the `consumes` prompt and the `hasConfig` prompt), add:
+
+```ts
+  const driverInput = await prompt(rl, `Is this a session driver? (y/N) [N]: `);
+  const driver = driverInput.toLowerCase() === "y";
+```
+
+- [ ] **Step 2: Update return statement**
+
+Change the `promptConfig` return (bottom of function) from:
+
+```ts
+  return { name, description, tier, grants, provides, consumes, hasConfig, configKeys, driver: false };
+```
+
+to:
+
+```ts
+  return { name, description, tier, grants, provides, consumes, hasConfig, configKeys, driver };
+```
+
+- [ ] **Step 3: Manual smoke test**
+
+Run: `bun run bin/kaizen plugin create /tmp/drv-smoke-$$`
+Answer `y` to "Is this a session driver?"; defaults for everything else.
+Then: `cat /tmp/drv-smoke-*/index.ts | grep -E "driver:|start\(ctx\)"`
+Expected: both `driver: true,` and `async start(ctx) {` present.
+Cleanup: `rm -rf /tmp/drv-smoke-*`
+
+- [ ] **Step 4: Run typecheck + tests**
+
+Run: `bun run typecheck && bun test src/commands/plugin-create.test.ts`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/plugin-create.ts
+git commit -m "feat(plugin-create): prompt for driver in interactive mode"
+```
+
+---
+
+## Task 4: `buildConfigFromFlags` helper (TDD)
+
+**Files:**
+- Modify: `src/commands/plugin-create.ts`
+- Test: `src/commands/plugin-create.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `src/commands/plugin-create.test.ts` (new describe at end of file):
+
+```ts
+describe("buildConfigFromFlags", () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "kaizen-create-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("fills defaults for unset flags", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const cfg = buildConfigFromFlags("/tmp/some-path/my-plug", {});
+    expect(cfg).toEqual({
+      name: "my-plug",
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: false,
+    });
+  });
+
+  it("applies all flags", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const cfg = buildConfigFromFlags("/tmp/x/plug", {
+      name: "custom-name",
+      description: "desc",
+      tier: "scoped",
+      grants: ["fs", "net"],
+      provides: ["svc:a"],
+      consumes: ["svc:b"],
+      driver: true,
+    });
+    expect(cfg.name).toBe("custom-name");
+    expect(cfg.description).toBe("desc");
+    expect(cfg.tier).toBe("scoped");
+    expect(cfg.grants).toEqual(["fs", "net"]);
+    expect(cfg.provides).toEqual(["svc:a"]);
+    expect(cfg.consumes).toEqual(["svc:b"]);
+    expect(cfg.driver).toBe(true);
+  });
+
+  it("rejects invalid tier", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    expect(() => buildConfigFromFlags("/tmp/p", { tier: "god-mode" as never }))
+      .toThrow(/tier/);
+  });
+
+  it("rejects invalid grant", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    expect(() => buildConfigFromFlags("/tmp/p", { grants: ["bogus" as never] }))
+      .toThrow(/grant/);
+  });
+
+  it("parses --config-keys-json inline", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const json = JSON.stringify([
+      { name: "api_key", type: "string", required: true, secret: true },
+    ]);
+    const cfg = buildConfigFromFlags("/tmp/p", { configKeysJson: json });
+    expect(cfg.hasConfig).toBe(true);
+    expect(cfg.configKeys).toEqual([
+      { name: "api_key", type: "string", required: true, secret: true },
+    ]);
+  });
+
+  it("parses --config-keys-file", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const file = join(tmpBase, "keys.json");
+    writeFileSync(file, JSON.stringify([
+      { name: "port", type: "number", required: false, secret: false },
+    ]));
+    const cfg = buildConfigFromFlags("/tmp/p", { configKeysFile: file });
+    expect(cfg.hasConfig).toBe(true);
+    expect(cfg.configKeys[0]?.name).toBe("port");
+  });
+
+  it("rejects both --config-keys-json and --config-keys-file", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    expect(() => buildConfigFromFlags("/tmp/p", {
+      configKeysJson: "[]",
+      configKeysFile: "/tmp/x.json",
+    })).toThrow(/mutually exclusive/);
+  });
+
+  it("rejects malformed config-keys JSON (not array)", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    expect(() => buildConfigFromFlags("/tmp/p", { configKeysJson: "{}" }))
+      .toThrow(/array/);
+  });
+
+  it("rejects malformed config-keys entry (missing name)", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const json = JSON.stringify([{ type: "string", required: false, secret: false }]);
+    expect(() => buildConfigFromFlags("/tmp/p", { configKeysJson: json }))
+      .toThrow(/name/);
+  });
+
+  it("rejects malformed config-keys entry (bad type)", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const json = JSON.stringify([{ name: "x", type: "enum", required: false, secret: false }]);
+    expect(() => buildConfigFromFlags("/tmp/p", { configKeysJson: json }))
+      .toThrow(/type/);
+  });
+});
+```
+
+Add `writeFileSync` to the imports at the top of the test file if not already present (check existing imports; it's already imported alongside `readFileSync`? The current file uses `readFileSync`. Add `writeFileSync`):
+
+```ts
+import { mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync } from "fs";
+```
+
+- [ ] **Step 2: Run tests, expect FAIL (function doesn't exist)**
+
+Run: `bun test src/commands/plugin-create.test.ts -t "buildConfigFromFlags"`
+Expected: FAIL with "buildConfigFromFlags is not a function" (or import error).
+
+- [ ] **Step 3: Define the flags type**
+
+In `src/commands/plugin-create.ts`, add after `PluginScaffoldConfig` (around line 26):
+
+```ts
+export interface PluginCreateFlags {
+  name?: string;
+  description?: string;
+  tier?: "trusted" | "scoped" | "unscoped";
+  grants?: Array<"fs" | "net" | "env" | "exec" | "events">;
+  provides?: string[];
+  consumes?: string[];
+  driver?: boolean;
+  configKeysJson?: string;
+  configKeysFile?: string;
+}
+```
+
+- [ ] **Step 4: Implement `buildConfigFromFlags`**
+
+Add to `src/commands/plugin-create.ts`, before the `runPluginCreate` function (around line 382). Also add `readFileSync` to the top-level imports:
+
+```ts
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+```
+
+Then:
+
+```ts
+const VALID_TIERS = ["trusted", "scoped", "unscoped"] as const;
+const VALID_GRANTS = ["fs", "net", "env", "exec", "events"] as const;
+const VALID_CONFIG_TYPES = ["string", "number"] as const;
+
+export function buildConfigFromFlags(
+  targetPath: string,
+  flags: PluginCreateFlags
+): PluginScaffoldConfig {
+  if (flags.tier && !VALID_TIERS.includes(flags.tier)) {
+    throw new Error(
+      `Invalid --tier "${flags.tier}"; must be one of ${VALID_TIERS.join(", ")}`
+    );
+  }
+
+  if (flags.grants) {
+    for (const g of flags.grants) {
+      if (!VALID_GRANTS.includes(g)) {
+        throw new Error(
+          `Invalid --grant "${g}"; must be one of ${VALID_GRANTS.join(", ")}`
+        );
+      }
+    }
+  }
+
+  if (flags.configKeysJson && flags.configKeysFile) {
+    throw new Error(
+      "--config-keys-json and --config-keys-file are mutually exclusive"
+    );
+  }
+
+  let configKeys: ConfigKey[] = [];
+  let hasConfig = false;
+  const rawJson =
+    flags.configKeysJson
+      ?? (flags.configKeysFile ? readFileSync(flags.configKeysFile, "utf8") : undefined);
+
+  if (rawJson !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawJson);
+    } catch (e) {
+      throw new Error(`config keys input is not valid JSON: ${String(e)}`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error("config keys input must be a JSON array");
+    }
+    configKeys = parsed.map((entry, i) => validateConfigKey(entry, i));
+    hasConfig = true;
+  }
+
+  return {
+    name: flags.name ?? basename(targetPath),
+    description: flags.description ?? "",
+    tier: flags.tier ?? "trusted",
+    grants: flags.grants ?? [],
+    provides: flags.provides ?? [],
+    consumes: flags.consumes ?? [],
+    hasConfig,
+    configKeys,
+    driver: flags.driver ?? false,
+  };
+}
+
+function validateConfigKey(entry: unknown, index: number): ConfigKey {
+  if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+    throw new Error(`config keys[${index}] must be an object`);
+  }
+  const e = entry as Record<string, unknown>;
+  if (typeof e.name !== "string" || e.name.length === 0) {
+    throw new Error(`config keys[${index}] missing required string "name"`);
+  }
+  if (typeof e.type !== "string" || !VALID_CONFIG_TYPES.includes(e.type as never)) {
+    throw new Error(
+      `config keys[${index}].type must be one of ${VALID_CONFIG_TYPES.join(", ")}`
+    );
+  }
+  if (typeof e.required !== "boolean") {
+    throw new Error(`config keys[${index}].required must be a boolean`);
+  }
+  if (typeof e.secret !== "boolean") {
+    throw new Error(`config keys[${index}].secret must be a boolean`);
+  }
+  return { name: e.name, type: e.type, required: e.required, secret: e.secret };
+}
+```
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+Run: `bun test src/commands/plugin-create.test.ts -t "buildConfigFromFlags" && bun run typecheck`
+Expected: all pass, typecheck clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/plugin-create.ts src/commands/plugin-create.test.ts
+git commit -m "feat(plugin-create): buildConfigFromFlags helper with validation"
+```
+
+---
+
+## Task 5: Mode selection in `runPluginCreate`
+
+**Files:**
+- Modify: `src/commands/plugin-create.ts`
+- Test: `src/commands/plugin-create.test.ts`
+
+- [ ] **Step 1: Write failing tests for non-interactive mode**
+
+Append to `src/commands/plugin-create.test.ts` (new describe at end):
+
+```ts
+describe("non-interactive mode", () => {
+  let tmpBase: string;
+  let targetPath: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "kaizen-create-"));
+    targetPath = join(tmpBase, "np");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("runs non-interactively when flags are passed", async () => {
+    const code = await runPluginCreate(targetPath, {
+      flags: { name: "np", tier: "scoped", grants: ["fs"], driver: true },
+    });
+    expect(code).toBe(0);
+    const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+    expect(src).toContain(`name: "np"`);
+    expect(src).toContain(`tier: "scoped"`);
+    expect(src).toContain(`fs:`);
+    expect(src).toContain("driver: true,");
+    expect(src).toContain("async start(ctx)");
+  });
+
+  it("non-interactive with no flags produces defaults-equivalent output", async () => {
+    const code = await runPluginCreate(targetPath, { flags: {} });
+    expect(code).toBe(0);
+    const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+    expect(src).toContain(`name: "np"`);
+    expect(src).toContain(`tier: "trusted"`);
+    expect(src).not.toContain("driver:");
+  });
+
+  it("returns 1 on invalid tier", async () => {
+    const code = await runPluginCreate(targetPath, {
+      flags: { tier: "god-mode" as never },
+    });
+    expect(code).toBe(1);
+    expect(existsSync(targetPath)).toBe(false);
+  });
+
+  it("returns 1 on invalid config-keys JSON", async () => {
+    const code = await runPluginCreate(targetPath, {
+      flags: { configKeysJson: "not json" },
+    });
+    expect(code).toBe(1);
+    expect(existsSync(targetPath)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+Run: `bun test src/commands/plugin-create.test.ts -t "non-interactive mode"`
+Expected: FAIL — the current signature doesn't accept `flags`.
+
+- [ ] **Step 3: Update `runPluginCreate` signature and mode selection**
+
+In `src/commands/plugin-create.ts`, replace the `runPluginCreate` function (around line 386-449) with:
+
+```ts
+export async function runPluginCreate(
+  targetPath: string,
+  opts: { defaults?: boolean; flags?: PluginCreateFlags } = {}
+): Promise<number> {
+  // 1. Check target does not exist
+  if (existsSync(targetPath)) {
+    console.error(`Error: target path already exists: ${targetPath}`);
+    return 1;
+  }
+
+  let cfg: PluginScaffoldConfig;
+
+  if (opts.defaults) {
+    cfg = {
+      name: basename(targetPath),
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: false,
+    };
+  } else if (opts.flags !== undefined) {
+    try {
+      cfg = buildConfigFromFlags(targetPath, opts.flags);
+    } catch (e) {
+      console.error(`Error: ${(e as Error).message}`);
+      return 1;
+    }
+  } else {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    try {
+      cfg = await promptConfig(rl, targetPath);
+    } finally {
+      rl.close();
+    }
+  }
+
+  // Create directory and write files
+  mkdirSync(targetPath, { recursive: true });
+  writeFileSync(join(targetPath, "package.json"), generatePackageJson(cfg));
+  writeFileSync(join(targetPath, "tsconfig.json"), generateTsConfig());
+  writeFileSync(join(targetPath, "index.ts"), generateIndexTs(cfg));
+  writeFileSync(join(targetPath, "index.test.ts"), generateIndexTestTs(cfg));
+  writeFileSync(join(targetPath, "README.md"), generateReadme(cfg));
+  mkdirSync(join(targetPath, ".kaizen"), { recursive: true });
+  writeFileSync(join(targetPath, ".kaizen", ".gitkeep"), "");
+
+  const displayPath = `./${basename(targetPath)}`;
+  console.log(`Created plugin scaffold at ${displayPath}`);
+  console.log(`Next steps:`);
+  console.log(`  cd ${basename(targetPath)}`);
+  console.log(`  bun install`);
+  console.log(`  bun test`);
+  console.log(`  kaizen plugin validate .`);
+
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+Run: `bun test src/commands/plugin-create.test.ts && bun run typecheck`
+Expected: all pass, typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/plugin-create.ts src/commands/plugin-create.test.ts
+git commit -m "feat(plugin-create): non-interactive mode via opts.flags"
+```
+
+---
+
+## Task 6: Wire CLI flags via `parseArgs`
+
+**Files:**
+- Modify: `src/cli.ts`
+- Test: `src/commands/plugin-create.test.ts` (add end-to-end)
+
+- [ ] **Step 1: Add end-to-end test exercising the CLI wiring contract**
+
+We don't spawn the CLI binary in unit tests; instead, verify the behavior we expect the CLI to rely on: `opts.flags = {}` with a non-TTY context produces defaults, and that `--defaults` still works.
+
+The test from Task 5 already covers the programmatic surface. For the CLI layer itself, add a targeted test that constructs the same inputs `cli.ts` would pass after `parseArgs`. Append to `src/commands/plugin-create.test.ts`:
+
+```ts
+describe("cli flag shapes", () => {
+  let tmpBase: string;
+  let targetPath: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "kaizen-create-"));
+    targetPath = join(tmpBase, "svc");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("accepts repeated + comma-separated grants merged", async () => {
+    // Simulating what cli.ts will produce after normalizing
+    // parseArgs output ("--grant fs,net --grant env" becomes ["fs","net","env"])
+    const code = await runPluginCreate(targetPath, {
+      flags: { grants: ["fs", "net", "env"] },
+    });
+    expect(code).toBe(0);
+    const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+    expect(src).toContain("fs:");
+    expect(src).toContain("net:");
+    expect(src).toContain("env:");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, expect PASS (programmatic path already works from Task 5)**
+
+Run: `bun test src/commands/plugin-create.test.ts -t "cli flag shapes"`
+Expected: PASS.
+
+- [ ] **Step 3: Replace CLI branch with `parseArgs`-based wiring**
+
+In `src/cli.ts`, locate the `if (pluginSub === "create")` block (around lines 432-437) and replace with:
+
+```ts
+  if (pluginSub === "create") {
+    const { runPluginCreate } = await import("./commands/plugin-create.js");
+    const { parseArgs } = await import("node:util");
+
+    let parsed: ReturnType<typeof parseArgs>;
+    try {
+      parsed = parseArgs({
+        args: rest,
+        allowPositionals: true,
+        strict: true,
+        options: {
+          name:                { type: "string" },
+          description:         { type: "string" },
+          tier:                { type: "string" },
+          grant:               { type: "string", multiple: true },
+          provides:            { type: "string", multiple: true },
+          consumes:            { type: "string", multiple: true },
+          driver:              { type: "boolean" },
+          "config-keys-json":  { type: "string" },
+          "config-keys-file":  { type: "string" },
+          defaults:            { type: "boolean" },
+        },
+      });
+    } catch (e) {
+      console.error(`error: ${(e as Error).message}`);
+      process.exit(1);
+    }
+
+    const values = parsed.values as Record<string, string | boolean | string[] | undefined>;
+    const targetPath = name ?? ".";
+
+    const splitList = (xs: string[] | undefined): string[] =>
+      (xs ?? []).flatMap((s) => s.split(",").map((x) => x.trim()).filter(Boolean));
+
+    const scaffoldFlagNames = [
+      "name", "description", "tier", "grant", "provides",
+      "consumes", "driver", "config-keys-json", "config-keys-file",
+    ];
+    const anyScaffoldFlag = scaffoldFlagNames.some((k) => values[k] !== undefined);
+
+    if (values.defaults) {
+      const code = await runPluginCreate(targetPath, { defaults: true });
+      process.exit(code);
+    }
+
+    if (!process.stdin.isTTY || anyScaffoldFlag) {
+      const flags = {
+        name: values.name as string | undefined,
+        description: values.description as string | undefined,
+        tier: values.tier as "trusted" | "scoped" | "unscoped" | undefined,
+        grants: splitList(values.grant as string[] | undefined) as Array<
+          "fs" | "net" | "env" | "exec" | "events"
+        >,
+        provides: splitList(values.provides as string[] | undefined),
+        consumes: splitList(values.consumes as string[] | undefined),
+        driver: values.driver as boolean | undefined,
+        configKeysJson: values["config-keys-json"] as string | undefined,
+        configKeysFile: values["config-keys-file"] as string | undefined,
+      };
+      const code = await runPluginCreate(targetPath, { flags });
+      process.exit(code);
+    }
+
+    const code = await runPluginCreate(targetPath, {});
+    process.exit(code);
+  }
+```
+
+- [ ] **Step 4: Smoke-test non-interactive via the built binary**
+
+Run:
+```bash
+rm -rf /tmp/kc-smoke
+bun run bin/kaizen plugin create /tmp/kc-smoke \
+  --name kc-smoke --tier scoped --grant fs,net --driver
+cat /tmp/kc-smoke/index.ts | grep -E "name:|tier:|fs:|net:|driver:|start\(ctx\)"
+```
+
+Expected output includes:
+```
+  name: "kc-smoke",
+    tier: "scoped",
+    fs: ["*"],
+    net: ["*"],
+  driver: true,
+  async start(ctx) {
+```
+
+Cleanup: `rm -rf /tmp/kc-smoke`
+
+- [ ] **Step 5: Smoke-test `--defaults` still works**
+
+Run:
+```bash
+rm -rf /tmp/kc-def
+bun run bin/kaizen plugin create /tmp/kc-def --defaults
+test -f /tmp/kc-def/index.ts && echo OK
+rm -rf /tmp/kc-def
+```
+Expected: `OK`.
+
+- [ ] **Step 6: Smoke-test unknown flag rejection**
+
+Run:
+```bash
+bun run bin/kaizen plugin create /tmp/kc-reject --bogus 2>&1 | head -2
+test ! -d /tmp/kc-reject && echo OK
+```
+Expected: error message from parseArgs; directory not created; `OK` printed.
+
+- [ ] **Step 7: Full typecheck + test suite**
+
+Run: `bun run typecheck && bun test`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cli.ts src/commands/plugin-create.test.ts
+git commit -m "feat(plugin-create): parse CLI flags via parseArgs (#38, #41)"
+```
+
+---
+
+## Task 7: Docs update
+
+**Files:**
+- Modify: `docs/guides/plugin-authoring.md`
+
+- [ ] **Step 1: Update the Scaffold section**
+
+In `docs/guides/plugin-authoring.md`, locate the `## Scaffold` section (around lines 25-62). Replace the block starting with "Add `--defaults` to skip prompts..." and ending just before "The generator writes:" with:
+
+```markdown
+Add `--defaults` to skip prompts and scaffold a minimal `trusted` plugin:
+
+```sh
+kaizen plugin create ./my-plugin --defaults
+```
+
+Every prompt also has a corresponding flag, so the command can run fully
+non-interactively (for agents, CI, or bulk scaffolding). When stdin is not a
+TTY, or any scaffold flag is passed, prompts are skipped entirely and unset
+fields fall back to defaults:
+
+```sh
+kaizen plugin create ./my-plugin \
+  --name my-plugin \
+  --description "does a thing" \
+  --tier scoped \
+  --grant fs,net \
+  --provides my-plugin:api \
+  --driver
+```
+
+Flags:
+
+| Flag                   | Purpose                                                    |
+|------------------------|------------------------------------------------------------|
+| `--name`               | Plugin name (default: basename of target path)             |
+| `--description`        | Description text                                           |
+| `--tier`               | `trusted` \| `scoped` \| `unscoped` (default `trusted`)     |
+| `--grant`              | One or more of `fs,net,env,exec,events`. Repeatable and/or comma-separated. |
+| `--provides`           | Service name; repeatable and/or comma-separated.           |
+| `--consumes`           | Service name; repeatable and/or comma-separated.           |
+| `--driver`             | Scaffold a session driver (adds `driver:true` and a `start(ctx)` stub). |
+| `--config-keys-json`   | Inline JSON array of ConfigKey objects.                    |
+| `--config-keys-file`   | Path to a JSON file with a ConfigKey array.                |
+| `--defaults`           | Use defaults for all fields; skip prompts.                 |
+
+ConfigKey shape (applies to both `--config-keys-json` and `--config-keys-file`):
+
+```json
+[
+  { "name": "api_key", "type": "string", "required": true,  "secret": true },
+  { "name": "port",    "type": "number", "required": false, "secret": false }
+]
+```
+
+`type` must be `string` or `number`. Kaizen validates this structure but does
+not validate the semantic correctness of the resulting config schema — that is
+the plugin author's responsibility.
+```
+
+- [ ] **Step 2: Verify docs render**
+
+Run: `grep -A2 "non-interactively" docs/guides/plugin-authoring.md`
+Expected: the new block is present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/guides/plugin-authoring.md
+git commit -m "docs(plugin-authoring): non-interactive scaffold flags"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `bun test`
+Expected: all tests pass; no new failures.
+
+- [ ] **Step 3: Inspect commit log**
+
+Run: `git log --oneline master..HEAD`
+Expected: commits from tasks 1-7 plus the spec commit.
+
+- [ ] **Step 4: Run `kaizen:update-docs` skill**
+
+Per project CLAUDE.md, before invoking `superpowers:finishing-a-development-branch`, run `kaizen:update-docs`.
+
+Run: `/kaizen:update-docs` (or invoke the skill via the Skill tool).
+Follow its output; it may propose additional doc edits to commit.
+
+- [ ] **Step 5: Push branch**
+
+```bash
+git push -u origin feat/plugin-create-non-interactive-38
+```
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "feat: non-interactive flags for plugin create (#38, #41)" --body "$(cat <<'EOF'
+## Summary
+- Every scaffold input for \`kaizen plugin create\` is now settable via CLI flag
+- Auto-detect non-interactive environments (non-TTY or any flag → no prompts)
+- Add first-class support for scaffolding session drivers (\`--driver\`, interactive prompt, generator stubs)
+
+Closes #38. Closes #41.
+
+Spec: \`docs/superpowers/specs/2026-04-23-plugin-create-non-interactive-design.md\`
+
+## Test plan
+- [x] \`bun run typecheck\`
+- [x] \`bun test\` (new tests for buildConfigFromFlags, non-interactive mode, generator driver support)
+- [x] Smoke: \`kaizen plugin create /tmp/x --name x --tier scoped --grant fs,net --driver\` → generates driver+start
+- [x] Smoke: \`kaizen plugin create /tmp/y --defaults\` still works
+- [x] Smoke: unknown flag rejected with error
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-23-plugin-create-non-interactive-design.md
+++ b/docs/superpowers/specs/2026-04-23-plugin-create-non-interactive-design.md
@@ -1,0 +1,280 @@
+# Non-interactive flags for `kaizen plugin create`
+
+**Status:** approved
+**Date:** 2026-04-23
+**Closes:** #38, #41
+
+## Problem
+
+`kaizen plugin create <path>` is interactive-only (readline prompts in
+`src/commands/plugin-create.ts`). That blocks scripted scaffolding (agents, CI,
+bulk plugin generation), reproducible harness bootstrapping, and onboarding
+scripts that want to create N plugins in one shot. The `--defaults` flag skips
+prompts but gives no control over fields — you get a minimal trusted plugin or
+you get prompts.
+
+The scaffolder also omits the `driver` field entirely. Authors building a
+session driver must scaffold, then hand-edit `index.ts` to add `driver: true`
+and a `start(ctx)` method. Easy to miss; not surfaced anywhere.
+
+## Goals
+
+- Make every scaffold input settable via CLI flag.
+- Auto-detect non-interactive environments (no TTY) and skip prompts.
+- Preserve the current interactive flow when run from a terminal with no flags.
+- Preserve `--defaults` back-compat.
+- Add `driver` to the scaffold (interactive prompt + flag + generator support).
+
+## Non-goals
+
+- Rewriting the CLI arg-parsing layer for other commands.
+- Adding a third-party arg-parsing dependency.
+- Validating the user's config schema shape beyond the `ConfigKey` structure.
+- Adding a `--yes` / `--non-interactive` mode flag (superseded by auto-detect).
+
+## Mode selection
+
+No new mode flag. The command picks a mode automatically:
+
+| Condition                                     | Mode            |
+|-----------------------------------------------|-----------------|
+| `--defaults` passed                           | defaults        |
+| `process.stdin.isTTY === true` AND no scaffold flags passed | interactive     |
+| otherwise                                     | non-interactive |
+
+"Scaffold flags" means any of: `--name`, `--description`, `--tier`, `--grant`,
+`--provides`, `--consumes`, `--driver`, `--config-keys-json`,
+`--config-keys-file`.
+
+In non-interactive mode, unset fields take the same defaults as `--defaults`
+mode (name = basename of path, tier = trusted, empty grants / provides /
+consumes, no config, driver = false). No field is strictly required; the
+command cannot fail due to missing input. It can fail due to *invalid* input —
+see Validation below.
+
+## Flag surface
+
+```
+kaizen plugin create <path> [flags]
+
+  --name <kebab>                  Plugin name (default: basename of path)
+  --description <string>          Description text
+  --tier trusted|scoped|unscoped  Permission tier (default: trusted)
+  --grant <list>                  Grants; repeatable and/or comma-separated.
+                                  Valid: fs, net, env, exec, events
+  --provides <svc>                Service provided; repeatable and/or comma-separated
+  --consumes <svc>                Service consumed; repeatable and/or comma-separated
+  --driver                        Scaffold as a session driver
+  --config-keys-json <string>     Inline JSON array of ConfigKey objects
+  --config-keys-file <path>       Path to JSON file containing a ConfigKey array
+  --defaults                      Use all defaults; skip prompts (existing)
+```
+
+- `--grant`, `--provides`, `--consumes` are repeatable. Each occurrence may
+  also be a comma-separated list. Implementation: `flags.flatMap(s =>
+  s.split(",").map(x => x.trim()).filter(Boolean))`.
+- `--config-keys-json` and `--config-keys-file` are mutually exclusive;
+  passing both is a usage error (exit 1).
+- Providing either config-keys flag implicitly sets `hasConfig: true`.
+
+## Config keys JSON shape
+
+Both `--config-keys-json` (inline) and `--config-keys-file` (path) accept the
+same format: a JSON array of `ConfigKey` objects.
+
+```json
+[
+  { "name": "api_key", "type": "string", "required": true,  "secret": true },
+  { "name": "port",    "type": "number", "required": false, "secret": false }
+]
+```
+
+Each entry MUST be an object with:
+
+- `name`: non-empty string
+- `type`: `"string"` or `"number"`
+- `required`: boolean
+- `secret`: boolean
+
+Kaizen validates this shape and rejects malformed input with a clear error
+naming the offending entry. Kaizen does not validate the semantics of the
+user's config schema beyond this structural check — the user (or CI system)
+is responsible for supplying a correct shape.
+
+## Validation
+
+Non-interactive input is validated before any files are written:
+
+- `--tier` must be one of `trusted`, `scoped`, `unscoped`.
+- `--grant` values must each be one of `fs`, `net`, `env`, `exec`, `events`.
+- `--config-keys-json` must parse as JSON.
+- `--config-keys-file` must exist and contain parseable JSON.
+- Parsed config-keys input must be an array of objects matching the shape
+  above.
+- `--config-keys-json` and `--config-keys-file` must not both be passed.
+
+Any failure prints a targeted error to stderr and exits 1. The existing
+"target path already exists" check remains the first gate.
+
+## Implementation
+
+### Arg parsing
+
+Use `node:util`'s `parseArgs` (available in Bun and Node; zero new deps).
+The parsing lives in `src/cli.ts`, in the `plugin create` branch, and produces
+a typed `CliFlags` object passed to `runPluginCreate`.
+
+```ts
+import { parseArgs } from "node:util";
+
+const { values, positionals } = parseArgs({
+  args: rest,
+  allowPositionals: true,
+  strict: true,
+  options: {
+    name:              { type: "string" },
+    description:       { type: "string" },
+    tier:              { type: "string" },
+    grant:             { type: "string", multiple: true },
+    provides:          { type: "string", multiple: true },
+    consumes:          { type: "string", multiple: true },
+    driver:            { type: "boolean" },
+    "config-keys-json":{ type: "string" },
+    "config-keys-file":{ type: "string" },
+    defaults:          { type: "boolean" },
+  },
+});
+```
+
+### Entry-point changes
+
+`runPluginCreate(targetPath, opts)` grows a richer opts type:
+
+```ts
+interface PluginCreateOpts {
+  defaults?: boolean;
+  flags?: Partial<{
+    name: string;
+    description: string;
+    tier: "trusted" | "scoped" | "unscoped";
+    grants: Array<"fs" | "net" | "env" | "exec" | "events">;
+    provides: string[];
+    consumes: string[];
+    driver: boolean;
+    configKeysJson: string;
+    configKeysFile: string;
+  }>;
+}
+```
+
+### Data model
+
+`PluginScaffoldConfig` gains a `driver: boolean` field:
+
+```ts
+export interface PluginScaffoldConfig {
+  name: string;
+  description: string;
+  tier: "trusted" | "scoped" | "unscoped";
+  grants: Array<"fs" | "net" | "env" | "exec" | "events">;
+  provides: string[];
+  consumes: string[];
+  hasConfig: boolean;
+  configKeys: ConfigKey[];
+  driver: boolean;          // new
+}
+```
+
+All existing default-builders (the `--defaults` path in `runPluginCreate`)
+initialise `driver: false`.
+
+### Flow
+
+1. `cli.ts` parses flags into `CliFlags`; builds `opts` for `runPluginCreate`.
+2. `runPluginCreate` selects mode (defaults / interactive / non-interactive)
+   per the table above.
+3. For non-interactive mode: `buildConfigFromFlags(targetPath, opts.flags)`
+   produces a validated `PluginScaffoldConfig`, or exits 1 with an error.
+4. The rest of the flow (mkdir, write files, print success) is unchanged.
+
+### Generator changes
+
+`generateIndexTs(cfg)`:
+
+- When `cfg.driver === true`, emit `driver: true,` in the manifest object.
+- When `cfg.driver === true`, append a `start(ctx)` method after `setup`:
+  ```ts
+  async start(ctx) {
+    // TODO: implement session loop
+    ctx.log("driver started");
+  },
+  ```
+
+`generateIndexTestTs(cfg)`:
+
+- When `cfg.driver === true`, add an assertion:
+  ```ts
+  it("declares driver: true", () => {
+    expect(plugin.driver).toBe(true);
+  });
+  ```
+
+### Interactive prompt
+
+`promptConfig` gains one question, after `consumes` and before the config
+question:
+
+```
+Is this a session driver? (y/N) [N]:
+```
+
+`y` → `driver: true`; anything else → `false`.
+
+## Tests
+
+Added to `src/commands/plugin-create.test.ts`:
+
+- `buildConfigFromFlags` builds the expected `PluginScaffoldConfig` from a
+  full flag set.
+- Comma-separated and repeated `--grant` produce identical results.
+- Invalid `--tier` → error, non-zero exit.
+- Invalid `--grant` value → error, non-zero exit.
+- `--config-keys-json` with valid JSON → `hasConfig: true`, configKeys parsed.
+- `--config-keys-json` with invalid JSON → error, non-zero exit.
+- `--config-keys-file` with valid file → same result as equivalent inline JSON.
+- Both `--config-keys-json` and `--config-keys-file` passed → error.
+- `--driver` → generated `index.ts` includes `driver: true` and a `start`
+  method; generated test asserts `plugin.driver === true`.
+- Non-interactive path with zero flags and non-TTY stdin produces the same
+  output as `--defaults`.
+- `--defaults` path still works (back-compat).
+
+Interactive-flow tests remain unchanged; the prompt additions for `driver`
+are covered by a unit test of `promptConfig` if one exists (today the
+interactive path is not covered; we do not add coverage for it here).
+
+## Docs
+
+Updated:
+
+- `docs/guides/plugin-authoring.md` — scaffold section adds a non-interactive
+  example (agent/CI invocation with full flags) and notes the auto-detect
+  behavior.
+- `docs/reference/plugin-standards.md` (if it documents `kaizen plugin create`
+  surface) — reflect new flags.
+
+## Files touched
+
+- `src/commands/plugin-create.ts` — `PluginScaffoldConfig.driver`, generator
+  updates, interactive driver prompt, `buildConfigFromFlags()`,
+  mode-selection logic.
+- `src/cli.ts` — `parseArgs` for the `plugin create` subcommand.
+- `src/commands/plugin-create.test.ts` — new tests listed above.
+- `docs/guides/plugin-authoring.md` — document non-interactive usage.
+
+## Rollout
+
+- No breaking changes. Existing interactive flow, `--defaults` flag, and
+  generator output for non-driver plugins are unchanged.
+- Existing callers of `runPluginCreate({ defaults: true })` continue to work;
+  the new `flags` field is optional.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -431,8 +431,72 @@ if (subcommand === "plugin") {
 
   if (pluginSub === "create") {
     const { runPluginCreate } = await import("./commands/plugin-create.js");
+    const { parseArgs } = await import("node:util");
+
+    let parsed: ReturnType<typeof parseArgs>;
+    try {
+      parsed = parseArgs({
+        args: rest,
+        allowPositionals: true,
+        strict: true,
+        options: {
+          name:                { type: "string" },
+          description:         { type: "string" },
+          tier:                { type: "string" },
+          grant:               { type: "string", multiple: true },
+          provides:            { type: "string", multiple: true },
+          consumes:            { type: "string", multiple: true },
+          driver:              { type: "boolean" },
+          "config-keys-json":  { type: "string" },
+          "config-keys-file":  { type: "string" },
+          defaults:            { type: "boolean" },
+        },
+      });
+    } catch (e) {
+      console.error(`error: ${(e as Error).message}`);
+      process.exit(1);
+    }
+
+    const values = parsed.values as Record<string, string | boolean | string[] | undefined>;
     const targetPath = name ?? ".";
-    const code = await runPluginCreate(targetPath, { defaults: rest.includes("--defaults") });
+
+    const splitList = (xs: string[] | undefined): string[] =>
+      (xs ?? []).flatMap((s) => s.split(",").map((x) => x.trim()).filter(Boolean));
+
+    const scaffoldFlagNames = [
+      "name", "description", "tier", "grant", "provides",
+      "consumes", "driver", "config-keys-json", "config-keys-file",
+    ];
+    const anyScaffoldFlag = scaffoldFlagNames.some((k) => values[k] !== undefined);
+
+    if (values.defaults) {
+      const code = await runPluginCreate(targetPath, { defaults: true });
+      process.exit(code);
+    }
+
+    if (!process.stdin.isTTY || anyScaffoldFlag) {
+      const flags: import("./commands/plugin-create.js").PluginCreateFlags = {
+        ...(values.name !== undefined ? { name: values.name as string } : {}),
+        ...(values.description !== undefined ? { description: values.description as string } : {}),
+        ...(values.tier !== undefined ? { tier: values.tier as "trusted" | "scoped" | "unscoped" } : {}),
+        ...(splitList(values.grant as string[] | undefined).length > 0
+          ? { grants: splitList(values.grant as string[] | undefined) as Array<"fs" | "net" | "env" | "exec" | "events"> }
+          : {}),
+        ...(splitList(values.provides as string[] | undefined).length > 0
+          ? { provides: splitList(values.provides as string[] | undefined) }
+          : {}),
+        ...(splitList(values.consumes as string[] | undefined).length > 0
+          ? { consumes: splitList(values.consumes as string[] | undefined) }
+          : {}),
+        ...(values.driver !== undefined ? { driver: values.driver as boolean } : {}),
+        ...(values["config-keys-json"] !== undefined ? { configKeysJson: values["config-keys-json"] as string } : {}),
+        ...(values["config-keys-file"] !== undefined ? { configKeysFile: values["config-keys-file"] as string } : {}),
+      };
+      const code = await runPluginCreate(targetPath, { flags });
+      process.exit(code);
+    }
+
+    const code = await runPluginCreate(targetPath, {});
     process.exit(code);
   }
 

--- a/src/commands/plugin-create.test.ts
+++ b/src/commands/plugin-create.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, existsSync, readFileSync, rmSync } from "fs";
+import { mkdtempSync, existsSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { runPluginCreate } from "./plugin-create.js";
@@ -171,5 +171,116 @@ describe("driver generator", () => {
     expect(generateIndexTs(cfg)).not.toContain("driver:");
     expect(generateIndexTs(cfg)).not.toContain("async start(ctx)");
     expect(generateIndexTestTs(cfg)).not.toContain("plugin.driver");
+  });
+});
+
+describe("buildConfigFromFlags", () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "kaizen-create-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("fills defaults for unset flags", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const cfg = buildConfigFromFlags("/tmp/some-path/my-plug", {});
+    expect(cfg).toEqual({
+      name: "my-plug",
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: false,
+    });
+  });
+
+  it("applies all flags", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const cfg = buildConfigFromFlags("/tmp/x/plug", {
+      name: "custom-name",
+      description: "desc",
+      tier: "scoped",
+      grants: ["fs", "net"],
+      provides: ["svc:a"],
+      consumes: ["svc:b"],
+      driver: true,
+    });
+    expect(cfg.name).toBe("custom-name");
+    expect(cfg.description).toBe("desc");
+    expect(cfg.tier).toBe("scoped");
+    expect(cfg.grants).toEqual(["fs", "net"]);
+    expect(cfg.provides).toEqual(["svc:a"]);
+    expect(cfg.consumes).toEqual(["svc:b"]);
+    expect(cfg.driver).toBe(true);
+  });
+
+  it("rejects invalid tier", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    expect(() => buildConfigFromFlags("/tmp/p", { tier: "god-mode" as never }))
+      .toThrow(/tier/);
+  });
+
+  it("rejects invalid grant", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    expect(() => buildConfigFromFlags("/tmp/p", { grants: ["bogus" as never] }))
+      .toThrow(/grant/);
+  });
+
+  it("parses --config-keys-json inline", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const json = JSON.stringify([
+      { name: "api_key", type: "string", required: true, secret: true },
+    ]);
+    const cfg = buildConfigFromFlags("/tmp/p", { configKeysJson: json });
+    expect(cfg.hasConfig).toBe(true);
+    expect(cfg.configKeys).toEqual([
+      { name: "api_key", type: "string", required: true, secret: true },
+    ]);
+  });
+
+  it("parses --config-keys-file", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const file = join(tmpBase, "keys.json");
+    writeFileSync(file, JSON.stringify([
+      { name: "port", type: "number", required: false, secret: false },
+    ]));
+    const cfg = buildConfigFromFlags("/tmp/p", { configKeysFile: file });
+    expect(cfg.hasConfig).toBe(true);
+    expect(cfg.configKeys[0]?.name).toBe("port");
+  });
+
+  it("rejects both --config-keys-json and --config-keys-file", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    expect(() => buildConfigFromFlags("/tmp/p", {
+      configKeysJson: "[]",
+      configKeysFile: "/tmp/x.json",
+    })).toThrow(/mutually exclusive/);
+  });
+
+  it("rejects malformed config-keys JSON (not array)", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    expect(() => buildConfigFromFlags("/tmp/p", { configKeysJson: "{}" }))
+      .toThrow(/array/);
+  });
+
+  it("rejects malformed config-keys entry (missing name)", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const json = JSON.stringify([{ type: "string", required: false, secret: false }]);
+    expect(() => buildConfigFromFlags("/tmp/p", { configKeysJson: json }))
+      .toThrow(/name/);
+  });
+
+  it("rejects malformed config-keys entry (bad type)", async () => {
+    const { buildConfigFromFlags } = await import("./plugin-create.js");
+    const json = JSON.stringify([{ name: "x", type: "enum", required: false, secret: false }]);
+    expect(() => buildConfigFromFlags("/tmp/p", { configKeysJson: json }))
+      .toThrow(/type/);
   });
 });

--- a/src/commands/plugin-create.test.ts
+++ b/src/commands/plugin-create.test.ts
@@ -336,3 +336,30 @@ describe("non-interactive mode", () => {
     expect(existsSync(targetPath)).toBe(false);
   });
 });
+
+describe("cli flag shapes", () => {
+  let tmpBase: string;
+  let targetPath: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "kaizen-create-"));
+    targetPath = join(tmpBase, "svc");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("accepts repeated + comma-separated grants merged", async () => {
+    // Simulating what cli.ts will produce after normalizing
+    // parseArgs output ("--grant fs,net --grant env" becomes ["fs","net","env"])
+    const code = await runPluginCreate(targetPath, {
+      flags: { grants: ["fs", "net", "env"] },
+    });
+    expect(code).toBe(0);
+    const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+    expect(src).toContain("fs:");
+    expect(src).toContain("net:");
+    expect(src).toContain("env:");
+  });
+});

--- a/src/commands/plugin-create.test.ts
+++ b/src/commands/plugin-create.test.ts
@@ -80,6 +80,13 @@ describe("runPluginCreate", () => {
       expect(readme).toContain("Installation");
     });
 
+    it("defaults do not produce a driver manifest", async () => {
+      await runPluginCreate(targetPath, { defaults: true });
+      const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+      expect(src).not.toContain("driver: true");
+      expect(src).not.toContain("async start(ctx)");
+    });
+
     it("uses basename of targetPath as name", async () => {
       const nestedTarget = join(tmpBase, "nested", "my-nested-plugin");
       const code = await runPluginCreate(nestedTarget, { defaults: true });

--- a/src/commands/plugin-create.test.ts
+++ b/src/commands/plugin-create.test.ts
@@ -107,3 +107,69 @@ describe("runPluginCreate", () => {
     });
   });
 });
+
+describe("driver generator", () => {
+  let tmpBase: string;
+  let targetPath: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "kaizen-create-"));
+    targetPath = join(tmpBase, "my-driver");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("emits driver: true and start(ctx) in index.ts when driver flag is set", async () => {
+    const { generateIndexTs } = await import("./plugin-create.js");
+    const src = generateIndexTs({
+      name: "my-driver",
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: true,
+    });
+    expect(src).toContain("driver: true,");
+    expect(src).toContain("async start(ctx)");
+    expect(src).toContain(`ctx.log("driver started")`);
+  });
+
+  it("generated test asserts driver: true when driver flag is set", async () => {
+    const { generateIndexTestTs } = await import("./plugin-create.js");
+    const src = generateIndexTestTs({
+      name: "my-driver",
+      description: "",
+      tier: "trusted",
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: true,
+    });
+    expect(src).toContain(`expect(plugin.driver).toBe(true)`);
+  });
+
+  it("non-driver generation is unchanged", async () => {
+    const { generateIndexTs, generateIndexTestTs } = await import("./plugin-create.js");
+    const cfg = {
+      name: "p",
+      description: "",
+      tier: "trusted" as const,
+      grants: [],
+      provides: [],
+      consumes: [],
+      hasConfig: false,
+      configKeys: [],
+      driver: false,
+    };
+    expect(generateIndexTs(cfg)).not.toContain("driver:");
+    expect(generateIndexTs(cfg)).not.toContain("async start(ctx)");
+    expect(generateIndexTestTs(cfg)).not.toContain("plugin.driver");
+  });
+});

--- a/src/commands/plugin-create.test.ts
+++ b/src/commands/plugin-create.test.ts
@@ -284,3 +284,55 @@ describe("buildConfigFromFlags", () => {
       .toThrow(/type/);
   });
 });
+
+describe("non-interactive mode", () => {
+  let tmpBase: string;
+  let targetPath: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "kaizen-create-"));
+    targetPath = join(tmpBase, "np");
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("runs non-interactively when flags are passed", async () => {
+    const code = await runPluginCreate(targetPath, {
+      flags: { name: "np", tier: "scoped", grants: ["fs"], driver: true },
+    });
+    expect(code).toBe(0);
+    const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+    expect(src).toContain(`name: "np"`);
+    expect(src).toContain(`tier: "scoped"`);
+    expect(src).toContain(`fs:`);
+    expect(src).toContain("driver: true,");
+    expect(src).toContain("async start(ctx)");
+  });
+
+  it("non-interactive with no flags produces defaults-equivalent output", async () => {
+    const code = await runPluginCreate(targetPath, { flags: {} });
+    expect(code).toBe(0);
+    const src = readFileSync(join(targetPath, "index.ts"), "utf8");
+    expect(src).toContain(`name: "np"`);
+    expect(src).toContain(`tier: "trusted"`);
+    expect(src).not.toContain("driver:");
+  });
+
+  it("returns 1 on invalid tier", async () => {
+    const code = await runPluginCreate(targetPath, {
+      flags: { tier: "god-mode" as never },
+    });
+    expect(code).toBe(1);
+    expect(existsSync(targetPath)).toBe(false);
+  });
+
+  it("returns 1 on invalid config-keys JSON", async () => {
+    const code = await runPluginCreate(targetPath, {
+      flags: { configKeysJson: "not json" },
+    });
+    expect(code).toBe(1);
+    expect(existsSync(targetPath)).toBe(false);
+  });
+});

--- a/src/commands/plugin-create.ts
+++ b/src/commands/plugin-create.ts
@@ -519,7 +519,7 @@ function validateConfigKey(entry: unknown, index: number): ConfigKey {
 
 export async function runPluginCreate(
   targetPath: string,
-  opts: { defaults?: boolean }
+  opts: { defaults?: boolean; flags?: PluginCreateFlags } = {}
 ): Promise<number> {
   // 1. Check target does not exist
   if (existsSync(targetPath)) {
@@ -530,7 +530,6 @@ export async function runPluginCreate(
   let cfg: PluginScaffoldConfig;
 
   if (opts.defaults) {
-    // 2. Defaults mode
     cfg = {
       name: basename(targetPath),
       description: "",
@@ -542,8 +541,14 @@ export async function runPluginCreate(
       configKeys: [],
       driver: false,
     };
+  } else if (opts.flags !== undefined) {
+    try {
+      cfg = buildConfigFromFlags(targetPath, opts.flags);
+    } catch (e) {
+      console.error(`Error: ${(e as Error).message}`);
+      return 1;
+    }
   } else {
-    // 3. Interactive mode
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
@@ -555,23 +560,16 @@ export async function runPluginCreate(
     }
   }
 
-  // 4. Create directory
+  // Create directory and write files
   mkdirSync(targetPath, { recursive: true });
-
-  // 5. Write files
   writeFileSync(join(targetPath, "package.json"), generatePackageJson(cfg));
   writeFileSync(join(targetPath, "tsconfig.json"), generateTsConfig());
   writeFileSync(join(targetPath, "index.ts"), generateIndexTs(cfg));
   writeFileSync(join(targetPath, "index.test.ts"), generateIndexTestTs(cfg));
   writeFileSync(join(targetPath, "README.md"), generateReadme(cfg));
-
-  // 6. Create .kaizen dir
   mkdirSync(join(targetPath, ".kaizen"), { recursive: true });
-
-  // 7. Write .gitkeep
   writeFileSync(join(targetPath, ".kaizen", ".gitkeep"), "");
 
-  // 8. Print success message
   const displayPath = `./${basename(targetPath)}`;
   console.log(`Created plugin scaffold at ${displayPath}`);
   console.log(`Next steps:`);

--- a/src/commands/plugin-create.ts
+++ b/src/commands/plugin-create.ts
@@ -385,6 +385,9 @@ async function promptConfig(rl: readline.Interface, targetPath: string): Promise
   const consumesInput = await prompt(rl, `Services consumed (comma-separated) [none]: `);
   const consumes = consumesInput ? consumesInput.split(",").map((s) => s.trim()).filter(Boolean) : [];
 
+  const driverInput = await prompt(rl, `Is this a session driver? (y/N) [N]: `);
+  const driver = driverInput.toLowerCase() === "y";
+
   const hasConfigInput = await prompt(rl, `Does this plugin have config? (y/N) [N]: `);
   const hasConfig = hasConfigInput.toLowerCase() === "y";
 
@@ -405,7 +408,7 @@ async function promptConfig(rl: readline.Interface, targetPath: string): Promise
     }
   }
 
-  return { name, description, tier, grants, provides, consumes, hasConfig, configKeys, driver: false };
+  return { name, description, tier, grants, provides, consumes, hasConfig, configKeys, driver };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/plugin-create.ts
+++ b/src/commands/plugin-create.ts
@@ -148,13 +148,20 @@ export function generateIndexTs(cfg: PluginScaffoldConfig): string {
     `const plugin: KaizenPlugin = {`,
     `  name: "${cfg.name}",`,
     `  apiVersion: "2.0.0",`,
+  ];
+
+  if (cfg.driver) {
+    lines.push(`  driver: true,`);
+  }
+
+  lines.push(
     `  permissions: {`,
     ...permissionsLines,
     `  },`,
     `  services: {`,
     ...capsLines,
     `  },`,
-  ];
+  );
 
   if (configBlock) {
     lines.push(configBlock);
@@ -165,6 +172,19 @@ export function generateIndexTs(cfg: PluginScaffoldConfig): string {
     `  async setup(ctx) {`,
     ...setupLines,
     `  },`,
+  );
+
+  if (cfg.driver) {
+    lines.push(
+      ``,
+      `  async start(ctx) {`,
+      `    // TODO: implement session loop`,
+      `    ctx.log("driver started");`,
+      `  },`,
+    );
+  }
+
+  lines.push(
     `};`,
     ``,
     `export default plugin;`,
@@ -231,6 +251,14 @@ export function generateIndexTestTs(cfg: PluginScaffoldConfig): string {
     `    expect(plugin.apiVersion).toBe("2.0.0");`,
     `  });`,
     ``,
+    ...(cfg.driver
+      ? [
+          `  it("declares driver: true", () => {`,
+          `    expect(plugin.driver).toBe(true);`,
+          `  });`,
+          ``,
+        ]
+      : []),
     `  it("setup runs without error", async () => {`,
     `    const ctx = makeCtx();`,
     `    await plugin.setup(ctx);`,

--- a/src/commands/plugin-create.ts
+++ b/src/commands/plugin-create.ts
@@ -22,6 +22,7 @@ export interface PluginScaffoldConfig {
   consumes: string[];
   hasConfig: boolean;
   configKeys: ConfigKey[];
+  driver: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -376,7 +377,7 @@ async function promptConfig(rl: readline.Interface, targetPath: string): Promise
     }
   }
 
-  return { name, description, tier, grants, provides, consumes, hasConfig, configKeys };
+  return { name, description, tier, grants, provides, consumes, hasConfig, configKeys, driver: false };
 }
 
 // ---------------------------------------------------------------------------
@@ -406,6 +407,7 @@ export async function runPluginCreate(
       consumes: [],
       hasConfig: false,
       configKeys: [],
+      driver: false,
     };
   } else {
     // 3. Interactive mode

--- a/src/commands/plugin-create.ts
+++ b/src/commands/plugin-create.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join, basename } from "path";
 import * as readline from "readline";
 
@@ -23,6 +23,18 @@ export interface PluginScaffoldConfig {
   hasConfig: boolean;
   configKeys: ConfigKey[];
   driver: boolean;
+}
+
+export interface PluginCreateFlags {
+  name?: string;
+  description?: string;
+  tier?: "trusted" | "scoped" | "unscoped";
+  grants?: Array<"fs" | "net" | "env" | "exec" | "events">;
+  provides?: string[];
+  consumes?: string[];
+  driver?: boolean;
+  configKeysJson?: string;
+  configKeysFile?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -409,6 +421,96 @@ async function promptConfig(rl: readline.Interface, targetPath: string): Promise
   }
 
   return { name, description, tier, grants, provides, consumes, hasConfig, configKeys, driver };
+}
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// buildConfigFromFlags
+// ---------------------------------------------------------------------------
+
+const VALID_TIERS = ["trusted", "scoped", "unscoped"] as const;
+const VALID_GRANTS = ["fs", "net", "env", "exec", "events"] as const;
+const VALID_CONFIG_TYPES = ["string", "number"] as const;
+
+export function buildConfigFromFlags(
+  targetPath: string,
+  flags: PluginCreateFlags
+): PluginScaffoldConfig {
+  if (flags.tier && !VALID_TIERS.includes(flags.tier)) {
+    throw new Error(
+      `Invalid --tier "${flags.tier}"; must be one of ${VALID_TIERS.join(", ")}`
+    );
+  }
+
+  if (flags.grants) {
+    for (const g of flags.grants) {
+      if (!VALID_GRANTS.includes(g)) {
+        throw new Error(
+          `Invalid --grant "${g}"; must be one of ${VALID_GRANTS.join(", ")}`
+        );
+      }
+    }
+  }
+
+  if (flags.configKeysJson && flags.configKeysFile) {
+    throw new Error(
+      "--config-keys-json and --config-keys-file are mutually exclusive"
+    );
+  }
+
+  let configKeys: ConfigKey[] = [];
+  let hasConfig = false;
+  const rawJson =
+    flags.configKeysJson
+      ?? (flags.configKeysFile ? readFileSync(flags.configKeysFile, "utf8") : undefined);
+
+  if (rawJson !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawJson);
+    } catch (e) {
+      throw new Error(`config keys input is not valid JSON: ${String(e)}`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error("config keys input must be a JSON array");
+    }
+    configKeys = parsed.map((entry, i) => validateConfigKey(entry, i));
+    hasConfig = true;
+  }
+
+  return {
+    name: flags.name ?? basename(targetPath),
+    description: flags.description ?? "",
+    tier: flags.tier ?? "trusted",
+    grants: flags.grants ?? [],
+    provides: flags.provides ?? [],
+    consumes: flags.consumes ?? [],
+    hasConfig,
+    configKeys,
+    driver: flags.driver ?? false,
+  };
+}
+
+function validateConfigKey(entry: unknown, index: number): ConfigKey {
+  if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+    throw new Error(`config keys[${index}] must be an object`);
+  }
+  const e = entry as Record<string, unknown>;
+  if (typeof e.name !== "string" || e.name.length === 0) {
+    throw new Error(`config keys[${index}] missing required string "name"`);
+  }
+  if (typeof e.type !== "string" || !VALID_CONFIG_TYPES.includes(e.type as never)) {
+    throw new Error(
+      `config keys[${index}].type must be one of ${VALID_CONFIG_TYPES.join(", ")}`
+    );
+  }
+  if (typeof e.required !== "boolean") {
+    throw new Error(`config keys[${index}].required must be a boolean`);
+  }
+  if (typeof e.secret !== "boolean") {
+    throw new Error(`config keys[${index}].secret must be a boolean`);
+  }
+  return { name: e.name, type: e.type, required: e.required, secret: e.secret };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Every scaffold input for `kaizen plugin create` is now settable via CLI flag (`--name`, `--description`, `--tier`, `--grant`, `--provides`, `--consumes`, `--driver`, `--config-keys-json`, `--config-keys-file`).
- Auto-detects non-interactive environments: if stdin is not a TTY, or any scaffold flag is passed, prompts are skipped entirely. No new `--yes`/`--non-interactive` mode flag.
- First-class support for scaffolding session drivers: `--driver` flag, interactive prompt, and generator emits `driver: true` plus a `start(ctx)` stub.
- `--defaults` preserved for back-compat.

Closes #38. Closes #41.

Spec: `docs/superpowers/specs/2026-04-23-plugin-create-non-interactive-design.md`
Plan: `docs/superpowers/plans/2026-04-23-plugin-create-non-interactive.md`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 372 pass, 0 fail (adds 17 new tests: generator driver support, buildConfigFromFlags validation, non-interactive mode, CLI flag shapes)
- [x] Smoke: \`bun run src/cli.ts plugin create /tmp/x --name x --tier scoped --grant fs,net --driver\` → generates plugin with driver:true and start(ctx) stub
- [x] Smoke: \`bun run src/cli.ts plugin create /tmp/y --defaults\` still works
- [x] Smoke: unknown flag rejected with parseArgs error; target directory not created
- [x] Docs updated: `docs/guides/plugin-authoring.md` scaffold section