### PR TITLE
fix(config): simplify kaizen config model (#34)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ gap. Open an issue or check `docs/superpowers/specs/` for in-progress work.
 ### Concepts
 - [Platform](concepts/platform.md) — why kaizen exists and what it is
 - [Architecture](concepts/architecture.md) — kernel model, event bus, registry
+- [Configuration](concepts/configuration.md) — `~/.kaizen/kaizen.json` schema and merge order
 - [Plugin Model](concepts/plugin-model.md) — what plugins are and how they load
 - [Security](concepts/security.md) — plugin security model and permission tiers
 - [Harnesses](concepts/harnesses.md) — sharing pre-configured plugin stacks

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -144,15 +144,12 @@ First-party plugins and harnesses live in a separate repo:
 
 ```
 ~/.kaizen/                   Global kaizen home (created by install.sh or kaizen init --global)
-  kaizen.json                Default config — used when no project config found
+  kaizen.json                User config — defaults.harness, defaults.plugin_config, marketplaces
   marketplaces/              Per-marketplace install trees (see "Install tree" below)
   harnesses/                 Authored harnesses, resolved by bare name
-
-<project>/
-  .kaizen/                   Project-local config (like .vscode/)
-    kaizen.json              Project config — extends a harness or defines full plugin stack
-    harnesses/               Project-local authored harnesses
 ```
+
+> **No project-level config.** There is no `.kaizen/kaizen.json` overlay or root `kaizen.json` in projects. All user configuration lives in `~/.kaizen/kaizen.json`. See [`docs/concepts/configuration.md`](./configuration.md).
 
 Plugins installed from marketplaces live under
 `~/.kaizen/marketplaces/<id>/plugins/`. Harnesses installed from marketplaces
@@ -181,7 +178,7 @@ All marketplace data lives under `~/.kaizen/` (or `$KAIZEN_HOME_OVERRIDE` in tes
 
 ```
 ~/.kaizen/
-  kaizen.json                              # global config (KaizenGlobalConfig)
+  kaizen.json                              # user global config (KaizenGlobalConfig — defaults, marketplaces)
   marketplaces/
     <id>/
       repo/                                # git clone (or symlink for local dev)

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -1,0 +1,52 @@
+# Configuration
+
+Kaizen has exactly one user-editable config file: `~/.kaizen/kaizen.json`.
+
+## Schema
+
+```json
+{
+  "defaults": {
+    "harness": "official/core-shell@1.0.0",
+    "plugin_config": {
+      "gitlab":   { "base_url": "https://gitlab.mycompany.com", "username": "alice" },
+      "core-cli": { "clis": ["docker", "kubectl"] }
+    }
+  },
+  "marketplaces": [
+    { "id": "official", "url": "https://github.com/CraightonH/kaizen-marketplace.git" }
+  ]
+}
+```
+
+### Fields
+
+- **`defaults`** *(optional, object)* — what this user defaults to.
+  - **`defaults.harness`** *(optional, string)* — harness ref used when `--harness` is not passed on the CLI.
+  - **`defaults.plugin_config`** *(optional, object)* — per-plugin config overrides, keyed by plugin name.
+- **`marketplaces`** *(optional, array)* — registered marketplaces. Managed by `kaizen marketplace add/remove`.
+- **`marketplaceUpdateTTL`** *(optional, number)* — background marketplace refresh interval in seconds.
+
+Any other top-level key is a validation error.
+
+## Effective plugin config
+
+For each plugin `P` in the active harness:
+
+```
+effective_config(P) = { ...plugin_declared_defaults, ...harness_defaults, ...user_plugin_config }
+```
+
+User `defaults.plugin_config[P]` wins over harness defaults. Harness defaults win over the plugin's own declared defaults.
+
+## Choosing a harness
+
+The active harness is selected by:
+
+1. `--harness <ref>` on the CLI
+2. `defaults.harness` in `~/.kaizen/kaizen.json`
+3. Otherwise, kaizen refuses to start.
+
+## What moved
+
+Project-level kaizen config (`.kaizen/kaizen.json` overlay and root `kaizen.json`) is no longer supported. If you had one, move its `extends` value to `defaults.harness` in `~/.kaizen/kaizen.json`. If it had per-plugin config overrides, move those under `defaults.plugin_config` in the same file. Per-project config scoping will be revisited in a future release.

--- a/docs/concepts/harnesses.md
+++ b/docs/concepts/harnesses.md
@@ -2,6 +2,10 @@
 
 *Read when: you want to share a pre-configured kaizen setup, or use one someone shared.*
 
+> **See also:** [`docs/concepts/configuration.md`](./configuration.md) — how user config in
+> `~/.kaizen/kaizen.json` interacts with the active harness (default harness selection,
+> per-plugin config overrides, and merge order).
+
 A **harness** is a `kaizen.json` — a plugin list plus default config for each plugin.
 Harnesses are distributed through **marketplaces** alongside plugins. A harness
 entry in a marketplace catalog points at a versioned directory containing a
@@ -59,41 +63,6 @@ kaizen --harness https://example.com/kaizen.json   # ERROR
 
 Raw URL harnesses are rejected. Publish the harness in a marketplace and
 reference it by ref instead.
-
-### Extending in kaizen.json
-
-```json
-{
-  "extends": "official/core-anthropic@0.1.0",
-  "core-driver": {
-    "systemPrompt": "You are a coding assistant."
-  }
-}
-```
-
-`extends` accepts the same forms as `--harness`:
-
-- A marketplace ref (`<marketplace-id>/<name>@<version>`) — materialized into
-  `~/.kaizen/marketplaces/<id>/harnesses/<name>/` on first run.
-- A bare name present in `.kaizen/harnesses/<name>/` or
-  `~/.kaizen/harnesses/<name>/`.
-- A local path (`./path/to/kaizen.json` or `./path/to/harness-dir/`).
-
-Raw URLs are rejected.
-
-The harness provides the base plugin list and config; your local `kaizen.json`
-overlays it.
-
-## Config merge rules
-
-| Key | Behavior |
-|-----|----------|
-| `plugins` | Local replaces harness entirely (if present) |
-| Plugin config objects | Shallow merge — local wins on key conflicts |
-| `extends` | Consumed during resolution, stripped from final config |
-
-If local `kaizen.json` omits `plugins`, it inherits the harness plugin stack.
-Add `plugins` to replace the stack entirely.
 
 ## Authoring a harness
 
@@ -172,9 +141,9 @@ next run because the tier-grant hash no longer matches.
 independent consent records — consenting in one does not grant consent in the
 other.
 
-**A named harness is required.** `kaizen` without `--harness` and without an
-`extends` entry in `.kaizen/kaizen.json` is an error. Use one of the three
-entry-point forms above.
+**A named harness is required.** `kaizen` without `--harness` and without
+`defaults.harness` set in `~/.kaizen/kaizen.json` is an error. Use one of the
+entry-point forms above, or set a default in your user config.
 
 ## Discovery
 
@@ -234,20 +203,3 @@ you've added.
 `kaizen-plugin-autonomous` provides the `driver` capability and runs
 headless — no `core-ui-terminal` needed.
 
-### Extending an installed harness with local overrides
-
-```json
-{
-  "extends": "./base-harness/kaizen.json",
-  "core-driver": {
-    "systemPrompt": "Focus on the payments service."
-  },
-  "core-cli": {
-    "clis": ["stripe", "gh"]
-  }
-}
-```
-
-`extends` takes a local path or a bare name under `.kaizen/harnesses/` or
-`~/.kaizen/harnesses/`. For a marketplace harness, use `--harness
-<marketplace>/<name>@<version>` at the CLI.

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -92,10 +92,8 @@ Review the proposed manifest, tighten globs by hand, paste into your plugin.
 
 Installing a SCOPED plugin prints a UAC showing all grants; the user accepts or
 rejects. Installing UNSCOPED requires typing the plugin name. Decisions persist
-to `permissions.lock` alongside each harness's `kaizen.json` (project:
-`.kaizen/harnesses/<name>/permissions.lock`; home: `~/.kaizen/harnesses/<name>/permissions.lock`;
-marketplace: `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock`) — **commit
-project-scoped lockfiles**. Reviewers approve changes like code.
+to `permissions.lock` alongside each harness's `kaizen.json` (home: `~/.kaizen/harnesses/<name>/permissions.lock`;
+marketplace: `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock`). Reviewers approve changes like code.
 
 Workflow:
 - `kaizen install <plugin>` — resolve, read manifest, run consent, write lockfile

--- a/docs/core-internals.md
+++ b/docs/core-internals.md
@@ -12,7 +12,7 @@ src/core/
   event-bus.ts        EventBus implementation
   service-registry.ts     ServiceRegistry — string-keyed define/provide/consume/use
   context.ts          createPluginContext() — state-checked facade
-  config.ts           kaizen.json loading, harness resolution, merging
+  config.ts           Harness kaizen.json loading and resolution (global user config is in kaizen-config.ts)
   errors.ts           fatal / warn / debug
 ```
 
@@ -134,27 +134,36 @@ Calling `on()` or `defineEvent()` outside the `INITIALIZING` state throws becaus
 
 Each plugin gets its own context instance with its own config slice.
 
-## Config system (`config.ts`)
+## Config system
 
-### Named harness required
+Kaizen has two distinct config layers; each lives in a separate module.
 
-Every invocation must resolve to a named harness, via `--harness` on the CLI
-or an `extends` field in the local / global `kaizen.json`. A bare
-`kaizen.json` with neither is an error:
+### User global config (`kaizen-config.ts`)
 
+`~/.kaizen/kaizen.json` — the only user-editable config file. Schema:
+
+```json
+{
+  "defaults": { "harness": "<ref>", "plugin_config": { "<plugin>": { ... } } },
+  "marketplaces": [ ... ],
+  "marketplaceUpdateTTL": 900
+}
 ```
-A named harness is required.
-See docs/concepts/harnesses.md.
-```
 
-### Harness resolution
+`loadKaizenGlobalConfig()` validates the schema strictly: `plugins`, `extends`, `default_harness`, `plugin_config` at top level, or any unknown key, is a fatal error. See [`docs/concepts/configuration.md`](concepts/configuration.md) for the full schema and migration notes.
+
+### Harness config and resolution (`config.ts`)
+
+Every invocation must resolve to a harness. The active harness is chosen by:
+1. `--harness` on the CLI
+2. `defaults.harness` in `~/.kaizen/kaizen.json`
 
 `resolveHarness(nameOrPath)` returns `{ kaizenJsonPath, config }`. It tries,
 in order:
 
 1. Project-scoped bare name → `.kaizen/harnesses/<name>/kaizen.json`
 2. Home-scoped bare name → `~/.kaizen/harnesses/<name>/kaizen.json`
-3. Explicit local path (`./`, `../`, `/`) → the kaizen.json at that path
+3. Explicit local path (`./`, `../`, `/`) → the `kaizen.json` at that path
 4. Raw URL → rejected (use a marketplace ref instead)
 
 Marketplace refs (`<id>/<name>@<version>`) are handled upstream in
@@ -162,12 +171,15 @@ Marketplace refs (`<id>/<name>@<version>`) are handled upstream in
 harness into `~/.kaizen/marketplaces/<id>/harnesses/<name>/` before passing
 the resulting absolute path to `resolveHarness`.
 
-### Config merge
+### Effective plugin config (`config-merge.ts`)
 
-Local overlays harness:
-- `plugins` array: local wins entirely if present.
-- Plugin config objects: shallow merge, local wins on key conflicts.
-- `extends`: consumed during resolution, not passed to plugins.
+For each plugin `P` in the active harness:
+
+```
+effective_config(P) = { ...plugin_declared_defaults, ...harness_defaults, ...user_plugin_config }
+```
+
+`defaults.plugin_config[P]` from `~/.kaizen/kaizen.json` wins over harness defaults. Harness defaults win over the plugin's own declared defaults.
 
 ### Per-harness lockfile path
 

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -352,6 +352,35 @@ fixes:
 | `config secrets key "..." not declared in config.schema.properties` | Add the key to `config.schema.properties`. |
 | `core-secrets:provider dependency is implicit` (warn) | List it in `services.consumes` for discoverability. |
 
+## Plugin config keys {#plugin-config-keys}
+
+If your plugin reads config values at runtime, document the keys in your
+`README.md` so users know what to put under `defaults.plugin_config.<your-plugin>`
+in `~/.kaizen/kaizen.json`. For example, a plugin named `gitlab` that reads
+`base_url` and `username` should include:
+
+```md
+### User config (`~/.kaizen/kaizen.json`)
+
+```json
+{
+  "defaults": {
+    "plugin_config": {
+      "gitlab": {
+        "base_url": "https://gitlab.mycompany.com",
+        "username": "alice"
+      }
+    }
+  }
+}
+```
+```
+
+Declare the same keys in `plugin.config.schema` (the JSON Schema block in your
+manifest) so kaizen can validate user-supplied values. Secret keys additionally
+go in `plugin.config.secrets`. See [`reference/plugin-api.md`](../reference/plugin-api.md)
+for the full `config` field shape.
+
 ## Next steps
 
 Once your plugin validates, publish it:

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -280,7 +280,9 @@ harness-authored providers.
 
 ---
 
-## KaizenConfig (kaizen.json shape)
+## KaizenConfig (harness kaizen.json shape)
+
+`KaizenConfig` describes a **harness** `kaizen.json` — the file maintained by harness authors, not end users. End-user config lives exclusively in `~/.kaizen/kaizen.json`; see [`docs/concepts/configuration.md`](../concepts/configuration.md).
 
 ```ts
 export interface KaizenConfig {
@@ -289,11 +291,19 @@ export interface KaizenConfig {
   marketplaces?: MarketplaceRef[];
   [pluginName: string]: unknown;  // per-plugin config slices
 }
+```
+
+## KaizenGlobalConfig (~/.kaizen/kaizen.json shape)
+
+```ts
+export interface KaizenDefaults {
+  harness?: string;                                    // default harness ref
+  plugin_config?: Record<string, Record<string, unknown>>;  // per-plugin overrides
+}
 
 export interface KaizenGlobalConfig {
   marketplaces?: MarketplaceRef[];
-  defaultHarness?: string;
-  defaults?: Record<string, unknown>;
+  defaults?: KaizenDefaults;
   marketplaceUpdateTTL?: number;   // seconds; 0 disables; default 900
 }
 ```

--- a/docs/superpowers/plans/2026-04-23-kaizen-config-simplification.md
+++ b/docs/superpowers/plans/2026-04-23-kaizen-config-simplification.md
@@ -2,9 +2,23 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Fix #34 by deleting kaizen's legacy project-level config path, consolidating on the existing `KaizenGlobalConfig` at `~/.kaizen/kaizen.json`, and flipping the plugin-config merge order so user globals win over harness defaults.
+**Goal:** Fix #34 by deleting kaizen's legacy project-level config path, consolidating on the existing `KaizenGlobalConfig` at `~/.kaizen/kaizen.json` with a nested `defaults` structure, and flipping the plugin-config merge order so user globals win over harness defaults.
 
-**Architecture:** Kaizen today has two coexisting config systems reading the same file. The legacy path (`src/core/config.ts`: `resolveConfig` + `mergeConfigs` + `findProjectConfig` + `PROJECT_CONFIG`/`LEGACY_CONFIG`) is where #34's clobber happens. The newer path (`src/core/kaizen-config.ts`: `KaizenGlobalConfig`, `loadKaizenGlobalConfig`, `mergePluginConfig`) is what stays. We delete the legacy path, rename `KaizenGlobalConfig.defaults` → `plugin_config` and `KaizenGlobalConfig.defaultHarness` → `default_harness`, flip `mergePluginConfig`'s merge order so user wins, add validation that rejects `plugins`/`extends`/unknown top-level keys, rewrite `kaizen init` to global-only, and add migration warnings for deprecated `.kaizen/kaizen.json` / root `kaizen.json` files.
+**Architecture:** Kaizen today has two coexisting config systems reading the same file. The legacy path (`src/core/config.ts`: `resolveConfig` + `mergeConfigs` + `findProjectConfig` + `PROJECT_CONFIG`/`LEGACY_CONFIG`) is where #34's clobber happens. The newer path (`src/core/kaizen-config.ts`: `KaizenGlobalConfig`, `loadKaizenGlobalConfig`, `mergePluginConfig`) is what stays. We delete the legacy path, restructure `KaizenGlobalConfig` so `defaults` becomes a nested object `{ harness?, plugin_config? }` (replacing the old flat plugin-name-keyed map and the sibling `defaultHarness` field), flip `mergePluginConfig`'s merge order so user wins, add validation that rejects `plugins`/`extends`/unknown top-level keys, rewrite `kaizen init` to global-only, and add migration warnings for deprecated `.kaizen/kaizen.json` / root `kaizen.json` files.
+
+**Final `~/.kaizen/kaizen.json` shape:**
+```json
+{
+  "defaults": {
+    "harness": "official/core-shell@1.0.0",
+    "plugin_config": {
+      "gitlab": { "base_url": "https://gitlab.mycompany.com" }
+    }
+  },
+  "marketplaces": [ { "id": "official", "url": "..." } ],
+  "marketplaceUpdateTTL": 900
+}
+```
 
 **Tech Stack:** TypeScript + Bun. Tests via `bun test`. Typecheck via `bun run typecheck`.
 
@@ -65,7 +79,7 @@ Task commit messages follow `<type>(<scope>): <subject> (#34)`. Types: `feat`, `
 
 ---
 
-## Task 1: Rename `KaizenGlobalConfig` fields
+## Task 1: Restructure `KaizenGlobalConfig` with nested `defaults`
 
 **Files:**
 - Modify: `src/types/plugin.ts:333-339`
@@ -75,36 +89,41 @@ Task commit messages follow `<type>(<scope>): <subject> (#34)`. Types: `feat`, `
 Open `src/types/plugin.ts`. Replace the `KaizenGlobalConfig` interface with:
 
 ```typescript
-export interface KaizenGlobalConfig {
-  marketplaces?: MarketplaceRef[];
-  /** Default harness ref used when --harness is not passed on the CLI. */
-  default_harness?: string;
+export interface KaizenDefaults {
+  /** Harness ref used when --harness is not passed on the CLI. */
+  harness?: string;
   /** Per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects. */
   plugin_config?: Record<string, Record<string, unknown>>;
+}
+
+export interface KaizenGlobalConfig {
+  marketplaces?: MarketplaceRef[];
+  /** User-chosen defaults: default harness + per-plugin config overrides. */
+  defaults?: KaizenDefaults;
   /** Seconds between background marketplace refreshes; 0 disables. Default 900. */
   marketplaceUpdateTTL?: number;
 }
 ```
 
-The prior shape had `defaultHarness` and `defaults` with a looser `Record<string, unknown>` type. We tighten `plugin_config` to a map of plugin-name → object.
+The prior shape had `defaultHarness` (top-level) and `defaults` (a loose `Record<string, unknown>` of plugin-name → config). We collapse both into a single nested `defaults` object with exactly two permitted sub-keys.
 
 - [ ] **Step 2: Typecheck to surface callers**
 
 Run: `bun run typecheck`
 Expected: FAIL in at least these locations:
-- `src/core/plugin-manager.ts` (references `.defaults`)
-- possibly `src/core/marketplace.ts` (reads/writes `marketplaces`, should still typecheck)
-- possibly `src/core/kaizen-config.test.ts`
+- `src/core/plugin-manager.ts` (reads `.defaults?.[plugin.name]` — that's the old flat-map access, which is now wrong)
+- `src/core/kaizen-config.test.ts` (any existing tests constructing the old shape)
+- possibly other callers of `globalConfig.defaults`
 
-Note the failing files for Task 5 and 6.
+Note the failing files for Task 2.
 
-- [ ] **Step 3: Commit (field rename alone, fix-ups come next)**
+- [ ] **Step 3: Commit (schema shape alone, fix-ups come next)**
 
 Do NOT commit yet — the tree won't compile. Continue to Task 2 before committing.
 
 ---
 
-## Task 2: Update `plugin-manager.ts` to read `plugin_config`
+## Task 2: Update `plugin-manager.ts` to read `defaults.plugin_config`
 
 **Files:**
 - Modify: `src/core/plugin-manager.ts:637`
@@ -120,26 +139,28 @@ const globalDefaults = (this.globalConfig?.defaults?.[plugin.name] as Record<str
 Replace with:
 
 ```typescript
-const userPluginConfig = (this.globalConfig?.plugin_config?.[plugin.name] as Record<string, unknown> | undefined) ?? {};
+const userPluginConfig = this.globalConfig?.defaults?.plugin_config?.[plugin.name] ?? {};
 ```
 
 Also update the call on the next line from `mergePluginConfig(plugin.config, globalDefaults, harnessConfig)` to `mergePluginConfig(plugin.config, userPluginConfig, harnessConfig)` — the arg order is still wrong at this point; Task 3 will flip it.
 
+Note: the `as Record<string, unknown> | undefined` cast is no longer needed because `KaizenDefaults.plugin_config` is now typed as `Record<string, Record<string, unknown>>`. If TypeScript complains, it means the types disagree — fix them, don't cast.
+
 - [ ] **Step 2: Typecheck**
 
 Run: `bun run typecheck`
-Expected: any remaining `defaults` references flagged. Fix each one by reading `plugin_config` instead. If `marketplaces.ts` / `marketplace.ts` references `.defaults`, that's a different thing (the test is marketplace catalog defaults, not plugin defaults) — leave it alone unless the type error says otherwise.
+Expected: any remaining `globalConfig.defaults[...]` direct accesses flagged. Fix each — plugin-name keys live at `globalConfig.defaults.plugin_config[...]` now, and the top-level `defaults.harness` replaces the former `defaultHarness` everywhere.
 
 - [ ] **Step 3: Run the affected unit tests**
 
 Run: `bun test src/core/plugin-manager.test.ts src/core/kaizen-config.test.ts`
-Expected: some failures around `defaults` vs `plugin_config`. Skip if tests still pass; otherwise note them for Task 6.
+Expected: some failures around the old flat shape. Note them for Task 6.
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add src/types/plugin.ts src/core/plugin-manager.ts
-git commit -m "refactor(config): rename KaizenGlobalConfig defaults → plugin_config, defaultHarness → default_harness (#34)"
+git commit -m "refactor(config): nest KaizenGlobalConfig.defaults with harness + plugin_config (#34)"
 ```
 
 ---
@@ -271,14 +292,16 @@ function writeCfg(obj: unknown) {
   writeFileSync(path, JSON.stringify(obj), "utf8");
 }
 
-test("loadKaizenGlobalConfig: accepts default_harness and plugin_config", async () => {
+test("loadKaizenGlobalConfig: accepts nested defaults.harness and defaults.plugin_config", async () => {
   writeCfg({
-    default_harness: "official/core-shell@1.0.0",
-    plugin_config: { gitlab: { base_url: "https://gitlab.mycompany.com" } },
+    defaults: {
+      harness: "official/core-shell@1.0.0",
+      plugin_config: { gitlab: { base_url: "https://gitlab.mycompany.com" } },
+    },
   });
   const cfg = await loadKaizenGlobalConfig();
-  expect(cfg.default_harness).toBe("official/core-shell@1.0.0");
-  expect(cfg.plugin_config?.gitlab).toEqual({ base_url: "https://gitlab.mycompany.com" });
+  expect(cfg.defaults?.harness).toBe("official/core-shell@1.0.0");
+  expect(cfg.defaults?.plugin_config?.gitlab).toEqual({ base_url: "https://gitlab.mycompany.com" });
 });
 
 test("loadKaizenGlobalConfig: rejects top-level `plugins` key", async () => {
@@ -286,13 +309,28 @@ test("loadKaizenGlobalConfig: rejects top-level `plugins` key", async () => {
   await expect(loadKaizenGlobalConfig()).rejects.toThrow(/plugins.*not allowed|not supported/i);
 });
 
-test("loadKaizenGlobalConfig: rejects top-level `extends` key with rename hint", async () => {
+test("loadKaizenGlobalConfig: rejects top-level `extends` with 'move to defaults.harness' hint", async () => {
   writeCfg({ extends: "foo/bar@1.0.0" });
-  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/extends.*default_harness/);
+  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/extends.*defaults\.harness/);
+});
+
+test("loadKaizenGlobalConfig: rejects top-level `default_harness` with 'nest under defaults' hint", async () => {
+  writeCfg({ default_harness: "foo/bar@1.0.0" });
+  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/default_harness.*defaults\.harness/);
+});
+
+test("loadKaizenGlobalConfig: rejects top-level `plugin_config` with 'nest under defaults' hint", async () => {
+  writeCfg({ plugin_config: { gitlab: {} } });
+  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/plugin_config.*defaults\.plugin_config/);
+});
+
+test("loadKaizenGlobalConfig: rejects old flat shape (plugin names directly under defaults)", async () => {
+  writeCfg({ defaults: { gitlab: { base_url: "x" } } });
+  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/defaults\.gitlab|defaults\.plugin_config/);
 });
 
 test("loadKaizenGlobalConfig: rejects unknown top-level keys", async () => {
-  writeCfg({ default_harness: "x/y@1", random_nonsense: true });
+  writeCfg({ defaults: { harness: "x/y@1" }, random_nonsense: true });
   await expect(loadKaizenGlobalConfig()).rejects.toThrow(/random_nonsense/);
 });
 
@@ -306,8 +344,8 @@ test("loadKaizenGlobalConfig: allows marketplaces and marketplaceUpdateTTL", asy
   expect(cfg.marketplaceUpdateTTL).toBe(600);
 });
 
-test("loadKaizenGlobalConfig: plugin_config must be an object of objects", async () => {
-  writeCfg({ plugin_config: { gitlab: "not an object" } });
+test("loadKaizenGlobalConfig: defaults.plugin_config must be an object of objects", async () => {
+  writeCfg({ defaults: { plugin_config: { gitlab: "not an object" } } });
   await expect(loadKaizenGlobalConfig()).rejects.toThrow(/plugin_config/);
 });
 
@@ -328,11 +366,11 @@ Open `src/core/kaizen-config.ts`. Replace `loadKaizenGlobalConfig` with:
 
 ```typescript
 const ALLOWED_TOP_LEVEL_KEYS = new Set([
-  "default_harness",
-  "plugin_config",
+  "defaults",
   "marketplaces",
   "marketplaceUpdateTTL",
 ]);
+const ALLOWED_DEFAULTS_KEYS = new Set(["harness", "plugin_config"]);
 
 export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
   const path = kaizenHomeConfigPath();
@@ -352,7 +390,18 @@ export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
   }
   if ("extends" in obj) {
     throw new Error(
-      `${path}: top-level 'extends' has been renamed to 'default_harness'. Rename the key and try again.`,
+      `${path}: top-level 'extends' has been replaced by 'defaults.harness'. ` +
+      `Move the value under \`defaults\` and try again.`,
+    );
+  }
+  if ("default_harness" in obj) {
+    throw new Error(
+      `${path}: top-level 'default_harness' is not allowed — nest it as 'defaults.harness'.`,
+    );
+  }
+  if ("plugin_config" in obj) {
+    throw new Error(
+      `${path}: top-level 'plugin_config' is not allowed — nest it as 'defaults.plugin_config'.`,
     );
   }
   const unknownKeys = Object.keys(obj).filter((k) => !ALLOWED_TOP_LEVEL_KEYS.has(k));
@@ -363,16 +412,30 @@ export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
     );
   }
 
-  if (obj.default_harness !== undefined && typeof obj.default_harness !== "string") {
-    throw new Error(`${path}: 'default_harness' must be a string.`);
-  }
-  if (obj.plugin_config !== undefined) {
-    if (typeof obj.plugin_config !== "object" || obj.plugin_config === null || Array.isArray(obj.plugin_config)) {
-      throw new Error(`${path}: 'plugin_config' must be an object.`);
+  if (obj.defaults !== undefined) {
+    if (typeof obj.defaults !== "object" || obj.defaults === null || Array.isArray(obj.defaults)) {
+      throw new Error(`${path}: 'defaults' must be an object.`);
     }
-    for (const [name, value] of Object.entries(obj.plugin_config)) {
-      if (typeof value !== "object" || value === null || Array.isArray(value)) {
-        throw new Error(`${path}: 'plugin_config.${name}' must be an object.`);
+    const defaults = obj.defaults as Record<string, unknown>;
+    const unknownDefaultsKeys = Object.keys(defaults).filter((k) => !ALLOWED_DEFAULTS_KEYS.has(k));
+    if (unknownDefaultsKeys.length > 0) {
+      throw new Error(
+        `${path}: unknown keys under 'defaults': ${unknownDefaultsKeys.join(", ")}. ` +
+        `Allowed: ${[...ALLOWED_DEFAULTS_KEYS].join(", ")}. ` +
+        `If these are plugin names, move them under 'defaults.plugin_config'.`,
+      );
+    }
+    if (defaults.harness !== undefined && typeof defaults.harness !== "string") {
+      throw new Error(`${path}: 'defaults.harness' must be a string.`);
+    }
+    if (defaults.plugin_config !== undefined) {
+      if (typeof defaults.plugin_config !== "object" || defaults.plugin_config === null || Array.isArray(defaults.plugin_config)) {
+        throw new Error(`${path}: 'defaults.plugin_config' must be an object.`);
+      }
+      for (const [name, value] of Object.entries(defaults.plugin_config)) {
+        if (typeof value !== "object" || value === null || Array.isArray(value)) {
+          throw new Error(`${path}: 'defaults.plugin_config.${name}' must be an object.`);
+        }
       }
     }
   }
@@ -454,14 +517,14 @@ export function resolveConfig(opts: {
   }
 
   // Fall through to global default harness. The caller is responsible for
-  // loading ~/.kaizen/kaizen.json and passing its default_harness via opts.harness
+  // loading ~/.kaizen/kaizen.json and passing defaults.harness via opts.harness
   // when they want that behavior; resolveConfig itself no longer reaches for
   // ~/.kaizen/kaizen.json synchronously (loadKaizenGlobalConfig is async).
   fatal(
     `A harness is required.\n` +
     `  kaizen --harness <marketplace>/<name>@<version>\n` +
     `  kaizen --harness ./path/to/harness/\n` +
-    `  Set 'default_harness' in ~/.kaizen/kaizen.json`,
+    `  Set 'defaults.harness' in ~/.kaizen/kaizen.json`,
   );
 }
 ```
@@ -476,7 +539,7 @@ Open `src/cli.ts`. Remove the imports of `findProjectConfig`, `PROJECT_CONFIG`, 
 
 Find every call-site that references the removed symbols and rewrite:
 
-- Before `resolveConfig({...})` is called, `cli.ts` needs to load `~/.kaizen/kaizen.json` via `loadKaizenGlobalConfig()` and pass `default_harness` as the `harness` opt when `--harness` is absent. The current `resolveConfig` call on line 647 looks like:
+- Before `resolveConfig({...})` is called, `cli.ts` needs to load `~/.kaizen/kaizen.json` via `loadKaizenGlobalConfig()` and pass `defaults.harness` as the `harness` opt when `--harness` is absent. The current `resolveConfig` call on line 647 looks like:
   ```typescript
   const kaizenConfig = resolveConfig({ harness, configPath, extendsOverride });
   ```
@@ -487,7 +550,7 @@ Find every call-site that references the removed symbols and rewrite:
   let effectiveHarness = harness;
   if (!effectiveHarness && !extendsOverride) {
     const global = await loadKaizenGlobalConfig();
-    effectiveHarness = global.default_harness;
+    effectiveHarness = global.defaults?.harness;
   }
   const kaizenConfig = resolveConfig({ harness: effectiveHarness, extendsOverride });
   ```
@@ -613,7 +676,7 @@ const LEGACY_ROOT = "kaizen.json";
 
 const MESSAGE = (path: string) =>
   `Found '${path}'. Project-level kaizen config is no longer supported. ` +
-  `Move 'extends' to '~/.kaizen/kaizen.json' as 'default_harness', ` +
+  `Move 'extends' to '~/.kaizen/kaizen.json' as 'defaults.harness', ` +
   `or pass --harness explicitly. See docs/concepts/configuration.md.`;
 
 export function warnStaleProjectConfig(sink: WarnSink): void {
@@ -693,15 +756,15 @@ if (subcommand === "init") {
 
   mkdirSync(KAIZEN_HOME, { recursive: true });
   const body: Record<string, unknown> = {};
-  if (harnessRef) body.default_harness = harnessRef;
+  if (harnessRef) body.defaults = { harness: harnessRef };
   writeFileSync(KAIZEN_HOME_CONFIG, JSON.stringify(body, null, 2) + "\n", "utf8");
 
   if (harnessRef) {
-    console.log(`Created ~/.kaizen/kaizen.json with default_harness=${harnessRef}`);
+    console.log(`Created ~/.kaizen/kaizen.json with defaults.harness=${harnessRef}`);
   } else {
     console.log(
       `Created ~/.kaizen/kaizen.json.\n` +
-      `Pass --harness on each run, or add 'default_harness' to the file.`,
+      `Pass --harness on each run, or add 'defaults.harness' to the file.`,
     );
   }
   process.exit(0);
@@ -726,7 +789,7 @@ to:
 Open whatever test files exercise `kaizen init`. Update them to:
 - Assert that `kaizen init` without `--global` exits non-zero with the project-config-not-supported message.
 - Assert that `kaizen init --global` writes `~/.kaizen/kaizen.json` (using `KAIZEN_HOME_OVERRIDE` for isolation).
-- Assert that `kaizen init --global --harness X` produces `{"default_harness": "X"}`.
+- Assert that `kaizen init --global --harness X` produces `{"defaults": {"harness": "X"}}`.
 
 If no test file covers this today, create `src/cli-init.test.ts` with at least the three cases above. Use `Bun.spawn` or direct import of the subcommand logic (if it's extractable); simplest approach is a subprocess-level test that invokes `bun src/cli.ts init ...` with `KAIZEN_HOME_OVERRIDE` set to a tmpdir.
 
@@ -843,10 +906,12 @@ Kaizen has exactly one user-editable config file: `~/.kaizen/kaizen.json`.
 
 ```json
 {
-  "default_harness": "official/core-shell@1.0.0",
-  "plugin_config": {
-    "gitlab":   { "base_url": "https://gitlab.mycompany.com", "username": "alice" },
-    "core-cli": { "clis": ["docker", "kubectl"] }
+  "defaults": {
+    "harness": "official/core-shell@1.0.0",
+    "plugin_config": {
+      "gitlab":   { "base_url": "https://gitlab.mycompany.com", "username": "alice" },
+      "core-cli": { "clis": ["docker", "kubectl"] }
+    }
   },
   "marketplaces": [
     { "id": "official", "url": "https://github.com/CraightonH/kaizen-marketplace.git" }
@@ -856,8 +921,9 @@ Kaizen has exactly one user-editable config file: `~/.kaizen/kaizen.json`.
 
 ### Fields
 
-- **`default_harness`** *(optional, string)* — harness ref used when `--harness` is not passed on the CLI.
-- **`plugin_config`** *(optional, object)* — per-plugin config overrides, keyed by plugin name.
+- **`defaults`** *(optional, object)* — what this user defaults to.
+  - **`defaults.harness`** *(optional, string)* — harness ref used when `--harness` is not passed on the CLI.
+  - **`defaults.plugin_config`** *(optional, object)* — per-plugin config overrides, keyed by plugin name.
 - **`marketplaces`** *(optional, array)* — registered marketplaces. Managed by `kaizen marketplace add/remove`.
 - **`marketplaceUpdateTTL`** *(optional, number)* — background marketplace refresh interval in seconds.
 
@@ -871,19 +937,19 @@ For each plugin `P` in the active harness:
 effective_config(P) = { ...plugin_declared_defaults, ...harness_defaults, ...user_plugin_config }
 ```
 
-User `plugin_config[P]` wins over harness defaults. Harness defaults win over the plugin's own declared defaults.
+User `defaults.plugin_config[P]` wins over harness defaults. Harness defaults win over the plugin's own declared defaults.
 
 ## Choosing a harness
 
 The active harness is selected by:
 
 1. `--harness <ref>` on the CLI
-2. `default_harness` in `~/.kaizen/kaizen.json`
+2. `defaults.harness` in `~/.kaizen/kaizen.json`
 3. Otherwise, kaizen refuses to start.
 
 ## What moved
 
-Project-level kaizen config (`.kaizen/kaizen.json` overlay and root `kaizen.json`) is no longer supported. If you had one, move its `extends` value to `default_harness` in `~/.kaizen/kaizen.json`. If it had per-plugin config overrides, move those under `plugin_config` in the same file. Per-project config scoping will be revisited in a future release.
+Project-level kaizen config (`.kaizen/kaizen.json` overlay and root `kaizen.json`) is no longer supported. If you had one, move its `extends` value to `defaults.harness` in `~/.kaizen/kaizen.json`. If it had per-plugin config overrides, move those under `defaults.plugin_config` in the same file. Per-project config scoping will be revisited in a future release.
 ````
 
 - [ ] **Step 2: Update `docs/concepts/harnesses.md`**
@@ -964,7 +1030,7 @@ Before declaring done, all of these must be true:
 - [ ] `bun test` passes.
 - [ ] `bun test --integration` passes.
 - [ ] `src/core/config.ts` no longer exports `mergeConfigs`, `findProjectConfig`, `loadKaizenConfig`, `PROJECT_CONFIG`, or `LEGACY_CONFIG`.
-- [ ] `KaizenGlobalConfig` in `src/types/plugin.ts` uses `default_harness` and `plugin_config` (not `defaultHarness` / `defaults`).
+- [ ] `KaizenGlobalConfig` in `src/types/plugin.ts` has a nested `defaults` object with `harness?` and `plugin_config?` (not a top-level `defaultHarness` or flat plugin-name-keyed `defaults`).
 - [ ] `mergePluginConfig` spreads arguments in the order `declaration → harness → user` (user wins).
 - [ ] `loadKaizenGlobalConfig` rejects top-level `plugins`, `extends`, and unknown keys.
 - [ ] `kaizen init` without `--global` errors out; `kaizen init --global [--harness X]` writes the new schema.

--- a/docs/superpowers/plans/2026-04-23-kaizen-config-simplification.md
+++ b/docs/superpowers/plans/2026-04-23-kaizen-config-simplification.md
@@ -1,0 +1,974 @@
+# Kaizen Config Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix #34 by deleting kaizen's legacy project-level config path, consolidating on the existing `KaizenGlobalConfig` at `~/.kaizen/kaizen.json`, and flipping the plugin-config merge order so user globals win over harness defaults.
+
+**Architecture:** Kaizen today has two coexisting config systems reading the same file. The legacy path (`src/core/config.ts`: `resolveConfig` + `mergeConfigs` + `findProjectConfig` + `PROJECT_CONFIG`/`LEGACY_CONFIG`) is where #34's clobber happens. The newer path (`src/core/kaizen-config.ts`: `KaizenGlobalConfig`, `loadKaizenGlobalConfig`, `mergePluginConfig`) is what stays. We delete the legacy path, rename `KaizenGlobalConfig.defaults` → `plugin_config` and `KaizenGlobalConfig.defaultHarness` → `default_harness`, flip `mergePluginConfig`'s merge order so user wins, add validation that rejects `plugins`/`extends`/unknown top-level keys, rewrite `kaizen init` to global-only, and add migration warnings for deprecated `.kaizen/kaizen.json` / root `kaizen.json` files.
+
+**Tech Stack:** TypeScript + Bun. Tests via `bun test`. Typecheck via `bun run typecheck`.
+
+---
+
+## Background for the executing engineer
+
+**Read before starting:**
+- Spec: `docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md`
+- Issue: https://github.com/CraightonH/kaizen/issues/34
+
+**Key code paths (current state):**
+- `src/core/config.ts` — legacy config resolution (`resolveConfig`, `mergeConfigs`, `findProjectConfig`, `loadKaizenConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG`). This file gets cut down significantly — `loadHarnessConfig`, `resolveHarness`, `parseAndValidateHarness`, and `KAIZEN_HOME_CONFIG` stay (they're still used).
+- `src/core/kaizen-config.ts` — `loadKaizenGlobalConfig`, `saveKaizenGlobalConfig`, marketplace/harness install paths. Stays; we add validation here.
+- `src/core/config-merge.ts` — `mergePluginConfig`. Stays; we flip the merge order.
+- `src/core/plugin-manager.ts` — calls `mergePluginConfig` around line 637 using `this.globalConfig?.defaults?.[plugin.name]`. Stays; we rename `defaults` to `plugin_config`.
+- `src/types/plugin.ts` — `KaizenGlobalConfig` interface at line 333. Stays; we rename fields.
+- `src/cli.ts` — has `kaizen init` subcommand (line 141), imports legacy helpers. Stays; we rewrite init.
+
+**Invariants to preserve:**
+- Harness resolution (`resolveHarness`, `loadHarnessConfig`, `parseAndValidateHarness`): unchanged. Harness files still have `plugins` arrays and per-plugin config keys.
+- `KAIZEN_HOME_OVERRIDE` test hook in `kaizen-config.ts:11` must keep working (tests depend on it).
+- Secret handling (`separateSecrets`, `applyEnvOverrides` in `config-merge.ts`): unchanged.
+- Marketplace refresh / `marketplaces` / `marketplaceUpdateTTL` fields in `~/.kaizen/kaizen.json`: unchanged.
+
+**Conventions:**
+- Commit frequently, one logical change per commit. Never `--no-verify`.
+- Use `bun test <file>` for scoped runs; `bun test` for full suite; `bun run typecheck` before pushing (CI uses strict tsc and catches inference bugs `bun test` misses).
+- Follow existing code style (snake_case for JSON keys, camelCase for TS locals).
+
+---
+
+## File Structure
+
+**Files modified:**
+- `src/types/plugin.ts` — rename `KaizenGlobalConfig` fields; add top-level-key whitelist type if helpful.
+- `src/core/kaizen-config.ts` — add schema validation to `loadKaizenGlobalConfig`.
+- `src/core/kaizen-config.test.ts` — add tests for new validation.
+- `src/core/config-merge.ts` — flip `mergePluginConfig` arg order; rename param.
+- `src/core/config-merge.test.ts` — update tests for new order and precedence.
+- `src/core/config.ts` — delete `mergeConfigs`, `findProjectConfig`, `loadKaizenConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG`, project/legacy/home branches of `resolveConfig`.
+- `src/core/plugin-manager.ts` — update field name (`defaults` → `plugin_config`).
+- `src/cli.ts` — rewrite `kaizen init` as global-only; remove legacy imports; add deprecation warnings.
+- `src/commands/manage.ts` — update any `PROJECT_CONFIG`-based error text.
+- Other `src/commands/*.ts` — update imports if any referenced deleted symbols.
+- Tests in `src/core/*.test.ts` and `src/commands/*.test.ts` referencing deleted symbols — update or remove.
+- `docs/concepts/harnesses.md` — remove overlay/project-config discussion.
+- `docs/guides/plugin-authoring.md` — document that plugin authors should enumerate config keys users can set under `plugin_config`.
+- `docs/concepts/configuration.md` — **new** short doc describing the single overlay rule and valid `~/.kaizen/kaizen.json` shape.
+
+**Files deleted:** none (all changes are in-place edits).
+
+---
+
+## Commit conventions
+
+Task commit messages follow `<type>(<scope>): <subject> (#34)`. Types: `feat`, `refactor`, `fix`, `test`, `docs`, `chore`.
+
+---
+
+## Task 1: Rename `KaizenGlobalConfig` fields
+
+**Files:**
+- Modify: `src/types/plugin.ts:333-339`
+
+- [ ] **Step 1: Update the interface**
+
+Open `src/types/plugin.ts`. Replace the `KaizenGlobalConfig` interface with:
+
+```typescript
+export interface KaizenGlobalConfig {
+  marketplaces?: MarketplaceRef[];
+  /** Default harness ref used when --harness is not passed on the CLI. */
+  default_harness?: string;
+  /** Per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects. */
+  plugin_config?: Record<string, Record<string, unknown>>;
+  /** Seconds between background marketplace refreshes; 0 disables. Default 900. */
+  marketplaceUpdateTTL?: number;
+}
+```
+
+The prior shape had `defaultHarness` and `defaults` with a looser `Record<string, unknown>` type. We tighten `plugin_config` to a map of plugin-name → object.
+
+- [ ] **Step 2: Typecheck to surface callers**
+
+Run: `bun run typecheck`
+Expected: FAIL in at least these locations:
+- `src/core/plugin-manager.ts` (references `.defaults`)
+- possibly `src/core/marketplace.ts` (reads/writes `marketplaces`, should still typecheck)
+- possibly `src/core/kaizen-config.test.ts`
+
+Note the failing files for Task 5 and 6.
+
+- [ ] **Step 3: Commit (field rename alone, fix-ups come next)**
+
+Do NOT commit yet — the tree won't compile. Continue to Task 2 before committing.
+
+---
+
+## Task 2: Update `plugin-manager.ts` to read `plugin_config`
+
+**Files:**
+- Modify: `src/core/plugin-manager.ts:637`
+
+- [ ] **Step 1: Update the field read**
+
+Open `src/core/plugin-manager.ts`. Around line 637 you'll find:
+
+```typescript
+const globalDefaults = (this.globalConfig?.defaults?.[plugin.name] as Record<string, unknown> | undefined) ?? {};
+```
+
+Replace with:
+
+```typescript
+const userPluginConfig = (this.globalConfig?.plugin_config?.[plugin.name] as Record<string, unknown> | undefined) ?? {};
+```
+
+Also update the call on the next line from `mergePluginConfig(plugin.config, globalDefaults, harnessConfig)` to `mergePluginConfig(plugin.config, userPluginConfig, harnessConfig)` — the arg order is still wrong at this point; Task 3 will flip it.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `bun run typecheck`
+Expected: any remaining `defaults` references flagged. Fix each one by reading `plugin_config` instead. If `marketplaces.ts` / `marketplace.ts` references `.defaults`, that's a different thing (the test is marketplace catalog defaults, not plugin defaults) — leave it alone unless the type error says otherwise.
+
+- [ ] **Step 3: Run the affected unit tests**
+
+Run: `bun test src/core/plugin-manager.test.ts src/core/kaizen-config.test.ts`
+Expected: some failures around `defaults` vs `plugin_config`. Skip if tests still pass; otherwise note them for Task 6.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/plugin.ts src/core/plugin-manager.ts
+git commit -m "refactor(config): rename KaizenGlobalConfig defaults → plugin_config, defaultHarness → default_harness (#34)"
+```
+
+---
+
+## Task 3: Flip `mergePluginConfig` merge order
+
+**Files:**
+- Modify: `src/core/config-merge.ts:3-13`
+- Modify: `src/core/config-merge.test.ts`
+
+- [ ] **Step 1: Write the failing test for the new precedence**
+
+Open `src/core/config-merge.test.ts`. Find the existing tests for `mergePluginConfig`. Add (or replace) a test that asserts **user globals win over harness config**:
+
+```typescript
+import { test, expect } from "bun:test";
+import { mergePluginConfig } from "./config-merge.js";
+
+test("mergePluginConfig: user global wins over harness default", () => {
+  const declaration = { defaults: { base_url: "https://gitlab.com", timeout: 30 } };
+  const userPluginConfig = { base_url: "https://gitlab.mycompany.com" };
+  const harnessConfig = { base_url: "https://harness.example.com" };
+
+  const merged = mergePluginConfig(declaration, userPluginConfig, harnessConfig);
+
+  expect(merged).toEqual({
+    base_url: "https://gitlab.mycompany.com", // user wins
+    timeout: 30,                              // declaration fallback preserved
+  });
+});
+
+test("mergePluginConfig: harness wins over plugin declaration defaults", () => {
+  const declaration = { defaults: { base_url: "plugin-default" } };
+  const userPluginConfig = {};
+  const harnessConfig = { base_url: "harness-default" };
+
+  const merged = mergePluginConfig(declaration, userPluginConfig, harnessConfig);
+
+  expect(merged.base_url).toBe("harness-default");
+});
+```
+
+Review any *existing* tests in this file that assert harness-wins behavior and either delete them or flip them to the new expectation.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/config-merge.test.ts`
+Expected: the new "user global wins" test FAILS because today harness wins.
+
+- [ ] **Step 3: Flip the merge order**
+
+Open `src/core/config-merge.ts`. Replace `mergePluginConfig` with:
+
+```typescript
+export function mergePluginConfig(
+  declaration: PluginConfigDeclaration | undefined,
+  userPluginConfig: Record<string, unknown>,
+  harnessConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...(declaration?.defaults ?? {}),
+    ...harnessConfig,
+    ...userPluginConfig,
+  };
+}
+```
+
+The first positional arg is unchanged (plugin's own declared defaults). The order of the remaining two spreads is flipped so `userPluginConfig` wins.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/config-merge.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run full test suite to catch flipped assumptions**
+
+Run: `bun test`
+Expected: possibly failures in `plugin-manager.test.ts` or `bootstrap.test.ts` that relied on harness-wins. For each failure, determine whether the test encoded the old (buggy) precedence or a different invariant. Update test expectations that encode the old precedence; leave others alone.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/config-merge.ts src/core/config-merge.test.ts src/core/plugin-manager.test.ts src/core/bootstrap.test.ts
+git commit -m "fix(config): flip mergePluginConfig so user globals win over harness defaults (#34)"
+```
+
+(Adjust the `git add` list to only files you actually changed.)
+
+---
+
+## Task 4: Validate `~/.kaizen/kaizen.json` schema
+
+**Files:**
+- Modify: `src/core/kaizen-config.ts` — augment `loadKaizenGlobalConfig`.
+- Modify: `src/core/kaizen-config.test.ts` — add validation tests.
+
+- [ ] **Step 1: Write failing tests**
+
+Open `src/core/kaizen-config.test.ts`. Add a test block that covers the new validation:
+
+```typescript
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { loadKaizenGlobalConfig, kaizenHomeConfigPath } from "./kaizen-config.js";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { dirname } from "path";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let tmpHome: string;
+
+beforeEach(() => {
+  tmpHome = join(tmpdir(), `kaizen-cfg-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  process.env.KAIZEN_HOME_OVERRIDE = tmpHome;
+});
+
+afterEach(() => {
+  delete process.env.KAIZEN_HOME_OVERRIDE;
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+function writeCfg(obj: unknown) {
+  const path = kaizenHomeConfigPath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(obj), "utf8");
+}
+
+test("loadKaizenGlobalConfig: accepts default_harness and plugin_config", async () => {
+  writeCfg({
+    default_harness: "official/core-shell@1.0.0",
+    plugin_config: { gitlab: { base_url: "https://gitlab.mycompany.com" } },
+  });
+  const cfg = await loadKaizenGlobalConfig();
+  expect(cfg.default_harness).toBe("official/core-shell@1.0.0");
+  expect(cfg.plugin_config?.gitlab).toEqual({ base_url: "https://gitlab.mycompany.com" });
+});
+
+test("loadKaizenGlobalConfig: rejects top-level `plugins` key", async () => {
+  writeCfg({ plugins: ["foo/bar@1.0.0"] });
+  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/plugins.*not allowed|not supported/i);
+});
+
+test("loadKaizenGlobalConfig: rejects top-level `extends` key with rename hint", async () => {
+  writeCfg({ extends: "foo/bar@1.0.0" });
+  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/extends.*default_harness/);
+});
+
+test("loadKaizenGlobalConfig: rejects unknown top-level keys", async () => {
+  writeCfg({ default_harness: "x/y@1", random_nonsense: true });
+  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/random_nonsense/);
+});
+
+test("loadKaizenGlobalConfig: allows marketplaces and marketplaceUpdateTTL", async () => {
+  writeCfg({
+    marketplaces: [{ id: "official", url: "https://example.com/repo.git" }],
+    marketplaceUpdateTTL: 600,
+  });
+  const cfg = await loadKaizenGlobalConfig();
+  expect(cfg.marketplaces?.[0]?.id).toBe("official");
+  expect(cfg.marketplaceUpdateTTL).toBe(600);
+});
+
+test("loadKaizenGlobalConfig: plugin_config must be an object of objects", async () => {
+  writeCfg({ plugin_config: { gitlab: "not an object" } });
+  await expect(loadKaizenGlobalConfig()).rejects.toThrow(/plugin_config/);
+});
+
+test("loadKaizenGlobalConfig: returns {} when file is absent", async () => {
+  const cfg = await loadKaizenGlobalConfig();
+  expect(cfg).toEqual({});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/kaizen-config.test.ts`
+Expected: multiple FAIL — validation logic doesn't exist yet.
+
+- [ ] **Step 3: Implement validation**
+
+Open `src/core/kaizen-config.ts`. Replace `loadKaizenGlobalConfig` with:
+
+```typescript
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "default_harness",
+  "plugin_config",
+  "marketplaces",
+  "marketplaceUpdateTTL",
+]);
+
+export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
+  const path = kaizenHomeConfigPath();
+  if (!existsSync(path)) return {};
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${path}: expected a JSON object.`);
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  if ("plugins" in obj) {
+    throw new Error(
+      `${path}: top-level 'plugins' key is not allowed. The plugin set is defined by the harness; ` +
+      `user config cannot add, remove, or replace plugins. Remove the 'plugins' key. See docs/concepts/configuration.md.`,
+    );
+  }
+  if ("extends" in obj) {
+    throw new Error(
+      `${path}: top-level 'extends' has been renamed to 'default_harness'. Rename the key and try again.`,
+    );
+  }
+  const unknownKeys = Object.keys(obj).filter((k) => !ALLOWED_TOP_LEVEL_KEYS.has(k));
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `${path}: unknown top-level keys: ${unknownKeys.join(", ")}. ` +
+      `Allowed keys: ${[...ALLOWED_TOP_LEVEL_KEYS].join(", ")}.`,
+    );
+  }
+
+  if (obj.default_harness !== undefined && typeof obj.default_harness !== "string") {
+    throw new Error(`${path}: 'default_harness' must be a string.`);
+  }
+  if (obj.plugin_config !== undefined) {
+    if (typeof obj.plugin_config !== "object" || obj.plugin_config === null || Array.isArray(obj.plugin_config)) {
+      throw new Error(`${path}: 'plugin_config' must be an object.`);
+    }
+    for (const [name, value] of Object.entries(obj.plugin_config)) {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error(`${path}: 'plugin_config.${name}' must be an object.`);
+      }
+    }
+  }
+
+  return obj as KaizenGlobalConfig;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/kaizen-config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/kaizen-config.ts src/core/kaizen-config.test.ts
+git commit -m "feat(config): validate ~/.kaizen/kaizen.json schema (#34)"
+```
+
+---
+
+## Task 5: Delete legacy project config in `src/core/config.ts`
+
+**Files:**
+- Modify: `src/core/config.ts` (heavy cut)
+- Modify: `src/core/config-harness.test.ts` (if tests there reference deleted symbols)
+- Modify: `src/commands/manage.ts` (it references `PROJECT_CONFIG`)
+
+- [ ] **Step 1: Survey what imports the legacy symbols**
+
+Run: `grep -rn "findProjectConfig\|PROJECT_CONFIG\|LEGACY_CONFIG\|mergeConfigs\|loadKaizenConfig" /Users/chancock/git/kaizen/src`
+
+Expected to see references in:
+- `src/cli.ts` (imports + uses)
+- `src/commands/manage.ts` (imports `PROJECT_CONFIG`)
+- `src/core/config.ts` (definitions)
+- test files
+
+Note each call-site — they all need to be updated or removed.
+
+- [ ] **Step 2: Rewrite `resolveConfig` and delete legacy helpers**
+
+Open `src/core/config.ts`. Delete these symbols entirely:
+- `PROJECT_DIR` constant (if only used for project config — but note that `PROJECT_HARNESSES` is still used by `resolveHarness`; preserve that).
+- `PROJECT_CONFIG` constant.
+- `LEGACY_CONFIG` constant.
+- `findProjectConfig` function.
+- `loadKaizenConfig` function.
+- `mergeConfigs` function.
+- `parseConfigFile` function (if only used by deleted code).
+- `validateConfig` function (if only used by deleted code; keep it if `parseAndValidateHarness` uses it).
+
+Verify `parseAndValidateHarness` and `resolveHarness` still compile — they should.
+
+Replace `resolveConfig` with:
+
+```typescript
+export function resolveConfig(opts: {
+  harness?: string;
+  /**
+   * Pre-materialized extends path (set by the CLI pre-pass when the caller
+   * already resolved a marketplace ref to a local harness dir).
+   */
+  extendsOverride?: string;
+}): KaizenConfig {
+  const { harness, extendsOverride } = opts;
+
+  if (harness) {
+    return loadHarnessConfig(harness);
+  }
+  if (extendsOverride) {
+    return loadHarnessConfig(extendsOverride);
+  }
+
+  // Fall through to global default harness. The caller is responsible for
+  // loading ~/.kaizen/kaizen.json and passing its default_harness via opts.harness
+  // when they want that behavior; resolveConfig itself no longer reaches for
+  // ~/.kaizen/kaizen.json synchronously (loadKaizenGlobalConfig is async).
+  fatal(
+    `A harness is required.\n` +
+    `  kaizen --harness <marketplace>/<name>@<version>\n` +
+    `  kaizen --harness ./path/to/harness/\n` +
+    `  Set 'default_harness' in ~/.kaizen/kaizen.json`,
+  );
+}
+```
+
+Remove the `configPath` / explicit-config-file opt entirely (it only existed to point at project config). Update the `opts` type accordingly.
+
+Also delete the unused `RESERVED_KEYS` set if it is only referenced by deleted code.
+
+- [ ] **Step 3: Update `src/cli.ts`**
+
+Open `src/cli.ts`. Remove the imports of `findProjectConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG` (line 10 import list and any other imports from `./core/config.js`). Keep `resolveConfig`, `resolveHarness`, `KAIZEN_HOME`, `KAIZEN_HOME_CONFIG`.
+
+Find every call-site that references the removed symbols and rewrite:
+
+- Before `resolveConfig({...})` is called, `cli.ts` needs to load `~/.kaizen/kaizen.json` via `loadKaizenGlobalConfig()` and pass `default_harness` as the `harness` opt when `--harness` is absent. The current `resolveConfig` call on line 647 looks like:
+  ```typescript
+  const kaizenConfig = resolveConfig({ harness, configPath, extendsOverride });
+  ```
+  Change to:
+  ```typescript
+  import { loadKaizenGlobalConfig } from "./core/kaizen-config.js";
+  // ... before the call ...
+  let effectiveHarness = harness;
+  if (!effectiveHarness && !extendsOverride) {
+    const global = await loadKaizenGlobalConfig();
+    effectiveHarness = global.default_harness;
+  }
+  const kaizenConfig = resolveConfig({ harness: effectiveHarness, extendsOverride });
+  ```
+  Note: `loadKaizenGlobalConfig` is async. The surrounding context in `cli.ts` appears to already be async (top-level await is used in Bun). If it isn't, wrap the resolution in an `async function main()` and invoke it. Inspect lines 620–660 for context; adapt.
+
+- If any subcommand in `cli.ts` references `PROJECT_CONFIG` for an error message ("no .kaizen/kaizen.json found, run kaizen init"), update the message to say "no `~/.kaizen/kaizen.json` found, run `kaizen init --global`" (or similar, depending on context).
+
+- [ ] **Step 4: Update `src/commands/manage.ts`**
+
+Open `src/commands/manage.ts:19`. It currently reads:
+```typescript
+console.error("No .kaizen/kaizen.json found. Run 'kaizen init' to create one.");
+```
+Replace with:
+```typescript
+console.error("No ~/.kaizen/kaizen.json found. Run 'kaizen init --global' to create one.");
+```
+Replace any `PROJECT_CONFIG` imports with `kaizenHomeConfigPath()` from `./core/kaizen-config.js` (or `KAIZEN_HOME_CONFIG` from `./core/config.js` — whichever this file's other imports are consistent with). Re-run `bun run typecheck` to find remaining references.
+
+- [ ] **Step 5: Typecheck + test sweep**
+
+Run: `bun run typecheck`
+Expected: errors pointing at remaining references to deleted symbols (possibly in `src/commands/*.ts` or test files). Fix each one. Preferred fix: if a test references `PROJECT_CONFIG` / `findProjectConfig` / `mergeConfigs`, either rewrite it to exercise the new global-config path or delete the test if its invariant no longer exists.
+
+Run: `bun test`
+Expected: remaining failures from tests that rely on project-config merging. Triage each: rewrite if the test's *intent* is still valid under the new model; delete if it's testing deleted behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/config.ts src/cli.ts src/commands/manage.ts src/core/config-harness.test.ts
+# ... plus any other modified files ...
+git commit -m "refactor(config): delete legacy project config path (#34)"
+```
+
+---
+
+## Task 6: Add deprecation warnings for stale project-local config files
+
+**Files:**
+- Modify: `src/cli.ts` (early in the startup path, before `resolveConfig`)
+- Create: `src/core/deprecation-warn.ts` (small helper module)
+- Create: `src/core/deprecation-warn.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/core/deprecation-warn.test.ts`:
+
+```typescript
+import { test, expect, afterEach, beforeEach } from "bun:test";
+import { warnStaleProjectConfig } from "./deprecation-warn.js";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let cwdBackup: string;
+let dir: string;
+
+beforeEach(() => {
+  cwdBackup = process.cwd();
+  dir = mkdtempSync(join(tmpdir(), "kaizen-stalecfg-"));
+  process.chdir(dir);
+});
+
+afterEach(() => {
+  process.chdir(cwdBackup);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("warnStaleProjectConfig: warns when .kaizen/kaizen.json exists", () => {
+  mkdirSync(".kaizen");
+  writeFileSync(".kaizen/kaizen.json", "{}", "utf8");
+  const warnings: string[] = [];
+  warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
+  expect(warnings.length).toBe(1);
+  expect(warnings[0]).toMatch(/\.kaizen\/kaizen\.json/);
+  expect(warnings[0]).toMatch(/no longer supported/);
+});
+
+test("warnStaleProjectConfig: warns when root kaizen.json exists", () => {
+  writeFileSync("kaizen.json", "{}", "utf8");
+  const warnings: string[] = [];
+  warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
+  expect(warnings.length).toBe(1);
+  expect(warnings[0]).toMatch(/^|\skaizen\.json/);
+});
+
+test("warnStaleProjectConfig: silent when neither file exists", () => {
+  const warnings: string[] = [];
+  warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
+  expect(warnings).toEqual([]);
+});
+
+test("warnStaleProjectConfig: warns for both when both exist", () => {
+  mkdirSync(".kaizen");
+  writeFileSync(".kaizen/kaizen.json", "{}", "utf8");
+  writeFileSync("kaizen.json", "{}", "utf8");
+  const warnings: string[] = [];
+  warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
+  expect(warnings.length).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/deprecation-warn.test.ts`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/core/deprecation-warn.ts`:
+
+```typescript
+import { existsSync } from "fs";
+import { join } from "path";
+
+export interface WarnSink {
+  warn: (message: string) => void;
+}
+
+const PROJECT_LOCAL = join(".kaizen", "kaizen.json");
+const LEGACY_ROOT = "kaizen.json";
+
+const MESSAGE = (path: string) =>
+  `Found '${path}'. Project-level kaizen config is no longer supported. ` +
+  `Move 'extends' to '~/.kaizen/kaizen.json' as 'default_harness', ` +
+  `or pass --harness explicitly. See docs/concepts/configuration.md.`;
+
+export function warnStaleProjectConfig(sink: WarnSink): void {
+  if (existsSync(PROJECT_LOCAL)) sink.warn(MESSAGE(PROJECT_LOCAL));
+  if (existsSync(LEGACY_ROOT)) sink.warn(MESSAGE(LEGACY_ROOT));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/deprecation-warn.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire it into `src/cli.ts`**
+
+In `src/cli.ts`, near the top of the main execution path (before `resolveConfig` is called), add:
+
+```typescript
+import { warn } from "./core/errors.js";
+import { warnStaleProjectConfig } from "./core/deprecation-warn.js";
+// ...
+warnStaleProjectConfig({ warn });
+```
+
+The existing `warn` helper in `./core/errors.js` prints to stderr in the format the rest of kaizen uses. Place this call so it runs for every subcommand except `--help` / `-h` (don't pollute help output). A good spot is just before the `subcommand` switch begins, or wherever the config resolution block starts.
+
+- [ ] **Step 6: Smoke test manually**
+
+Run: `mkdir -p /tmp/kaizen-stale && cd /tmp/kaizen-stale && mkdir -p .kaizen && echo '{}' > .kaizen/kaizen.json && <path-to-built-kaizen> --help; cd -`
+
+Expected: a warning line mentioning `.kaizen/kaizen.json` prints to stderr (or, if `--help` is excluded, try a non-help command that will error out before doing real work; the warning should still print). If `--help` is excluded, run with some failing subcommand instead — just verify the warning appears.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/deprecation-warn.ts src/core/deprecation-warn.test.ts src/cli.ts
+git commit -m "feat(config): warn when legacy project config files are present (#34)"
+```
+
+---
+
+## Task 7: Rewrite `kaizen init` to be global-only
+
+**Files:**
+- Modify: `src/cli.ts` (the `kaizen init` subcommand, around line 141)
+- Modify: any cli test exercising init
+
+- [ ] **Step 1: Find existing init tests**
+
+Run: `grep -rn "kaizen init\|init.*--global" /Users/chancock/git/kaizen/src --include="*.test.ts"`
+
+Note the tests so you can update them in step 4.
+
+- [ ] **Step 2: Rewrite the subcommand**
+
+Open `src/cli.ts`, find the `if (subcommand === "init")` block (around line 141). Replace with:
+
+```typescript
+if (subcommand === "init") {
+  const isGlobal = rawArgs.includes("--global");
+  const harnessFlagIdx = rawArgs.findIndex((a) => a === "--harness");
+  const harnessRef = harnessFlagIdx >= 0 ? rawArgs[harnessFlagIdx + 1] : undefined;
+
+  if (!isGlobal) {
+    console.error(
+      `'kaizen init' now requires --global.\n` +
+      `Project-level kaizen config is no longer supported.\n` +
+      `Run: kaizen init --global [--harness <ref>]`,
+    );
+    process.exit(2);
+  }
+
+  if (existsSync(KAIZEN_HOME_CONFIG)) {
+    console.log(`~/.kaizen/kaizen.json already exists.`);
+    process.exit(0);
+  }
+
+  mkdirSync(KAIZEN_HOME, { recursive: true });
+  const body: Record<string, unknown> = {};
+  if (harnessRef) body.default_harness = harnessRef;
+  writeFileSync(KAIZEN_HOME_CONFIG, JSON.stringify(body, null, 2) + "\n", "utf8");
+
+  if (harnessRef) {
+    console.log(`Created ~/.kaizen/kaizen.json with default_harness=${harnessRef}`);
+  } else {
+    console.log(
+      `Created ~/.kaizen/kaizen.json.\n` +
+      `Pass --harness on each run, or add 'default_harness' to the file.`,
+    );
+  }
+  process.exit(0);
+}
+```
+
+Also delete the now-unused `DEFAULT_PLUGINS` constant (lines 80–96). The inline plugin list it contained was the source of #34; nothing references it after this change. Run `bun run typecheck` to confirm no callers remain before deleting.
+
+- [ ] **Step 3: Update `--help` output**
+
+Still in `src/cli.ts`, find the help text block (around line 103). Update the `init` line from:
+```
+  init [--global]                       scaffold kaizen.json (project or ~/.kaizen/)
+```
+to:
+```
+  init --global [--harness <ref>]       scaffold ~/.kaizen/kaizen.json
+```
+
+- [ ] **Step 4: Update init tests**
+
+Open whatever test files exercise `kaizen init`. Update them to:
+- Assert that `kaizen init` without `--global` exits non-zero with the project-config-not-supported message.
+- Assert that `kaizen init --global` writes `~/.kaizen/kaizen.json` (using `KAIZEN_HOME_OVERRIDE` for isolation).
+- Assert that `kaizen init --global --harness X` produces `{"default_harness": "X"}`.
+
+If no test file covers this today, create `src/cli-init.test.ts` with at least the three cases above. Use `Bun.spawn` or direct import of the subcommand logic (if it's extractable); simplest approach is a subprocess-level test that invokes `bun src/cli.ts init ...` with `KAIZEN_HOME_OVERRIDE` set to a tmpdir.
+
+- [ ] **Step 5: Run tests**
+
+Run: `bun test src/cli-init.test.ts` (or the existing file).
+Expected: PASS.
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli.ts src/cli-init.test.ts
+# ... plus any other touched test files ...
+git commit -m "feat(init): rewrite kaizen init as --global-only (#34)"
+```
+
+---
+
+## Task 8: Reproduce #34 and verify the fix
+
+**Files:**
+- Create: `src/core/issue-34.test.ts` (integration-style regression test)
+
+- [ ] **Step 1: Write the regression test**
+
+Create `src/core/issue-34.test.ts`:
+
+```typescript
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let dir: string;
+let cwdBackup: string;
+let homeBackup: string | undefined;
+
+beforeEach(() => {
+  cwdBackup = process.cwd();
+  dir = mkdtempSync(join(tmpdir(), "kaizen-issue-34-"));
+  process.chdir(dir);
+  homeBackup = process.env.KAIZEN_HOME_OVERRIDE;
+  process.env.KAIZEN_HOME_OVERRIDE = join(dir, "home");
+  mkdirSync(process.env.KAIZEN_HOME_OVERRIDE, { recursive: true });
+});
+
+afterEach(() => {
+  process.chdir(cwdBackup);
+  if (homeBackup === undefined) delete process.env.KAIZEN_HOME_OVERRIDE;
+  else process.env.KAIZEN_HOME_OVERRIDE = homeBackup;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("issue #34: local .kaizen/kaizen.json cannot clobber --harness plugin list", async () => {
+  // Set up a project-local kaizen.json that (under the old behavior) would
+  // silently replace the harness's plugins array.
+  mkdirSync(".kaizen", { recursive: true });
+  writeFileSync(".kaizen/kaizen.json", JSON.stringify({
+    plugins: ["evil/injected@0.0.0"],
+  }), "utf8");
+
+  // Build a minimal local-path harness with a known plugin list.
+  const harnessDir = join(dir, "harness");
+  mkdirSync(harnessDir, { recursive: true });
+  writeFileSync(join(harnessDir, "kaizen.json"), JSON.stringify({
+    plugins: ["official/core-cli@0.1.0"],
+  }), "utf8");
+
+  // Call resolveConfig explicitly — this is the function whose old behavior
+  // was buggy.
+  const { resolveConfig } = await import("./config.js");
+  const cfg = resolveConfig({ harness: "./harness" });
+
+  expect(cfg.plugins).toEqual(["official/core-cli@0.1.0"]);
+  // The "evil/injected" ref from project-local config must NOT appear.
+  expect(JSON.stringify(cfg)).not.toContain("evil/injected");
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bun test src/core/issue-34.test.ts`
+Expected: PASS (the preceding tasks have already removed the clobber path; this is a regression guard).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/issue-34.test.ts
+git commit -m "test(config): regression test for #34 harness-plugin-clobber"
+```
+
+---
+
+## Task 9: Update documentation
+
+**Files:**
+- Create: `docs/concepts/configuration.md`
+- Modify: `docs/concepts/harnesses.md`
+- Modify: `docs/guides/plugin-authoring.md`
+
+- [ ] **Step 1: Create `docs/concepts/configuration.md`**
+
+Create the file with:
+
+````markdown
+# Configuration
+
+Kaizen has exactly one user-editable config file: `~/.kaizen/kaizen.json`.
+
+## Schema
+
+```json
+{
+  "default_harness": "official/core-shell@1.0.0",
+  "plugin_config": {
+    "gitlab":   { "base_url": "https://gitlab.mycompany.com", "username": "alice" },
+    "core-cli": { "clis": ["docker", "kubectl"] }
+  },
+  "marketplaces": [
+    { "id": "official", "url": "https://github.com/CraightonH/kaizen-marketplace.git" }
+  ]
+}
+```
+
+### Fields
+
+- **`default_harness`** *(optional, string)* — harness ref used when `--harness` is not passed on the CLI.
+- **`plugin_config`** *(optional, object)* — per-plugin config overrides, keyed by plugin name.
+- **`marketplaces`** *(optional, array)* — registered marketplaces. Managed by `kaizen marketplace add/remove`.
+- **`marketplaceUpdateTTL`** *(optional, number)* — background marketplace refresh interval in seconds.
+
+Any other top-level key is a validation error.
+
+## Effective plugin config
+
+For each plugin `P` in the active harness:
+
+```
+effective_config(P) = { ...plugin_declared_defaults, ...harness_defaults, ...user_plugin_config }
+```
+
+User `plugin_config[P]` wins over harness defaults. Harness defaults win over the plugin's own declared defaults.
+
+## Choosing a harness
+
+The active harness is selected by:
+
+1. `--harness <ref>` on the CLI
+2. `default_harness` in `~/.kaizen/kaizen.json`
+3. Otherwise, kaizen refuses to start.
+
+## What moved
+
+Project-level kaizen config (`.kaizen/kaizen.json` overlay and root `kaizen.json`) is no longer supported. If you had one, move its `extends` value to `default_harness` in `~/.kaizen/kaizen.json`. If it had per-plugin config overrides, move those under `plugin_config` in the same file. Per-project config scoping will be revisited in a future release.
+````
+
+- [ ] **Step 2: Update `docs/concepts/harnesses.md`**
+
+Remove any section describing the project-level overlay or `extends` semantics. Add a link to `docs/concepts/configuration.md` for how user config interacts with the harness.
+
+Read the file first, then edit. Preserve everything that describes harness *authoring* — only cut the overlay/project-config discussion.
+
+- [ ] **Step 3: Update `docs/guides/plugin-authoring.md`**
+
+Add a short section titled "Plugin config keys" (or extend an existing one) documenting that plugin authors should enumerate the keys their plugin reads so users know what to put under `plugin_config.<plugin>` in `~/.kaizen/kaizen.json`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/concepts/configuration.md docs/concepts/harnesses.md docs/guides/plugin-authoring.md
+git commit -m "docs: document ~/.kaizen/kaizen.json single-config model (#34)"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 1: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean, no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `bun test`
+Expected: all tests pass.
+
+- [ ] **Step 3: Integration smoke test**
+
+Run: `bun test --integration` (the `test:integration` script exists in package.json).
+Expected: all pass. If any fail due to project-config assumptions, update them.
+
+- [ ] **Step 4: Manual smoke — the original #34 repro**
+
+```bash
+# Build
+bun run build
+
+# Create a fake project with legacy project config
+mkdir -p /tmp/kaizen-34-smoke && cd /tmp/kaizen-34-smoke
+mkdir -p .kaizen
+echo '{"plugins":["evil/injected@0.0.0"]}' > .kaizen/kaizen.json
+
+# Run with explicit harness — should warn about stale config and ignore it
+./path/to/kaizen --harness official/core-shell@<available-version> --help
+
+# Expected:
+#  - Warning printed: "Found .kaizen/kaizen.json. Project-level config is no longer supported..."
+#  - Help runs normally; no plugin consent prompt for "evil/injected"
+```
+
+- [ ] **Step 5: Run `kaizen:update-docs` skill**
+
+Per `CLAUDE.md`, run the kaizen docs-update skill on this branch before wrapping up.
+
+- [ ] **Step 6: Final commit if any loose ends**
+
+If any typecheck/test fixes accumulated, commit them:
+
+```bash
+git add -u
+git commit -m "chore(config): cleanup after #34 simplification"
+```
+
+---
+
+## Acceptance checklist
+
+Before declaring done, all of these must be true:
+
+- [ ] `bun run typecheck` passes.
+- [ ] `bun test` passes.
+- [ ] `bun test --integration` passes.
+- [ ] `src/core/config.ts` no longer exports `mergeConfigs`, `findProjectConfig`, `loadKaizenConfig`, `PROJECT_CONFIG`, or `LEGACY_CONFIG`.
+- [ ] `KaizenGlobalConfig` in `src/types/plugin.ts` uses `default_harness` and `plugin_config` (not `defaultHarness` / `defaults`).
+- [ ] `mergePluginConfig` spreads arguments in the order `declaration → harness → user` (user wins).
+- [ ] `loadKaizenGlobalConfig` rejects top-level `plugins`, `extends`, and unknown keys.
+- [ ] `kaizen init` without `--global` errors out; `kaizen init --global [--harness X]` writes the new schema.
+- [ ] Running kaizen in a cwd with `.kaizen/kaizen.json` prints the deprecation warning and does not merge that file into config.
+- [ ] `src/core/issue-34.test.ts` passes (regression guard).
+- [ ] `docs/concepts/configuration.md` exists.
+- [ ] Running `kaizen:update-docs` reports no drift.

--- a/docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md
+++ b/docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md
@@ -24,7 +24,7 @@ There is exactly one kaizen config file: `~/.kaizen/kaizen.json`. It holds exact
 
 ```json
 {
-  "extends": "official/core-shell@1.0.0",
+  "default_harness": "official/core-shell@1.0.0",
   "plugin_config": {
     "gitlab":   { "base_url": "https://gitlab.mycompany.com", "username": "alice" },
     "core-cli": { "clis": ["docker", "kubectl"] }
@@ -32,13 +32,14 @@ There is exactly one kaizen config file: `~/.kaizen/kaizen.json`. It holds exact
 }
 ```
 
-- **`extends`** (optional, string): the default harness ref used when `--harness` is not passed on the CLI.
+- **`default_harness`** (optional, string): the harness ref used when `--harness` is not passed on the CLI.
 - **`plugin_config`** (optional, object): per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects.
 
 Any other top-level key is a validation error. In particular:
 
 - **`plugins` is rejected.** The plugin set is defined by the harness. Users cannot add, remove, or replace plugins via config.
 - Unknown top-level keys fatal with a clear message listing the allowed keys.
+- A top-level `extends` key (the pre-change name) fatals with a targeted message telling the user to rename it to `default_harness`.
 
 ### No project-level config
 
@@ -53,7 +54,7 @@ Any other top-level key is a validation error. In particular:
 When kaizen starts, the active harness is selected by this precedence:
 
 1. `--harness <ref>` flag on the CLI.
-2. `extends` field in `~/.kaizen/kaizen.json`.
+2. `default_harness` field in `~/.kaizen/kaizen.json`.
 3. Fatal with guidance (same shape as today's error).
 
 Harness files keep their current schema: `plugins` is an array of refs, and per-plugin config keys may appear at the top level as defaults.
@@ -76,19 +77,19 @@ This is the entire configuration system. There is no other merge, no other overl
 - Delete `findProjectConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG`.
 - Rewrite `resolveConfig`:
   ```
-  1. Determine harness ref: opts.harness || global.extends || fatal.
+  1. Determine harness ref: opts.harness || global.default_harness || fatal.
   2. Load harness config.
   3. If ~/.kaizen/kaizen.json has plugin_config, apply the per-plugin shallow merge described above.
   4. Return the resulting effective config.
   ```
-- Add a validator for `~/.kaizen/kaizen.json` that rejects any top-level key outside `{extends, plugin_config}`, rejects `plugins` with a targeted message, and validates that `plugin_config` is an object of objects.
+- Add a validator for `~/.kaizen/kaizen.json` that rejects any top-level key outside `{default_harness, plugin_config}`, rejects `plugins` and `extends` with targeted messages, and validates that `plugin_config` is an object of objects.
 - Update `loadKaizenConfig` (or split into `loadUserConfig`) so the user-config validator is distinct from the harness validator. They have different schemas now.
 
 ### `kaizen init`
 
 Simplified to global-only:
 
-- `kaizen init --global [--harness <ref>]` writes `~/.kaizen/kaizen.json`. With `--harness`, the file is `{"extends": "<ref>"}`. Without it, the file is `{}` and the user is told they'll need `--harness` on each run or must add `extends` manually.
+- `kaizen init --global [--harness <ref>]` writes `~/.kaizen/kaizen.json`. With `--harness`, the file is `{"default_harness": "<ref>"}`. Without it, the file is `{}` and the user is told they'll need `--harness` on each run or must add `default_harness` manually.
 - `kaizen init` without `--global` prints an error pointing to `--global` (project-level init no longer exists).
 - Existing no-clobber behavior preserved: if `~/.kaizen/kaizen.json` already exists, print a message and exit 0.
 
@@ -97,7 +98,7 @@ Simplified to global-only:
 Users who have existing `.kaizen/kaizen.json` files (including ones produced by `kaizen init` pre-change) will see them become inert — kaizen no longer looks there. To avoid silent surprise:
 
 - On first run where `.kaizen/kaizen.json` exists and `~/.kaizen/kaizen.json` does not, print a prominent warning:
-  > Found `.kaizen/kaizen.json`. Project-level config is no longer supported. Move `extends` to `~/.kaizen/kaizen.json`, or pass `--harness` explicitly. See `docs/concepts/configuration.md`.
+  > Found `.kaizen/kaizen.json`. Project-level config is no longer supported. Move `extends` to `~/.kaizen/kaizen.json` as `default_harness`, or pass `--harness` explicitly. See `docs/concepts/configuration.md`.
 - Same warning for legacy root `kaizen.json`.
 - The warning reads the deprecated file only to surface useful info in the message; it is not merged into config.
 
@@ -114,7 +115,7 @@ Users whose existing `.kaizen/kaizen.json` contains plugin config overrides must
 Each of these was discussed during brainstorming and deliberately deferred:
 
 - **Per-project plugin config overrides.** The "different gitlab URL per project" use case is not supported in v1. Users fork a harness and tune defaults there, or live with one global config. Revisit once a consistent override architecture is designed.
-- **Per-project default harness.** No pointer file, no `.kaizen/harness`, no project config. Use `--harness` explicitly, or rely on the global `extends`.
+- **Per-project default harness.** No pointer file, no `.kaizen/harness`, no project config. Use `--harness` explicitly, or rely on the global `default_harness`.
 - **`kaizen harness fork`.** Deferred. When we revisit per-project configuration, fork ergonomics and lockfile-copy semantics become part of that design.
 - **File format change (YAML/JSONC).** Tracked in [#48](https://github.com/CraightonH/kaizen/issues/48). Will be decided holistically across harnesses, marketplaces, and user config.
 - **Secrets.** Already handled by `kaizen config set-secret` and the secret providers. No change.

--- a/docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md
+++ b/docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md
@@ -24,16 +24,23 @@ There is exactly one kaizen config file: `~/.kaizen/kaizen.json`. It holds exact
 
 ```json
 {
-  "default_harness": "official/core-shell@1.0.0",
-  "plugin_config": {
-    "gitlab":   { "base_url": "https://gitlab.mycompany.com", "username": "alice" },
-    "core-cli": { "clis": ["docker", "kubectl"] }
-  }
+  "defaults": {
+    "harness": "official/core-shell@1.0.0",
+    "plugin_config": {
+      "gitlab":   { "base_url": "https://gitlab.mycompany.com", "username": "alice" },
+      "core-cli": { "clis": ["docker", "kubectl"] }
+    }
+  },
+  "marketplaces": [
+    { "id": "official", "url": "https://github.com/example/marketplace.git" }
+  ]
 }
 ```
 
-- **`default_harness`** (optional, string): the harness ref used when `--harness` is not passed on the CLI.
-- **`plugin_config`** (optional, object): per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects.
+- **`defaults`** (optional, object): what this user defaults to when no CLI flag overrides it.
+  - **`defaults.harness`** (optional, string): the harness ref used when `--harness` is not passed on the CLI.
+  - **`defaults.plugin_config`** (optional, object): per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects.
+  - No other sub-keys of `defaults` are permitted. A sub-key that's a plugin name (the pre-change shape) fatals with a targeted message telling the user to nest it under `defaults.plugin_config`.
 
 The following pre-existing top-level keys are also allowed (they live at `~/.kaizen/kaizen.json` today and are orthogonal to the config-simplification work):
 
@@ -43,8 +50,9 @@ The following pre-existing top-level keys are also allowed (they live at `~/.kai
 Any other top-level key is a validation error. In particular:
 
 - **`plugins` is rejected.** The plugin set is defined by the harness. Users cannot add, remove, or replace plugins via config.
-- Unknown top-level keys fatal with a clear message listing the allowed keys.
-- A top-level `extends` key (the pre-change name) fatals with a targeted message telling the user to rename it to `default_harness`.
+- Unknown top-level keys fatal with a clear message listing the allowed keys (`defaults`, `marketplaces`, `marketplaceUpdateTTL`).
+- A top-level `extends` key (the pre-change name) fatals with a targeted message telling the user to move it to `defaults.harness`.
+- Top-level `default_harness` or `plugin_config` (names from an intermediate design) fatal with "move this under `defaults`".
 
 ### No project-level config
 
@@ -59,7 +67,7 @@ Any other top-level key is a validation error. In particular:
 When kaizen starts, the active harness is selected by this precedence:
 
 1. `--harness <ref>` flag on the CLI.
-2. `default_harness` field in `~/.kaizen/kaizen.json`.
+2. `defaults.harness` field in `~/.kaizen/kaizen.json`.
 3. Fatal with guidance (same shape as today's error).
 
 Harness files keep their current schema: `plugins` is an array of refs, and per-plugin config keys may appear at the top level as defaults.
@@ -76,7 +84,7 @@ Shallow merge, user wins on conflicts, harness wins over plugin's own declared d
 
 - `plugin_declared_defaults(P)` comes from the plugin's own `config.defaults` declaration.
 - `harness_defaults_for(P)` comes from the top-level `P`-keyed object inside the harness's `kaizen.json`.
-- `user_global_config_for(P)` comes from `plugin_config[P]` in `~/.kaizen/kaizen.json`.
+- `user_global_config_for(P)` comes from `defaults.plugin_config[P]` in `~/.kaizen/kaizen.json`.
 
 This is the entire configuration system. There is no other merge, no other overlay, no other precedence rule.
 
@@ -96,9 +104,9 @@ This is the entire configuration system. There is no other merge, no other overl
   ```
 
 **In `src/core/kaizen-config.ts` and `src/types/plugin.ts` (new canonical path — augment):**
-- Rename `KaizenGlobalConfig.defaultHarness` → `default_harness`.
-- Rename `KaizenGlobalConfig.defaults` → `plugin_config`.
-- Update `loadKaizenGlobalConfig` to validate: reject `plugins`, reject `extends` (with a "rename to default_harness" message), reject unknown top-level keys outside `{default_harness, plugin_config, marketplaces, marketplaceUpdateTTL}`.
+- Restructure `KaizenGlobalConfig`: replace top-level `defaultHarness` and flat `defaults` with a nested `defaults: { harness?: string; plugin_config?: Record<string, Record<string, unknown>> }`.
+- Update `loadKaizenGlobalConfig` to validate: reject top-level `plugins`, reject top-level `extends` (with a "move to defaults.harness" message), reject unknown top-level keys outside `{defaults, marketplaces, marketplaceUpdateTTL}`.
+- Within `defaults`, reject any sub-key other than `harness` or `plugin_config` (the old shape stored plugin-name keys directly under `defaults`; detect and explain migration).
 - `loadKaizenGlobalConfig` must stay tolerant of an absent file (returns `{}`), same as today.
 
 **In `src/core/config-merge.ts` (merge-order flip):**
@@ -106,7 +114,7 @@ This is the entire configuration system. There is no other merge, no other overl
 - Rename parameter `globalDefaults` → `userPluginConfig` for clarity.
 
 **In `src/core/plugin-manager.ts`:**
-- Update line ~637 to read `this.globalConfig?.plugin_config?.[plugin.name]` (was `defaults`).
+- Update line ~637 to read `this.globalConfig?.defaults?.plugin_config?.[plugin.name]` (was `defaults[plugin.name]`).
 
 **In `src/cli.ts`:**
 - Remove imports of `findProjectConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG`.
@@ -116,7 +124,7 @@ This is the entire configuration system. There is no other merge, no other overl
 
 Simplified to global-only:
 
-- `kaizen init --global [--harness <ref>]` writes `~/.kaizen/kaizen.json`. With `--harness`, the file is `{"default_harness": "<ref>"}`. Without it, the file is `{}` and the user is told they'll need `--harness` on each run or must add `default_harness` manually.
+- `kaizen init --global [--harness <ref>]` writes `~/.kaizen/kaizen.json`. With `--harness`, the file is `{"defaults": {"harness": "<ref>"}}`. Without it, the file is `{}` and the user is told they'll need `--harness` on each run or must add `defaults.harness` manually.
 - `kaizen init` without `--global` prints an error pointing to `--global` (project-level init no longer exists).
 - Existing no-clobber behavior preserved: if `~/.kaizen/kaizen.json` already exists, print a message and exit 0.
 
@@ -125,7 +133,7 @@ Simplified to global-only:
 Users who have existing `.kaizen/kaizen.json` files (including ones produced by `kaizen init` pre-change) will see them become inert — kaizen no longer looks there. To avoid silent surprise:
 
 - On first run where `.kaizen/kaizen.json` exists and `~/.kaizen/kaizen.json` does not, print a prominent warning:
-  > Found `.kaizen/kaizen.json`. Project-level config is no longer supported. Move `extends` to `~/.kaizen/kaizen.json` as `default_harness`, or pass `--harness` explicitly. See `docs/concepts/configuration.md`.
+  > Found `.kaizen/kaizen.json`. Project-level config is no longer supported. Move `extends` to `~/.kaizen/kaizen.json` as `defaults.harness`, or pass `--harness` explicitly. See `docs/concepts/configuration.md`.
 - Same warning for legacy root `kaizen.json`.
 - The warning reads the deprecated file only to surface useful info in the message; it is not merged into config.
 
@@ -142,7 +150,7 @@ Users whose existing `.kaizen/kaizen.json` contains plugin config overrides must
 Each of these was discussed during brainstorming and deliberately deferred:
 
 - **Per-project plugin config overrides.** The "different gitlab URL per project" use case is not supported in v1. Users fork a harness and tune defaults there, or live with one global config. Revisit once a consistent override architecture is designed.
-- **Per-project default harness.** No pointer file, no `.kaizen/harness`, no project config. Use `--harness` explicitly, or rely on the global `default_harness`.
+- **Per-project default harness.** No pointer file, no `.kaizen/harness`, no project config. Use `--harness` explicitly, or rely on the global `defaults.harness`.
 - **`kaizen harness fork`.** Deferred. When we revisit per-project configuration, fork ergonomics and lockfile-copy semantics become part of that design.
 - **File format change (YAML/JSONC).** Tracked in [#48](https://github.com/CraightonH/kaizen/issues/48). Will be decided holistically across harnesses, marketplaces, and user config.
 - **Secrets.** Already handled by `kaizen config set-secret` and the secret providers. No change.

--- a/docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md
+++ b/docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md
@@ -35,6 +35,11 @@ There is exactly one kaizen config file: `~/.kaizen/kaizen.json`. It holds exact
 - **`default_harness`** (optional, string): the harness ref used when `--harness` is not passed on the CLI.
 - **`plugin_config`** (optional, object): per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects.
 
+The following pre-existing top-level keys are also allowed (they live at `~/.kaizen/kaizen.json` today and are orthogonal to the config-simplification work):
+
+- **`marketplaces`** (array): registered marketplace refs, managed by `kaizen marketplace add/remove`.
+- **`marketplaceUpdateTTL`** (number): background marketplace refresh cadence.
+
 Any other top-level key is a validation error. In particular:
 
 - **`plugins` is rejected.** The plugin set is defined by the harness. Users cannot add, remove, or replace plugins via config.
@@ -64,26 +69,48 @@ Harness files keep their current schema: `plugins` is an array of refs, and per-
 For each plugin `P` in the active harness:
 
 ```
-effective_config(P) = { ...harness_defaults_for(P), ...user_global_config_for(P) }
+effective_config(P) = { ...plugin_declared_defaults(P), ...harness_defaults_for(P), ...user_global_config_for(P) }
 ```
 
-Shallow merge, user wins on conflicts. Applied only to plugin config — nothing else merges. `harness_defaults_for(P)` comes from the top-level `P`-keyed object inside the harness's `kaizen.json`. `user_global_config_for(P)` comes from `plugin_config[P]` in `~/.kaizen/kaizen.json`.
+Shallow merge, user wins on conflicts, harness wins over plugin's own declared defaults. Applied only to plugin config — nothing else merges.
+
+- `plugin_declared_defaults(P)` comes from the plugin's own `config.defaults` declaration.
+- `harness_defaults_for(P)` comes from the top-level `P`-keyed object inside the harness's `kaizen.json`.
+- `user_global_config_for(P)` comes from `plugin_config[P]` in `~/.kaizen/kaizen.json`.
 
 This is the entire configuration system. There is no other merge, no other overlay, no other precedence rule.
 
+**Note:** the existing `mergePluginConfig` in `src/core/config-merge.ts` currently orders these arguments `{ ...declaration, ...global, ...harness }` (harness wins). This must flip to `{ ...declaration, ...harness, ...global }` so the user's `~/.kaizen/kaizen.json` takes precedence over harness defaults — otherwise the north-star gitlab use case fails.
+
 ### Code changes
 
-- Delete `mergeConfigs` from `src/core/config.ts`.
+**In `src/core/config.ts` (legacy path — delete):**
+- Delete `mergeConfigs`.
 - Delete `findProjectConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG`.
+- Delete `loadKaizenConfig` (its only remaining caller is project/legacy/global paths we're removing).
 - Rewrite `resolveConfig`:
   ```
   1. Determine harness ref: opts.harness || global.default_harness || fatal.
-  2. Load harness config.
-  3. If ~/.kaizen/kaizen.json has plugin_config, apply the per-plugin shallow merge described above.
-  4. Return the resulting effective config.
+  2. Load harness config (via loadHarnessConfig, unchanged).
+  3. Return harness config as-is; per-plugin user overrides are applied in plugin-manager via mergePluginConfig.
   ```
-- Add a validator for `~/.kaizen/kaizen.json` that rejects any top-level key outside `{default_harness, plugin_config}`, rejects `plugins` and `extends` with targeted messages, and validates that `plugin_config` is an object of objects.
-- Update `loadKaizenConfig` (or split into `loadUserConfig`) so the user-config validator is distinct from the harness validator. They have different schemas now.
+
+**In `src/core/kaizen-config.ts` and `src/types/plugin.ts` (new canonical path — augment):**
+- Rename `KaizenGlobalConfig.defaultHarness` → `default_harness`.
+- Rename `KaizenGlobalConfig.defaults` → `plugin_config`.
+- Update `loadKaizenGlobalConfig` to validate: reject `plugins`, reject `extends` (with a "rename to default_harness" message), reject unknown top-level keys outside `{default_harness, plugin_config, marketplaces, marketplaceUpdateTTL}`.
+- `loadKaizenGlobalConfig` must stay tolerant of an absent file (returns `{}`), same as today.
+
+**In `src/core/config-merge.ts` (merge-order flip):**
+- Change `mergePluginConfig` from `{ ...declaration, ...globalDefaults, ...harnessConfig }` to `{ ...declaration, ...harnessConfig, ...globalDefaults }` so user globals win over harness defaults.
+- Rename parameter `globalDefaults` → `userPluginConfig` for clarity.
+
+**In `src/core/plugin-manager.ts`:**
+- Update line ~637 to read `this.globalConfig?.plugin_config?.[plugin.name]` (was `defaults`).
+
+**In `src/cli.ts`:**
+- Remove imports of `findProjectConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG`.
+- Rewrite `kaizen init` to global-only (see section below).
 
 ### `kaizen init`
 

--- a/docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md
+++ b/docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md
@@ -1,0 +1,147 @@
+# Kaizen config simplification (fix #34)
+
+**Status:** Draft
+**Tracks:** [#34](https://github.com/CraightonH/kaizen/issues/34)
+**Related:** [#48](https://github.com/CraightonH/kaizen/issues/48) (format question, out of scope)
+
+## Problem
+
+`kaizen --harness <ref>` run from a directory with `.kaizen/kaizen.json` silently lets the local config's `plugins` array replace the harness's plugin list (see `src/core/config.ts:168`). The user asked for a specific harness; kaizen ran a different plugin set without telling them.
+
+The root cause is conceptual: `.kaizen/kaizen.json` was trying to be three things at once — a harness selector (`extends`), a per-plugin config overlay, and an inline plugin list. Those three roles have conflicting merge semantics and their interaction has never been cleanly specified. The #34 clobber is the most visible symptom; other merge-bug classes lurk behind it.
+
+## North star
+
+The one user need kaizen cannot punt: **an installed plugin must be configurable for the user's environment.** Concrete example: a `gitlab` plugin ships with `base_url: https://gitlab.com`. A user of a self-hosted GitLab needs to override `base_url`, set their `username`, and store a token as a secret. Without this, plugins are hardcoded to their defaults and useless outside them.
+
+Every other "configuration" concern is out of scope for this change.
+
+## Design
+
+### Single config file
+
+There is exactly one kaizen config file: `~/.kaizen/kaizen.json`. It holds exactly two things:
+
+```json
+{
+  "extends": "official/core-shell@1.0.0",
+  "plugin_config": {
+    "gitlab":   { "base_url": "https://gitlab.mycompany.com", "username": "alice" },
+    "core-cli": { "clis": ["docker", "kubectl"] }
+  }
+}
+```
+
+- **`extends`** (optional, string): the default harness ref used when `--harness` is not passed on the CLI.
+- **`plugin_config`** (optional, object): per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects.
+
+Any other top-level key is a validation error. In particular:
+
+- **`plugins` is rejected.** The plugin set is defined by the harness. Users cannot add, remove, or replace plugins via config.
+- Unknown top-level keys fatal with a clear message listing the allowed keys.
+
+### No project-level config
+
+- `.kaizen/kaizen.json` (project overlay) is removed entirely.
+- Legacy root `kaizen.json` support is removed.
+- `findProjectConfig`, `PROJECT_CONFIG`, and `LEGACY_CONFIG` are deleted.
+- `.kaizen/harnesses/<name>/kaizen.json` (project-scoped harnesses) continues to work unchanged — that's a harness definition, not a config.
+- `.kaizen/marketplaces/` (project-scoped marketplaces) continues to work unchanged.
+
+### Harness resolution
+
+When kaizen starts, the active harness is selected by this precedence:
+
+1. `--harness <ref>` flag on the CLI.
+2. `extends` field in `~/.kaizen/kaizen.json`.
+3. Fatal with guidance (same shape as today's error).
+
+Harness files keep their current schema: `plugins` is an array of refs, and per-plugin config keys may appear at the top level as defaults.
+
+### The one overlay rule
+
+For each plugin `P` in the active harness:
+
+```
+effective_config(P) = { ...harness_defaults_for(P), ...user_global_config_for(P) }
+```
+
+Shallow merge, user wins on conflicts. Applied only to plugin config — nothing else merges. `harness_defaults_for(P)` comes from the top-level `P`-keyed object inside the harness's `kaizen.json`. `user_global_config_for(P)` comes from `plugin_config[P]` in `~/.kaizen/kaizen.json`.
+
+This is the entire configuration system. There is no other merge, no other overlay, no other precedence rule.
+
+### Code changes
+
+- Delete `mergeConfigs` from `src/core/config.ts`.
+- Delete `findProjectConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG`.
+- Rewrite `resolveConfig`:
+  ```
+  1. Determine harness ref: opts.harness || global.extends || fatal.
+  2. Load harness config.
+  3. If ~/.kaizen/kaizen.json has plugin_config, apply the per-plugin shallow merge described above.
+  4. Return the resulting effective config.
+  ```
+- Add a validator for `~/.kaizen/kaizen.json` that rejects any top-level key outside `{extends, plugin_config}`, rejects `plugins` with a targeted message, and validates that `plugin_config` is an object of objects.
+- Update `loadKaizenConfig` (or split into `loadUserConfig`) so the user-config validator is distinct from the harness validator. They have different schemas now.
+
+### `kaizen init`
+
+Simplified to global-only:
+
+- `kaizen init --global [--harness <ref>]` writes `~/.kaizen/kaizen.json`. With `--harness`, the file is `{"extends": "<ref>"}`. Without it, the file is `{}` and the user is told they'll need `--harness` on each run or must add `extends` manually.
+- `kaizen init` without `--global` prints an error pointing to `--global` (project-level init no longer exists).
+- Existing no-clobber behavior preserved: if `~/.kaizen/kaizen.json` already exists, print a message and exit 0.
+
+### Migration
+
+Users who have existing `.kaizen/kaizen.json` files (including ones produced by `kaizen init` pre-change) will see them become inert — kaizen no longer looks there. To avoid silent surprise:
+
+- On first run where `.kaizen/kaizen.json` exists and `~/.kaizen/kaizen.json` does not, print a prominent warning:
+  > Found `.kaizen/kaizen.json`. Project-level config is no longer supported. Move `extends` to `~/.kaizen/kaizen.json`, or pass `--harness` explicitly. See `docs/concepts/configuration.md`.
+- Same warning for legacy root `kaizen.json`.
+- The warning reads the deprecated file only to surface useful info in the message; it is not merged into config.
+
+Users whose existing `.kaizen/kaizen.json` contains plugin config overrides must move those entries under `plugin_config` in `~/.kaizen/kaizen.json`. The warning references the docs update.
+
+### Docs
+
+- `docs/concepts/harnesses.md`: remove the "local config overrides harness" section; describe the single overlay rule.
+- `docs/guides/plugin-authoring.md`: note that plugin authors should document each config key the plugin reads so users know what to put under `plugin_config.<plugin>`.
+- Add `docs/concepts/configuration.md` (new, short): the `~/.kaizen/kaizen.json` schema and the one merge rule.
+
+## What's explicitly out of scope
+
+Each of these was discussed during brainstorming and deliberately deferred:
+
+- **Per-project plugin config overrides.** The "different gitlab URL per project" use case is not supported in v1. Users fork a harness and tune defaults there, or live with one global config. Revisit once a consistent override architecture is designed.
+- **Per-project default harness.** No pointer file, no `.kaizen/harness`, no project config. Use `--harness` explicitly, or rely on the global `extends`.
+- **`kaizen harness fork`.** Deferred. When we revisit per-project configuration, fork ergonomics and lockfile-copy semantics become part of that design.
+- **File format change (YAML/JSONC).** Tracked in [#48](https://github.com/CraightonH/kaizen/issues/48). Will be decided holistically across harnesses, marketplaces, and user config.
+- **Secrets.** Already handled by `kaizen config set-secret` and the secret providers. No change.
+
+## Consequences
+
+### Resolved
+
+- **#34** dissolves by construction: no file exists to clobber the harness's plugin list.
+- Plugin authors can ship sensible defaults (via harness) and know users can override exactly the keys that matter via `plugin_config`.
+- The mental model collapses to: one harness, one user config, one merge rule.
+
+### Accepted trade-offs
+
+- Users who relied on `.kaizen/kaizen.json` to scope behavior per-repo lose that ability until the override architecture is redesigned. The migration warning surfaces this; the docs point at alternatives (`--harness` per invocation, or fork a harness).
+- `kaizen init` is less useful than before — it writes a nearly-empty file. Acceptable because the file it used to produce was misleading (DEFAULT_PLUGINS was inconsistent with the overlay semantics and contributed to #34).
+
+### Reversibility
+
+If a future override design requires project-level config, this simplification does not foreclose it — reintroducing a second layer is additive on top of the clean single-overlay rule. The change we're avoiding is trying to design that layer now without a clear use case.
+
+## Implementation order
+
+1. Add user-config validator (rejects `plugins`, unknown keys); drop `mergeConfigs` reliance on project config.
+2. Delete `findProjectConfig` and the project/legacy config branches of `resolveConfig`.
+3. Add the single-overlay `plugin_config` merge.
+4. Rewrite `kaizen init` for `--global`-only.
+5. Add the deprecation warning for existing `.kaizen/kaizen.json` / root `kaizen.json`.
+6. Update docs.
+7. Update fixtures and tests.

--- a/src/cli-init.test.ts
+++ b/src/cli-init.test.ts
@@ -1,9 +1,10 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 
-const CLI = "/Users/chancock/git/kaizen/src/cli.ts";
+const CLI = join(dirname(fileURLToPath(import.meta.url)), "cli.ts");
 
 let home: string;
 

--- a/src/cli-init.test.ts
+++ b/src/cli-init.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = "/Users/chancock/git/kaizen/src/cli.ts";
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kaizen-init-"));
+});
+
+afterEach(() => {
+  try { rmSync(home, { recursive: true, force: true }); } catch {}
+});
+
+async function run(args: string[]): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  const proc = Bun.spawn({
+    cmd: ["bun", CLI, ...args],
+    env: { ...process.env, KAIZEN_HOME_OVERRIDE: home },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+test("kaizen init without --global errors and exits 2", async () => {
+  const { code, stderr } = await run(["init"]);
+  expect(code).toBe(2);
+  expect(stderr).toMatch(/requires --global/);
+  expect(existsSync(join(home, "kaizen.json"))).toBe(false);
+});
+
+test("kaizen init --global writes {} when no --harness", async () => {
+  const { code } = await run(["init", "--global"]);
+  expect(code).toBe(0);
+  const file = join(home, "kaizen.json");
+  expect(existsSync(file)).toBe(true);
+  expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({});
+});
+
+test("kaizen init --global --harness X writes {defaults: {harness: X}}", async () => {
+  const { code, stdout } = await run(["init", "--global", "--harness", "example/foo@1.0.0"]);
+  expect(code).toBe(0);
+  expect(stdout).toMatch(/defaults\.harness=example\/foo@1\.0\.0/);
+  const body = JSON.parse(readFileSync(join(home, "kaizen.json"), "utf8"));
+  expect(body).toEqual({ defaults: { harness: "example/foo@1.0.0" } });
+});
+
+test("kaizen init --global is no-clobber when file exists", async () => {
+  writeFileSync(join(home, "kaizen.json"), '{"marketplaces":[]}\n', "utf8");
+  const { code, stdout } = await run(["init", "--global"]);
+  expect(code).toBe(0);
+  expect(stdout).toMatch(/already exists/);
+  const body = JSON.parse(readFileSync(join(home, "kaizen.json"), "utf8"));
+  expect(body).toEqual({ marketplaces: [] });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,8 +7,8 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { bootstrap } from "./core/index.js";
-import { resolveConfig, findProjectConfig, resolveHarness, PROJECT_DIR, PROJECT_CONFIG, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
-import { readFileSync } from "fs";
+import { resolveConfig, resolveHarness, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
+import { loadKaizenGlobalConfig } from "./core/kaizen-config.js";
 import { fatal } from "./core/errors.js";
 import { deriveLockfilePath } from "./core/lockfile-path.js";
 import {
@@ -59,41 +59,14 @@ function setCliList(config: Record<string, unknown>, clis: string[]): void {
   (config["core-cli"] as Record<string, unknown>)["clis"] = clis;
 }
 
-function resolveHarnessJsonPath(opts: { harness?: string; extendsOverride?: string; configPath?: string }): string {
+function resolveHarnessJsonPath(opts: { harness?: string; extendsOverride?: string }): string {
   if (opts.harness) return resolveHarness(opts.harness).kaizenJsonPath;
   if (opts.extendsOverride) return resolveHarness(opts.extendsOverride).kaizenJsonPath;
-  // Fallback: read extends out of the local (or global) config and resolve it.
-  const activePath = opts.configPath ?? findProjectConfig() ??
-    (existsSync(KAIZEN_HOME_CONFIG) ? KAIZEN_HOME_CONFIG : null);
-  if (activePath) {
-    try {
-      const raw = JSON.parse(readFileSync(activePath, "utf8")) as { extends?: unknown };
-      if (typeof raw.extends === "string") return resolveHarness(raw.extends).kaizenJsonPath;
-    } catch { /* resolveConfig will raise the right error */ }
-  }
   return fatal(
     `this command requires an active harness. Pass --harness <marketplace>/<name>@<version>, ` +
-    `or set 'extends' in kaizen.json. See docs/concepts/harnesses.md.`,
+    `or set 'defaults.harness' in ~/.kaizen/kaizen.json. See docs/concepts/harnesses.md.`,
   );
 }
-
-const DEFAULT_PLUGINS = {
-  plugins: [
-    "official/core-events@0.1.0",
-    "official/core-executor-anthropic@0.1.0",
-    "official/core-ui-terminal@0.1.0",
-    "official/core-cli@0.1.0",
-    "official/core-driver@0.1.0",
-  ],
-  "core-executor-anthropic": {
-    model: "claude-opus-4-6",
-  },
-  "core-cli": {
-    clis: [] as string[],
-    allow_destructive: false,
-    subprocess_timeout_ms: 30000,
-  },
-};
 
 // ---------------------------------------------------------------------------
 // Subcommand: kaizen --help | -h | help
@@ -108,7 +81,7 @@ Usage:
   kaizen <subcommand> [args]
 
 Subcommands:
-  init [--global]                       scaffold kaizen.json (project or ~/.kaizen/)
+  init --global [--harness <ref>]       scaffold ~/.kaizen/kaizen.json
   install <ref> [--allow-unscoped]      install a plugin or harness
   uninstall <ref> [--purge]             uninstall a plugin
   update [<ref>]                        update plugins
@@ -140,26 +113,36 @@ See docs/concepts/harnesses.md for harness configuration.`);
 
 if (subcommand === "init") {
   const isGlobal = rawArgs.includes("--global");
+  const harnessFlagIdx = rawArgs.findIndex((a) => a === "--harness");
+  const harnessRef = harnessFlagIdx >= 0 ? rawArgs[harnessFlagIdx + 1] : undefined;
 
-  if (isGlobal) {
-    if (existsSync(KAIZEN_HOME_CONFIG)) {
-      console.log(`~/.kaizen/kaizen.json already exists.`);
-      process.exit(0);
-    }
-    mkdirSync(KAIZEN_HOME, { recursive: true });
-    writeFileSync(KAIZEN_HOME_CONFIG, JSON.stringify(DEFAULT_PLUGINS, null, 2) + "\n", "utf8");
-    console.log(`Created ~/.kaizen/kaizen.json`);
-  } else {
-    if (existsSync(PROJECT_CONFIG)) {
-      console.log(`.kaizen/kaizen.json already exists.`);
-      process.exit(0);
-    }
-    mkdirSync(PROJECT_DIR, { recursive: true });
-    writeFileSync(PROJECT_CONFIG, JSON.stringify(DEFAULT_PLUGINS, null, 2) + "\n", "utf8");
-    console.log(`Created .kaizen/kaizen.json`);
+  if (!isGlobal) {
+    console.error(
+      `'kaizen init' now requires --global.\n` +
+      `Project-level kaizen config is no longer supported.\n` +
+      `Run: kaizen init --global [--harness <ref>]`,
+    );
+    process.exit(2);
   }
 
-  console.log(`Run 'kaizen add <cli>' to register CLI tools.`);
+  if (existsSync(KAIZEN_HOME_CONFIG)) {
+    console.log(`~/.kaizen/kaizen.json already exists.`);
+    process.exit(0);
+  }
+
+  mkdirSync(KAIZEN_HOME, { recursive: true });
+  const initBody: Record<string, unknown> = {};
+  if (harnessRef) initBody.defaults = { harness: harnessRef };
+  writeFileSync(KAIZEN_HOME_CONFIG, JSON.stringify(initBody, null, 2) + "\n", "utf8");
+
+  if (harnessRef) {
+    console.log(`Created ~/.kaizen/kaizen.json with defaults.harness=${harnessRef}`);
+  } else {
+    console.log(
+      `Created ~/.kaizen/kaizen.json.\n` +
+      `Pass --harness on each run, or add 'defaults.harness' to the file.`,
+    );
+  }
   process.exit(0);
 }
 
@@ -559,16 +542,14 @@ if (subcommand === "service") {
 // Subcommand: kaizen run [prompt]  (also: kaizen [flags])
 // ---------------------------------------------------------------------------
 
-const FLAGS_WITH_VALUE = new Set(["--harness", "--config"]);
+const FLAGS_WITH_VALUE = new Set(["--harness"]);
 
 function parseRunArgs(args: string[]): {
   harness?: string;
-  configPath?: string;
   allowDestructive: boolean;
   prompt?: string;
 } {
   let harness: string | undefined;
-  let configPath: string | undefined;
   let allowDestructive = false;
   const positional: string[] = [];
 
@@ -578,7 +559,6 @@ function parseRunArgs(args: string[]): {
     if (FLAGS_WITH_VALUE.has(arg)) {
       const val = args[i + 1] ?? "";
       if (arg === "--harness") harness = val;
-      if (arg === "--config") configPath = val;
       i += 2;
     } else if (arg === "--allow-destructive") {
       allowDestructive = true;
@@ -596,7 +576,6 @@ function parseRunArgs(args: string[]): {
 
   return {
     ...(harness !== undefined ? { harness } : {}),
-    ...(configPath !== undefined ? { configPath } : {}),
     allowDestructive,
     ...(prompt !== undefined ? { prompt } : {}),
   };
@@ -614,40 +593,25 @@ const allowUnscopedFlag = rawArgs.includes("--allow-unscoped");
 
 const { looksLikeHarnessRef, materializeHarnessRef } = await import("./core/kaizen-config.js");
 
-// Materialize a marketplace-ref --harness to a concrete path.
+// If no --harness on CLI, check ~/.kaizen/kaizen.json for defaults.harness.
 let harnessArg = parsed.harness;
+if (harnessArg === undefined) {
+  const globalCfgForHarness = await loadKaizenGlobalConfig();
+  harnessArg = globalCfgForHarness.defaults?.harness;
+}
+
+// Materialize a marketplace-ref --harness to a concrete path.
 if (harnessArg !== undefined && looksLikeHarnessRef(harnessArg)) {
   harnessArg = await materializeHarnessRef(harnessArg);
 }
 
-// Materialize a marketplace-ref `extends` in the local (or home) config,
-// so resolveConfig can stay sync.
-let extendsOverride: string | undefined;
-if (harnessArg === undefined) {
-  const activePath = parsed.configPath ?? findProjectConfig() ??
-    (existsSync(KAIZEN_HOME_CONFIG) ? KAIZEN_HOME_CONFIG : null);
-  if (activePath) {
-    try {
-      const raw = JSON.parse(readFileSync(activePath, "utf8")) as { extends?: unknown };
-      const ext = typeof raw.extends === "string" ? raw.extends : null;
-      if (ext && looksLikeHarnessRef(ext)) {
-        extendsOverride = await materializeHarnessRef(ext);
-      }
-    } catch { /* ignore; resolveConfig will surface parse errors */ }
-  }
-}
-
 const harnessJsonPath = resolveHarnessJsonPath({
   ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
-  ...(extendsOverride !== undefined ? { extendsOverride } : {}),
-  ...(parsed.configPath !== undefined ? { configPath: parsed.configPath } : {}),
 });
 const lockfilePath = deriveLockfilePath(harnessJsonPath);
 
 const kaizenConfig = resolveConfig({
   ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
-  ...(parsed.configPath !== undefined ? { configPath: parsed.configPath } : {}),
-  ...(extendsOverride !== undefined ? { extendsOverride } : {}),
 });
 
 // Bootstrap any missing marketplaces + plugins referenced by the harness.
@@ -674,9 +638,8 @@ if (parsed.prompt) {
 
 // Background marketplace refresh (non-blocking).
 {
-  const { loadKaizenGlobalConfig: loadGlobal2 } = await import("./core/kaizen-config.js");
   const { shouldRefresh, refreshInBackground } = await import("./core/marketplace.js");
-  const globalCfg = await loadGlobal2();
+  const globalCfg = await loadKaizenGlobalConfig();
   const ttl = globalCfg.marketplaceUpdateTTL ?? 900;
   for (const m of globalCfg.marketplaces ?? []) {
     if (shouldRefresh(m, ttl)) refreshInBackground(m.id);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,8 +92,7 @@ Subcommands:
 
 Flags:
   --harness <ref>                       harness ref (marketplace/name@version)
-  --config <path>                       alternate kaizen.json path
-  --trust-lockfile                      reuse existing lockfile; no prompts
+--trust-lockfile                      reuse existing lockfile; no prompts
   --non-interactive                     refuse any prompt-requiring consent
   --allow-unscoped                      permit non-interactive UNSCOPED consent
   --allow-destructive                   enable destructive CLI tools

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,7 +102,7 @@ Subcommands:
 
 Flags:
   --harness <ref>                       harness ref (marketplace/name@version)
---trust-lockfile                      reuse existing lockfile; no prompts
+  --trust-lockfile                      reuse existing lockfile; no prompts
   --non-interactive                     refuse any prompt-requiring consent
   --allow-unscoped                      permit non-interactive UNSCOPED consent
   --allow-destructive                   enable destructive CLI tools

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,8 @@ import { join } from "path";
 import { bootstrap } from "./core/index.js";
 import { resolveConfig, resolveHarness, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
 import { loadKaizenGlobalConfig } from "./core/kaizen-config.js";
-import { fatal } from "./core/errors.js";
+import { fatal, warn } from "./core/errors.js";
+import { warnStaleProjectConfig } from "./core/deprecation-warn.js";
 import { deriveLockfilePath } from "./core/lockfile-path.js";
 import {
   readLocalConfig,
@@ -115,6 +116,13 @@ Environment:
 See docs/concepts/harnesses.md for harness configuration.`);
   process.exit(0);
 }
+
+// ---------------------------------------------------------------------------
+// Deprecation check: warn if stale project-local config files are present.
+// Runs after --help so help output stays clean.
+// ---------------------------------------------------------------------------
+
+warnStaleProjectConfig({ warn });
 
 // ---------------------------------------------------------------------------
 // Subcommand: kaizen init [--global]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,15 +48,25 @@ const rawArgs = process.argv.slice(2);
 const subcommand = rawArgs[0];
 
 function getCliList(config: Record<string, unknown>): string[] {
-  const cliConfig = config["core-cli"] as Record<string, unknown> | undefined;
-  return (cliConfig?.["clis"] as string[] | undefined) ?? [];
+  const defaults = config["defaults"] as Record<string, unknown> | undefined;
+  const pluginConfig = defaults?.["plugin_config"] as Record<string, unknown> | undefined;
+  const coreCli = pluginConfig?.["core-cli"] as Record<string, unknown> | undefined;
+  return (coreCli?.["clis"] as string[] | undefined) ?? [];
 }
 
 function setCliList(config: Record<string, unknown>, clis: string[]): void {
-  if (typeof config["core-cli"] !== "object" || config["core-cli"] === null) {
-    config["core-cli"] = {};
+  if (typeof config["defaults"] !== "object" || config["defaults"] === null) {
+    config["defaults"] = {};
   }
-  (config["core-cli"] as Record<string, unknown>)["clis"] = clis;
+  const defaults = config["defaults"] as Record<string, unknown>;
+  if (typeof defaults["plugin_config"] !== "object" || defaults["plugin_config"] === null) {
+    defaults["plugin_config"] = {};
+  }
+  const pluginConfig = defaults["plugin_config"] as Record<string, unknown>;
+  if (typeof pluginConfig["core-cli"] !== "object" || pluginConfig["core-cli"] === null) {
+    pluginConfig["core-cli"] = {};
+  }
+  (pluginConfig["core-cli"] as Record<string, unknown>)["clis"] = clis;
 }
 
 function resolveHarnessJsonPath(opts: { harness?: string; extendsOverride?: string }): string {
@@ -160,7 +170,7 @@ if (subcommand === "add") {
     clis.push(cliName);
     setCliList(config, clis);
     writeLocalConfig(config);
-    console.log(`Added '${cliName}' to core-cli.clis.`);
+    console.log(`Added '${cliName}' to defaults.plugin_config.core-cli.clis.`);
   }
   process.exit(0);
 }
@@ -180,7 +190,7 @@ if (subcommand === "remove") {
   } else {
     setCliList(config, filtered);
     writeLocalConfig(config);
-    console.log(`Removed '${cliName}' from core-cli.clis.`);
+    console.log(`Removed '${cliName}' from defaults.plugin_config.core-cli.clis.`);
   }
   process.exit(0);
 }
@@ -490,9 +500,12 @@ if (subcommand === "plugin") {
   }
 
   switch (pluginSub) {
-    case "list":
-      cmdPluginList();
+    case "list": {
+      const harnessIdxForList = rawArgs.findIndex((a) => a === "--harness");
+      const harnessRefForList = harnessIdxForList >= 0 ? rawArgs[harnessIdxForList + 1] : undefined;
+      await cmdPluginList(harnessRefForList);
       break;
+    }
     case "install":
     case "remove":
       console.error(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { bootstrap } from "./core/index.js";
 import { resolveConfig, resolveHarness, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
-import { loadKaizenGlobalConfig } from "./core/kaizen-config.js";
+import { loadKaizenGlobalConfig, kaizenHome, kaizenHomeConfigPath } from "./core/kaizen-config.js";
 import { fatal, warn } from "./core/errors.js";
 import { warnStaleProjectConfig } from "./core/deprecation-warn.js";
 import { deriveLockfilePath } from "./core/lockfile-path.js";
@@ -125,7 +125,7 @@ See docs/concepts/harnesses.md for harness configuration.`);
 warnStaleProjectConfig({ warn });
 
 // ---------------------------------------------------------------------------
-// Subcommand: kaizen init [--global]
+// Subcommand: kaizen init --global [--harness <ref>]
 // ---------------------------------------------------------------------------
 
 if (subcommand === "init") {
@@ -142,15 +142,16 @@ if (subcommand === "init") {
     process.exit(2);
   }
 
-  if (existsSync(KAIZEN_HOME_CONFIG)) {
+  const homeConfigPath = kaizenHomeConfigPath();
+  if (existsSync(homeConfigPath)) {
     console.log(`~/.kaizen/kaizen.json already exists.`);
     process.exit(0);
   }
 
-  mkdirSync(KAIZEN_HOME, { recursive: true });
+  mkdirSync(kaizenHome(), { recursive: true });
   const initBody: Record<string, unknown> = {};
   if (harnessRef) initBody.defaults = { harness: harnessRef };
-  writeFileSync(KAIZEN_HOME_CONFIG, JSON.stringify(initBody, null, 2) + "\n", "utf8");
+  writeFileSync(homeConfigPath, JSON.stringify(initBody, null, 2) + "\n", "utf8");
 
   if (harnessRef) {
     console.log(`Created ~/.kaizen/kaizen.json with defaults.harness=${harnessRef}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { bootstrap } from "./core/index.js";
-import { resolveConfig, resolveHarness, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
+import { resolveHarnessOrFatal, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
 import { loadKaizenGlobalConfig, kaizenHome, kaizenHomeConfigPath } from "./core/kaizen-config.js";
 import { fatal, warn } from "./core/errors.js";
 import { warnStaleProjectConfig } from "./core/deprecation-warn.js";
@@ -71,12 +71,7 @@ function setCliList(config: Record<string, unknown>, clis: string[]): void {
 }
 
 function resolveHarnessJsonPath(opts: { harness?: string; extendsOverride?: string }): string {
-  if (opts.harness) return resolveHarness(opts.harness).kaizenJsonPath;
-  if (opts.extendsOverride) return resolveHarness(opts.extendsOverride).kaizenJsonPath;
-  return fatal(
-    `this command requires an active harness. Pass --harness <marketplace>/<name>@<version>, ` +
-    `or set 'defaults.harness' in ~/.kaizen/kaizen.json. See docs/concepts/harnesses.md.`,
-  );
+  return resolveHarnessOrFatal(opts).kaizenJsonPath;
 }
 
 // ---------------------------------------------------------------------------
@@ -387,7 +382,6 @@ if (subcommand === "plugin") {
   if (pluginSub === "dev" && rest.includes("--observe")) {
     const { runPluginDevObserve } = await import("./commands/plugin-dev.js");
     const { readFileSync } = await import("fs");
-    const { resolveConfig: resolveConfigInner } = await import("./core/config.js");
     const nameArg = rest.find((a) => !a.startsWith("--"));
     if (!nameArg) {
       console.error("usage: kaizen plugin dev --observe <plugin-dir>");
@@ -401,8 +395,9 @@ if (subcommand === "plugin") {
     // Honor --harness flag if provided
     const harnessIdx = rest.indexOf("--harness");
     const devHarnessArg = harnessIdx !== -1 ? rest[harnessIdx + 1] : undefined;
-    const devConfig = resolveConfigInner(devHarnessArg !== undefined ? { harness: devHarnessArg } : {});
-    const devHarnessJsonPath = resolveHarnessJsonPath(devHarnessArg !== undefined ? { harness: devHarnessArg } : {});
+    const { kaizenJsonPath: devHarnessJsonPath, config: devConfig } = resolveHarnessOrFatal(
+      devHarnessArg !== undefined ? { harness: devHarnessArg } : {},
+    );
     const devLockfilePath = deriveLockfilePath(devHarnessJsonPath);
     const code = await runPluginDevObserve({ pluginName, pluginDir, outDir, kaizenConfig: devConfig, lockfilePath: devLockfilePath });
     process.exit(code);
@@ -539,9 +534,8 @@ if (subcommand === "service") {
   const sub = rawArgs[1];
   const { serviceList, serviceShow } = await import("./commands/service.js");
   const { initializePluginSystem } = await import("./core/index.js");
-  const harnessJsonPath = resolveHarnessJsonPath({});
+  const { kaizenJsonPath: harnessJsonPath, config: cfg } = resolveHarnessOrFatal({});
   const lockfilePath = deriveLockfilePath(harnessJsonPath);
-  const cfg = resolveConfig({});
   const { serviceRegistry } = await initializePluginSystem(cfg, { lockfilePath });
   if (sub === "list") {
     serviceList(serviceRegistry);
@@ -626,14 +620,10 @@ if (harnessArg !== undefined && looksLikeHarnessRef(harnessArg)) {
   harnessArg = await materializeHarnessRef(harnessArg);
 }
 
-const harnessJsonPath = resolveHarnessJsonPath({
-  ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
-});
+const { kaizenJsonPath: harnessJsonPath, config: kaizenConfig } = resolveHarnessOrFatal(
+  harnessArg !== undefined ? { harness: harnessArg } : {},
+);
 const lockfilePath = deriveLockfilePath(harnessJsonPath);
-
-const kaizenConfig = resolveConfig({
-  ...(harnessArg !== undefined ? { harness: harnessArg } : {}),
-});
 
 // Bootstrap any missing marketplaces + plugins referenced by the harness.
 if ((kaizenConfig.marketplaces as unknown[])?.length || ((kaizenConfig.plugins as string[] | undefined) ?? []).some((p: string) => p.includes("/"))) {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,23 +1,12 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { dirname } from "path";
 import type { KaizenGlobalConfig } from "../types/plugin.js";
-import { PROJECT_CONFIG, KAIZEN_HOME_CONFIG } from "../core/config.js";
-
-function readProjectConfig(): Record<string, unknown> {
-  if (!existsSync(PROJECT_CONFIG)) return {};
-  try { return JSON.parse(readFileSync(PROJECT_CONFIG, "utf8")) as Record<string, unknown>; }
-  catch { return {}; }
-}
+import { KAIZEN_HOME_CONFIG } from "../core/config.js";
 
 function readGlobalConfig(): KaizenGlobalConfig {
   if (!existsSync(KAIZEN_HOME_CONFIG)) return {};
   try { return JSON.parse(readFileSync(KAIZEN_HOME_CONFIG, "utf8")) as KaizenGlobalConfig; }
   catch { return {}; }
-}
-
-function writeProjectConfig(config: Record<string, unknown>): void {
-  mkdirSync(dirname(PROJECT_CONFIG), { recursive: true });
-  writeFileSync(PROJECT_CONFIG, JSON.stringify(config, null, 2) + "\n", "utf8");
 }
 
 function writeGlobalConfig(config: KaizenGlobalConfig): void {
@@ -63,18 +52,12 @@ function coerceValue(raw: string, existing: unknown): unknown {
 }
 
 export function cmdConfigShow(pluginName?: string): number {
-  const project = readProjectConfig();
   const global = readGlobalConfig();
   const globalPluginConfig = global.defaults?.plugin_config ?? {};
 
-  const plugins = (project["plugins"] as string[] | undefined) ?? [];
   const allPluginNames = pluginName
     ? [pluginName]
-    : [...new Set([
-        ...plugins,
-        ...Object.keys(project).filter((k) => k !== "plugins" && k !== "extends"),
-        ...Object.keys(globalPluginConfig),
-      ])];
+    : Object.keys(globalPluginConfig);
 
   if (allPluginNames.length === 0) {
     console.log("No plugin configuration found.");
@@ -82,17 +65,15 @@ export function cmdConfigShow(pluginName?: string): number {
   }
 
   for (const name of allPluginNames) {
-    const harness = (project[name] as Record<string, unknown> | undefined) ?? {};
     const gDefaults = globalPluginConfig[name] ?? {};
-    const merged = { ...gDefaults, ...harness };
 
     console.log(`${name}:`);
-    for (const [key, value] of Object.entries(merged)) {
+    for (const [key, value] of Object.entries(gDefaults)) {
       if (typeof value === "object" && value !== null && "provider" in value) {
         const ref = value as { provider: string; ref: string };
-        console.log(`  ${key.padEnd(20)} *** (provider: ${ref.provider}, ref: ${ref.ref})  [harness]`);
+        console.log(`  ${key.padEnd(20)} *** (provider: ${ref.provider}, ref: ${ref.ref})  [global]`);
       } else {
-        console.log(`  ${key.padEnd(20)} ${JSON.stringify(value)}  [${harness[key] !== undefined ? "harness" : "global"}]`);
+        console.log(`  ${key.padEnd(20)} ${JSON.stringify(value)}  [global]`);
       }
     }
     console.log();
@@ -106,11 +87,8 @@ export function cmdConfigGet(pluginName: string | undefined, path: string | unde
     return 2;
   }
 
-  const project = readProjectConfig();
   const global = readGlobalConfig();
-  const harness = (project[pluginName] as Record<string, unknown> | undefined) ?? {};
-  const gDefaults = global.defaults?.plugin_config?.[pluginName] ?? {};
-  const merged = { ...gDefaults, ...harness };
+  const merged = global.defaults?.plugin_config?.[pluginName] ?? {};
 
   const value = getNestedValue(merged, path);
   if (value === undefined) {
@@ -138,27 +116,19 @@ export function cmdConfigSet(
     return 2;
   }
 
-  if (flags.global) {
-    const cfg = readGlobalConfig();
-    if (!cfg.defaults) cfg.defaults = {};
-    if (!cfg.defaults.plugin_config) cfg.defaults.plugin_config = {};
-    const pluginCfgMap = cfg.defaults.plugin_config;
-    if (!pluginCfgMap[pluginName]) pluginCfgMap[pluginName] = {};
-    const existing = getNestedValue(pluginCfgMap[pluginName]!, path);
-    setNestedValue(pluginCfgMap[pluginName]!, path, coerceValue(value, existing));
-    writeGlobalConfig(cfg);
-    console.log(`Set ${pluginName}.${path} in global config.`);
-  } else {
-    const cfg = readProjectConfig();
-    if (typeof cfg[pluginName] !== "object" || cfg[pluginName] === null) {
-      cfg[pluginName] = {};
-    }
-    const pluginCfg = cfg[pluginName] as Record<string, unknown>;
-    const existing = getNestedValue(pluginCfg, path);
-    setNestedValue(pluginCfg, path, coerceValue(value, existing));
-    writeProjectConfig(cfg);
-    console.log(`Set ${pluginName}.${path} in project config.`);
+  if (!flags.global) {
+    console.error("Project-level config is no longer supported. Use --global to write to ~/.kaizen/kaizen.json.");
+    return 2;
   }
+  const cfg = readGlobalConfig();
+  if (!cfg.defaults) cfg.defaults = {};
+  if (!cfg.defaults.plugin_config) cfg.defaults.plugin_config = {};
+  const pluginCfgMap = cfg.defaults.plugin_config;
+  if (!pluginCfgMap[pluginName]) pluginCfgMap[pluginName] = {};
+  const existing = getNestedValue(pluginCfgMap[pluginName]!, path);
+  setNestedValue(pluginCfgMap[pluginName]!, path, coerceValue(value, existing));
+  writeGlobalConfig(cfg);
+  console.log(`Set ${pluginName}.${path} in global config.`);
   return 0;
 }
 
@@ -221,20 +191,13 @@ export async function cmdConfigSetSecret(
     await fileProvider.set(ref, secretValue);
 
     const refObj = { provider: "kaizen", ref };
-    if (flags.global) {
-      const cfg = readGlobalConfig();
-      if (!cfg.defaults) cfg.defaults = {};
-      if (!cfg.defaults.plugin_config) cfg.defaults.plugin_config = {};
-      const pluginCfgMap = cfg.defaults.plugin_config;
-      if (!pluginCfgMap[pluginName]) pluginCfgMap[pluginName] = {};
-      pluginCfgMap[pluginName]![key] = refObj;
-      writeGlobalConfig(cfg);
-    } else {
-      const cfg = readProjectConfig();
-      if (typeof cfg[pluginName] !== "object" || cfg[pluginName] === null) cfg[pluginName] = {};
-      (cfg[pluginName] as Record<string, unknown>)[key] = refObj;
-      writeProjectConfig(cfg);
-    }
+    const cfg = readGlobalConfig();
+    if (!cfg.defaults) cfg.defaults = {};
+    if (!cfg.defaults.plugin_config) cfg.defaults.plugin_config = {};
+    const pluginCfgMap = cfg.defaults.plugin_config;
+    if (!pluginCfgMap[pluginName]) pluginCfgMap[pluginName] = {};
+    pluginCfgMap[pluginName]![key] = refObj;
+    writeGlobalConfig(cfg);
     console.log(`Secret stored. Ref: ${JSON.stringify(refObj)}`);
     return 0;
   } else {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -71,9 +71,9 @@ export function cmdConfigShow(pluginName?: string): number {
     for (const [key, value] of Object.entries(gDefaults)) {
       if (typeof value === "object" && value !== null && "provider" in value) {
         const ref = value as { provider: string; ref: string };
-        console.log(`  ${key.padEnd(20)} *** (provider: ${ref.provider}, ref: ${ref.ref})  [global]`);
+        console.log(`  ${key.padEnd(20)} *** (provider: ${ref.provider}, ref: ${ref.ref})`);
       } else {
-        console.log(`  ${key.padEnd(20)} ${JSON.stringify(value)}  [global]`);
+        console.log(`  ${key.padEnd(20)} ${JSON.stringify(value)}`);
       }
     }
     console.log();

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -65,7 +65,7 @@ function coerceValue(raw: string, existing: unknown): unknown {
 export function cmdConfigShow(pluginName?: string): number {
   const project = readProjectConfig();
   const global = readGlobalConfig();
-  const globalDefaults = (global.defaults ?? {}) as Record<string, Record<string, unknown>>;
+  const globalPluginConfig = global.defaults?.plugin_config ?? {};
 
   const plugins = (project["plugins"] as string[] | undefined) ?? [];
   const allPluginNames = pluginName
@@ -73,7 +73,7 @@ export function cmdConfigShow(pluginName?: string): number {
     : [...new Set([
         ...plugins,
         ...Object.keys(project).filter((k) => k !== "plugins" && k !== "extends"),
-        ...Object.keys(globalDefaults),
+        ...Object.keys(globalPluginConfig),
       ])];
 
   if (allPluginNames.length === 0) {
@@ -83,7 +83,7 @@ export function cmdConfigShow(pluginName?: string): number {
 
   for (const name of allPluginNames) {
     const harness = (project[name] as Record<string, unknown> | undefined) ?? {};
-    const gDefaults = globalDefaults[name] ?? {};
+    const gDefaults = globalPluginConfig[name] ?? {};
     const merged = { ...gDefaults, ...harness };
 
     console.log(`${name}:`);
@@ -109,7 +109,7 @@ export function cmdConfigGet(pluginName: string | undefined, path: string | unde
   const project = readProjectConfig();
   const global = readGlobalConfig();
   const harness = (project[pluginName] as Record<string, unknown> | undefined) ?? {};
-  const gDefaults = ((global.defaults as Record<string, Record<string, unknown>> | undefined)?.[pluginName]) ?? {};
+  const gDefaults = global.defaults?.plugin_config?.[pluginName] ?? {};
   const merged = { ...gDefaults, ...harness };
 
   const value = getNestedValue(merged, path);
@@ -141,10 +141,11 @@ export function cmdConfigSet(
   if (flags.global) {
     const cfg = readGlobalConfig();
     if (!cfg.defaults) cfg.defaults = {};
-    const defaults = cfg.defaults as Record<string, Record<string, unknown>>;
-    if (!defaults[pluginName]) defaults[pluginName] = {};
-    const existing = getNestedValue(defaults[pluginName]!, path);
-    setNestedValue(defaults[pluginName]!, path, coerceValue(value, existing));
+    if (!cfg.defaults.plugin_config) cfg.defaults.plugin_config = {};
+    const pluginCfgMap = cfg.defaults.plugin_config;
+    if (!pluginCfgMap[pluginName]) pluginCfgMap[pluginName] = {};
+    const existing = getNestedValue(pluginCfgMap[pluginName]!, path);
+    setNestedValue(pluginCfgMap[pluginName]!, path, coerceValue(value, existing));
     writeGlobalConfig(cfg);
     console.log(`Set ${pluginName}.${path} in global config.`);
   } else {
@@ -223,9 +224,10 @@ export async function cmdConfigSetSecret(
     if (flags.global) {
       const cfg = readGlobalConfig();
       if (!cfg.defaults) cfg.defaults = {};
-      const defaults = cfg.defaults as Record<string, Record<string, unknown>>;
-      if (!defaults[pluginName]) defaults[pluginName] = {};
-      defaults[pluginName][key] = refObj;
+      if (!cfg.defaults.plugin_config) cfg.defaults.plugin_config = {};
+      const pluginCfgMap = cfg.defaults.plugin_config;
+      if (!pluginCfgMap[pluginName]) pluginCfgMap[pluginName] = {};
+      pluginCfgMap[pluginName]![key] = refObj;
       writeGlobalConfig(cfg);
     } else {
       const cfg = readProjectConfig();

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, writeFileSync } from "fs";
+import { readFileSync } from "fs";
 import { join } from "path";
 import type { PluginPermissions, MarketplaceCatalog } from "../types/plugin.js";
 import { parseRef, resolveRef } from "../core/ref-resolver.js";
@@ -12,7 +12,6 @@ import { canonicalTierGrantHash } from "../core/plugin-hash.js";
 import { renderScopedUAC, renderUnscopedUAC } from "../core/uac-renderer.js";
 import { decideConsent } from "../core/consent-flow.js";
 import { readStdinLine } from "./cli-readline.js";
-import { PROJECT_CONFIG } from "../core/config.js";
 import { mergePluginConfig, separateSecrets } from "../core/config-merge.js";
 import { validateConfig, validateSchemaItself } from "../core/config-validator.js";
 
@@ -50,16 +49,7 @@ export async function runUnifiedInstall(args: UnifiedInstallArgs): Promise<numbe
       console.error(`plugin '${plugin.name}': config.schema is not valid JSON Schema`);
       return 1;
     }
-    const harnessConfig = (() => {
-      try {
-        if (existsSync(PROJECT_CONFIG)) {
-          const cfg = JSON.parse(readFileSync(PROJECT_CONFIG, "utf8")) as Record<string, unknown>;
-          return (cfg[plugin.name] as Record<string, unknown>) ?? {};
-        }
-      } catch { /* ignore */ }
-      return {};
-    })();
-    const merged = mergePluginConfig(plugin.config, {}, harnessConfig);
+    const merged = mergePluginConfig(plugin.config, {}, {});
     const { config: nonSecretConfig } = separateSecrets(merged, plugin.config.secrets ?? []);
     const errors = validateConfig(plugin.config.schema, nonSecretConfig);
     if (errors.length > 0) {
@@ -84,12 +74,10 @@ export async function runUnifiedInstall(args: UnifiedInstallArgs): Promise<numbe
   switch (decision.kind) {
     case "accept":
       console.log(`plugin '${resolved.entry.name}' already in lockfile (no changes).`);
-      await maybeAppendProjectPlugin(canonical);
       return 0;
 
     case "accept-and-record": {
       writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, resolved.entry.name, decision.entry));
-      await maybeAppendProjectPlugin(canonical);
       console.log(`plugin '${resolved.entry.name}' recorded (tier: ${decision.entry.tier}).`);
       return 0;
     }
@@ -100,7 +88,6 @@ export async function runUnifiedInstall(args: UnifiedInstallArgs): Promise<numbe
       const answer = (await readStdinLine()).trim().toLowerCase();
       if (answer === "a" || answer === "accept") {
         writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, resolved.entry.name, decision.entry));
-        await maybeAppendProjectPlugin(canonical);
         console.log(`plugin '${resolved.entry.name}' accepted and recorded.`);
         return 0;
       }
@@ -118,7 +105,6 @@ export async function runUnifiedInstall(args: UnifiedInstallArgs): Promise<numbe
       }
       const entry: LockfileEntry = { ...decision.entry, consentMode: "interactive" };
       writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, resolved.entry.name, entry));
-      await maybeAppendProjectPlugin(canonical);
       console.log(`plugin '${resolved.entry.name}' accepted as UNSCOPED and recorded.`);
       return 0;
     }
@@ -136,16 +122,6 @@ async function loadAllCatalogs(): Promise<Record<string, MarketplaceCatalog>> {
     try { out[ref.id] = await readCatalog(ref.id); } catch { /* skip bad */ }
   }
   return out;
-}
-
-async function maybeAppendProjectPlugin(canonicalRef: string): Promise<void> {
-  if (!existsSync(PROJECT_CONFIG)) return;
-  const cfg = JSON.parse(readFileSync(PROJECT_CONFIG, "utf8")) as { plugins?: string[] };
-  cfg.plugins ??= [];
-  if (!cfg.plugins.includes(canonicalRef)) {
-    cfg.plugins.push(canonicalRef);
-    writeFileSync(PROJECT_CONFIG, JSON.stringify(cfg, null, 2) + "\n", "utf8");
-  }
 }
 
 /** @deprecated use runUnifiedInstall. Retained for one release for cli.ts callers. */

--- a/src/commands/manage.ts
+++ b/src/commands/manage.ts
@@ -3,9 +3,9 @@
  *   plugin list               — list plugins with install status
  */
 
-import { existsSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
-import { findProjectConfig, PROJECT_CONFIG } from "../core/config.js";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { KAIZEN_HOME_CONFIG } from "../core/config.js";
 import { pluginInstallDir } from "../core/kaizen-config.js";
 import { parseRef } from "../core/ref-resolver.js";
 
@@ -14,16 +14,16 @@ import { parseRef } from "../core/ref-resolver.js";
 // ---------------------------------------------------------------------------
 
 export function readLocalConfig(): Record<string, unknown> {
-  const configPath = findProjectConfig();
-  if (!configPath) {
-    console.error("No .kaizen/kaizen.json found. Run 'kaizen init' to create one.");
+  if (!existsSync(KAIZEN_HOME_CONFIG)) {
+    console.error("No ~/.kaizen/kaizen.json found. Run 'kaizen init --global' to create one.");
     process.exit(1);
   }
-  return JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+  return JSON.parse(readFileSync(KAIZEN_HOME_CONFIG, "utf8")) as Record<string, unknown>;
 }
 
 export function writeLocalConfig(config: Record<string, unknown>): void {
-  writeFileSync(PROJECT_CONFIG, JSON.stringify(config, null, 2) + "\n", "utf8");
+  mkdirSync(dirname(KAIZEN_HOME_CONFIG), { recursive: true });
+  writeFileSync(KAIZEN_HOME_CONFIG, JSON.stringify(config, null, 2) + "\n", "utf8");
 }
 
 function getPlugins(config: Record<string, unknown>): string[] {

--- a/src/commands/manage.ts
+++ b/src/commands/manage.ts
@@ -5,8 +5,8 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
-import { KAIZEN_HOME_CONFIG } from "../core/config.js";
-import { pluginInstallDir } from "../core/kaizen-config.js";
+import { KAIZEN_HOME_CONFIG, loadHarnessConfig } from "../core/config.js";
+import { pluginInstallDir, loadKaizenGlobalConfig, looksLikeHarnessRef, materializeHarnessRef } from "../core/kaizen-config.js";
 import { parseRef } from "../core/ref-resolver.js";
 
 // ---------------------------------------------------------------------------
@@ -24,10 +24,6 @@ export function readLocalConfig(): Record<string, unknown> {
 export function writeLocalConfig(config: Record<string, unknown>): void {
   mkdirSync(dirname(KAIZEN_HOME_CONFIG), { recursive: true });
   writeFileSync(KAIZEN_HOME_CONFIG, JSON.stringify(config, null, 2) + "\n", "utf8");
-}
-
-function getPlugins(config: Record<string, unknown>): string[] {
-  return (config["plugins"] as string[] | undefined) ?? [];
 }
 
 // ---------------------------------------------------------------------------
@@ -58,12 +54,31 @@ function statusFor(name: string): InstallStatus {
 // kaizen plugin list
 // ---------------------------------------------------------------------------
 
-export function cmdPluginList(): void {
-  const config = readLocalConfig();
-  const plugins = getPlugins(config);
+export async function cmdPluginList(harnessRef?: string): Promise<void> {
+  // Resolve active harness: CLI flag takes precedence, then defaults.harness.
+  let resolvedRef = harnessRef;
+  if (!resolvedRef) {
+    const globalCfg = await loadKaizenGlobalConfig();
+    resolvedRef = globalCfg.defaults?.harness;
+  }
+
+  if (!resolvedRef) {
+    console.log(
+      "No harness active. Pass --harness or set defaults.harness in ~/.kaizen/kaizen.json.",
+    );
+    return;
+  }
+
+  // Materialize marketplace refs (e.g. "official/core-shell@0.1.0") to local paths.
+  if (looksLikeHarnessRef(resolvedRef)) {
+    resolvedRef = await materializeHarnessRef(resolvedRef);
+  }
+
+  const harnessConfig = loadHarnessConfig(resolvedRef);
+  const plugins = (harnessConfig["plugins"] as string[] | undefined) ?? [];
 
   if (plugins.length === 0) {
-    console.log("No plugins configured in kaizen.json.");
+    console.log("No plugins configured in the active harness.");
     return;
   }
 

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, rmSync } from "fs";
-import { PROJECT_CONFIG } from "../core/config.js";
+import { rmSync } from "fs";
 import { readLockfile, writeLockfile, removePluginEntry } from "../core/lockfile.js";
 import { loadKaizenGlobalConfig } from "../core/kaizen-config.js";
 import { readCatalog } from "../core/marketplace.js";
@@ -31,18 +30,6 @@ export async function runUninstall(args: UninstallArgs): Promise<number> {
       rmSync(pluginInstallDir(r.marketplaceId, r.entry.name, r.version), { recursive: true, force: true });
     }
   } catch { /* uninstall still removes from harness + lockfile */ }
-
-  // Remove from project harness.
-  if (existsSync(PROJECT_CONFIG)) {
-    const h = JSON.parse(readFileSync(PROJECT_CONFIG, "utf8")) as { plugins?: string[] };
-    const before = h.plugins?.length ?? 0;
-    h.plugins = (h.plugins ?? []).filter((p) =>
-      p !== name && (canonicalPrefix ? !p.startsWith(canonicalPrefix) : true),
-    );
-    if ((h.plugins?.length ?? 0) !== before) {
-      writeFileSync(PROJECT_CONFIG, JSON.stringify(h, null, 2) + "\n", "utf8");
-    }
-  }
 
   // Remove from lockfile when --purge.
   if (args.purge) {

--- a/src/core/config-harness.test.ts
+++ b/src/core/config-harness.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { resolveHarness, resolveConfig } from "./config.js";
+import { resolveHarness, resolveHarnessOrFatal } from "./config.js";
 
 let tmp: string;
 let cwdOrig: string;
@@ -54,25 +54,25 @@ describe("resolveHarness", () => {
   });
 });
 
-describe("resolveConfig", () => {
+describe("resolveHarnessOrFatal", () => {
   test("errors when no harness provided", () => {
-    expect(() => resolveConfig({})).toThrow(/harness is required/i);
+    expect(() => resolveHarnessOrFatal({})).toThrow(/harness is required/i);
   });
 
   test("succeeds with explicit harness name", () => {
     const dir = join(tmp, ".kaizen", "harnesses", "dev");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: ["a"] }));
-    const cfg = resolveConfig({ harness: "dev" });
-    expect(cfg.plugins).toEqual(["a"]);
+    const { config } = resolveHarnessOrFatal({ harness: "dev" });
+    expect(config.plugins).toEqual(["a"]);
   });
 
   test("succeeds with extendsOverride", () => {
     const dir = join(tmp, ".kaizen", "harnesses", "base");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: ["x"] }));
-    const cfg = resolveConfig({ extendsOverride: "base" });
-    expect(cfg.plugins).toEqual(["x"]);
+    const { config } = resolveHarnessOrFatal({ extendsOverride: "base" });
+    expect(config.plugins).toEqual(["x"]);
   });
 
   test("harness plugins are returned unchanged (no project-config overlay)", () => {
@@ -82,8 +82,8 @@ describe("resolveConfig", () => {
     // Even if a project .kaizen/kaizen.json exists, it is NOT merged into the harness config.
     mkdirSync(join(tmp, ".kaizen"), { recursive: true });
     writeFileSync(join(tmp, ".kaizen", "kaizen.json"), JSON.stringify({ plugins: ["evil/injected@0.0.0"] }));
-    const cfg = resolveConfig({ harness: "official" });
-    expect(cfg.plugins).toEqual(["official/core-cli@0.1.0"]);
-    expect(JSON.stringify(cfg)).not.toContain("evil/injected");
+    const { config } = resolveHarnessOrFatal({ harness: "official" });
+    expect(config.plugins).toEqual(["official/core-cli@0.1.0"]);
+    expect(JSON.stringify(config)).not.toContain("evil/injected");
   });
 });

--- a/src/core/config-harness.test.ts
+++ b/src/core/config-harness.test.ts
@@ -54,14 +54,12 @@ describe("resolveHarness", () => {
   });
 });
 
-describe("resolveConfig — named harness required", () => {
-  test("errors when no --harness and no extends in config", () => {
-    mkdirSync(join(tmp, ".kaizen"), { recursive: true });
-    writeFileSync(join(tmp, ".kaizen", "kaizen.json"), JSON.stringify({ plugins: [] }));
-    expect(() => resolveConfig({})).toThrow(/named harness required/i);
+describe("resolveConfig", () => {
+  test("errors when no harness provided", () => {
+    expect(() => resolveConfig({})).toThrow(/harness is required/i);
   });
 
-  test("succeeds with --harness", () => {
+  test("succeeds with explicit harness name", () => {
     const dir = join(tmp, ".kaizen", "harnesses", "dev");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: ["a"] }));
@@ -69,13 +67,23 @@ describe("resolveConfig — named harness required", () => {
     expect(cfg.plugins).toEqual(["a"]);
   });
 
-  test("succeeds when local config has extends", () => {
-    const h = join(tmp, ".kaizen", "harnesses", "base");
-    mkdirSync(h, { recursive: true });
-    writeFileSync(join(h, "kaizen.json"), JSON.stringify({ plugins: ["x"] }));
-    mkdirSync(join(tmp, ".kaizen"), { recursive: true });
-    writeFileSync(join(tmp, ".kaizen", "kaizen.json"), JSON.stringify({ extends: "base" }));
-    const cfg = resolveConfig({});
+  test("succeeds with extendsOverride", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "base");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: ["x"] }));
+    const cfg = resolveConfig({ extendsOverride: "base" });
     expect(cfg.plugins).toEqual(["x"]);
+  });
+
+  test("harness plugins are returned unchanged (no project-config overlay)", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "official");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "kaizen.json"), JSON.stringify({ plugins: ["official/core-cli@0.1.0"] }));
+    // Even if a project .kaizen/kaizen.json exists, it is NOT merged into the harness config.
+    mkdirSync(join(tmp, ".kaizen"), { recursive: true });
+    writeFileSync(join(tmp, ".kaizen", "kaizen.json"), JSON.stringify({ plugins: ["evil/injected@0.0.0"] }));
+    const cfg = resolveConfig({ harness: "official" });
+    expect(cfg.plugins).toEqual(["official/core-cli@0.1.0"]);
+    expect(JSON.stringify(cfg)).not.toContain("evil/injected");
   });
 });

--- a/src/core/config-merge.test.ts
+++ b/src/core/config-merge.test.ts
@@ -2,14 +2,37 @@ import { test, expect, describe, afterEach } from "bun:test";
 import { mergePluginConfig, separateSecrets, applyEnvOverrides, envVarNameFor } from "./config-merge";
 
 describe("mergePluginConfig", () => {
-  test("plugin defaults < global defaults < harness config (right wins)", () => {
+  test("mergePluginConfig: user global wins over harness default", () => {
+    const declaration = { defaults: { base_url: "https://gitlab.com", timeout: 30 } };
+    const userPluginConfig = { base_url: "https://gitlab.mycompany.com" };
+    const harnessConfig = { base_url: "https://harness.example.com" };
+
+    const merged = mergePluginConfig(declaration, userPluginConfig, harnessConfig);
+
+    expect(merged).toEqual({
+      base_url: "https://gitlab.mycompany.com", // user wins
+      timeout: 30,                              // declaration fallback preserved
+    });
+  });
+
+  test("mergePluginConfig: harness wins over plugin declaration defaults", () => {
+    const declaration = { defaults: { base_url: "plugin-default" } };
+    const userPluginConfig = {};
+    const harnessConfig = { base_url: "harness-default" };
+
+    const merged = mergePluginConfig(declaration, userPluginConfig, harnessConfig);
+
+    expect(merged.base_url).toBe("harness-default");
+  });
+
+  test("plugin defaults < harness config < user config (right wins)", () => {
     const declaration = {
       defaults: { timeout: 5000, retries: 2 },
     };
-    const globalDefaults = { timeout: 10000 };
+    const userPluginConfig = { timeout: 10000 };
     const harnessConfig = { retries: 5 };
 
-    const result = mergePluginConfig(declaration, globalDefaults, harnessConfig);
+    const result = mergePluginConfig(declaration, userPluginConfig, harnessConfig);
 
     expect(result).toEqual({
       timeout: 10000,
@@ -37,10 +60,10 @@ describe("mergePluginConfig", () => {
   });
 
   test("undefined declaration defaults to empty object", () => {
-    const globalDefaults = { timeout: 5000 };
+    const userPluginConfig = { timeout: 5000 };
     const harnessConfig = { retries: 3 };
 
-    const result = mergePluginConfig(undefined, globalDefaults, harnessConfig);
+    const result = mergePluginConfig(undefined, userPluginConfig, harnessConfig);
 
     expect(result).toEqual({
       timeout: 5000,

--- a/src/core/config-merge.ts
+++ b/src/core/config-merge.ts
@@ -2,13 +2,13 @@ import type { PluginConfigDeclaration, SecretRef, StructuredSecretRef } from "..
 
 export function mergePluginConfig(
   declaration: PluginConfigDeclaration | undefined,
-  globalDefaults: Record<string, unknown>,
+  userPluginConfig: Record<string, unknown>,
   harnessConfig: Record<string, unknown>,
 ): Record<string, unknown> {
   return {
     ...(declaration?.defaults ?? {}),
-    ...globalDefaults,
     ...harnessConfig,
+    ...userPluginConfig,
   };
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import type { KaizenConfig } from "../types/plugin.js";
-import { fatal, warn } from "./errors.js";
+import { fatal } from "./errors.js";
 
 // ---------------------------------------------------------------------------
 // Well-known paths
@@ -13,11 +13,7 @@ export const KAIZEN_HOME_CONFIG = join(KAIZEN_HOME, "kaizen.json");
 export const KAIZEN_HOME_HARNESSES = join(KAIZEN_HOME, "harnesses");
 
 export const PROJECT_DIR = ".kaizen";
-export const PROJECT_CONFIG = join(PROJECT_DIR, "kaizen.json");
 export const PROJECT_HARNESSES = join(PROJECT_DIR, "harnesses");
-
-/** Legacy root-level kaizen.json — supported during migration. */
-export const LEGACY_CONFIG = "kaizen.json";
 
 // Reserved top-level keys — not treated as plugin config namespaces.
 export const RESERVED_KEYS = new Set(["plugins", "extends"]);
@@ -85,7 +81,7 @@ export function loadHarnessConfig(nameOrPath: string): KaizenConfig {
 // Config loading
 // ---------------------------------------------------------------------------
 
-function validateConfig(config: Record<string, unknown>, source: string): void {
+function validateHarnessConfig(config: Record<string, unknown>, source: string): void {
   for (const [key, value] of Object.entries(config)) {
     if (Array.isArray(value) && value.some((v) => v === null || v === undefined)) {
       fatal(`Config error: '${key}' array in ${source} contains null/undefined entries.`);
@@ -104,154 +100,40 @@ function parseAndValidateHarness(path: string, label: string): KaizenConfig {
     fatal(`${path} must be a JSON object.`);
   }
   const config = raw as Record<string, unknown>;
-  validateConfig(config, path);
+  validateHarnessConfig(config, path);
   if (!config["plugins"]) fatal(`Harness '${label}' kaizen.json is missing 'plugins'.`);
   if (!Array.isArray(config["plugins"])) fatal(`Harness '${label}' kaizen.json 'plugins' must be an array.`);
   return config as KaizenConfig;
 }
 
-function parseConfigFile(path: string): Record<string, unknown> {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(readFileSync(path, "utf8"));
-  } catch (e) {
-    fatal(`Failed to parse ${path}: ${e instanceof Error ? e.message : String(e)}`);
-  }
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    fatal(`${path} must be a JSON object.`);
-  }
-  const config = raw as Record<string, unknown>;
-  validateConfig(config, path);
-  return config;
-}
-
-/**
- * Find the project config file.
- * Priority: .kaizen/kaizen.json > kaizen.json (legacy)
- */
-export function findProjectConfig(): string | null {
-  if (existsSync(PROJECT_CONFIG)) return PROJECT_CONFIG;
-  if (existsSync(LEGACY_CONFIG)) {
-    warn(`Found kaizen.json at root. Consider moving it to .kaizen/kaizen.json.`);
-    return LEGACY_CONFIG;
-  }
-  return null;
-}
-
-export function loadKaizenConfig(path: string): KaizenConfig {
-  if (!existsSync(path)) {
-    fatal(`Config not found at ${path}. Run 'kaizen init' to create one.`);
-  }
-  const config = parseConfigFile(path);
-  // plugins is optional when config delegates to a harness via 'extends'
-  if (config["plugins"] !== undefined && !Array.isArray(config["plugins"])) {
-    fatal(`${path} 'plugins' must be an array.`);
-  }
-  return config as KaizenConfig;
-}
-
-// ---------------------------------------------------------------------------
-// Config merging
-//
-// Harness is the base. Local config overlays it:
-//   - plugins: local replaces harness entirely (if specified)
-//   - plugin configs (objects): shallow-merged, local wins on conflicts
-//   - extends: stripped — it's resolved before merging
-// ---------------------------------------------------------------------------
-
-export function mergeConfigs(base: KaizenConfig, overlay: KaizenConfig): KaizenConfig {
-  const merged: Record<string, unknown> = { ...base };
-
-  for (const [key, value] of Object.entries(overlay)) {
-    if (key === "extends") continue;
-
-    if (key === "plugins") {
-      merged["plugins"] = value;
-    } else if (
-      typeof value === "object" && value !== null && !Array.isArray(value) &&
-      typeof merged[key] === "object" && merged[key] !== null && !Array.isArray(merged[key])
-    ) {
-      merged[key] = { ...(merged[key] as Record<string, unknown>), ...(value as Record<string, unknown>) };
-    } else {
-      merged[key] = value;
-    }
-  }
-
-  return merged as KaizenConfig;
-}
-
 // ---------------------------------------------------------------------------
 // Resolve the final config from CLI args
 //
-// Priority (highest → lowest):
-//   CLI --config flag
-//   .kaizen/kaizen.json      (project)
-//   kaizen.json              (legacy root)
-//   ~/.kaizen/kaizen.json    (global default)
+// The caller is responsible for loading ~/.kaizen/kaizen.json and passing
+// defaults.harness via opts.harness before calling this function.
 // ---------------------------------------------------------------------------
 
 export function resolveConfig(opts: {
   harness?: string;
-  configPath?: string;
   /**
-   * Pre-materialized extends path (set by the CLI pre-pass when the local
-   * config's `extends` is a marketplace ref). Overrides the raw `extends`
-   * string read from the local config.
+   * Pre-materialized extends path (set by the CLI pre-pass when the caller
+   * already resolved a marketplace ref to a local harness dir).
    */
   extendsOverride?: string;
 }): KaizenConfig {
-  const { harness, configPath, extendsOverride } = opts;
-
-  // Explicit --config path
-  const explicitPath = configPath ?? null;
-  const projectConfigPath = explicitPath ?? findProjectConfig();
+  const { harness, extendsOverride } = opts;
 
   if (harness) {
-    const harnessConfig = loadHarnessConfig(harness);
-    if (projectConfigPath) {
-      const localConfig = loadKaizenConfig(projectConfigPath);
-      if (localConfig.extends && localConfig.extends !== harness) {
-        warn(`--harness ${harness} overrides extends '${localConfig.extends}' in config.`);
-      }
-      return mergeConfigs(harnessConfig, localConfig);
-    }
-    return harnessConfig;
+    return loadHarnessConfig(harness);
   }
-
-  if (projectConfigPath) {
-    const localConfig = loadKaizenConfig(projectConfigPath);
-    const ext = extendsOverride ?? localConfig.extends;
-    if (!ext) {
-      fatal(
-        `A named harness required.\n` +
-        `Found ${projectConfigPath} but no --harness flag and no 'extends' field.\n` +
-        `See docs/concepts/harnesses.md. Valid forms:\n` +
-        `  kaizen --harness <marketplace>/<name>@<version>\n` +
-        `  kaizen --harness ./path/to/harness/\n` +
-        `  Add "extends": "<harness-ref>" to ${projectConfigPath}`,
-      );
-    }
-    return mergeConfigs(loadHarnessConfig(ext), localConfig);
-  }
-
-  // Global default
-  if (existsSync(KAIZEN_HOME_CONFIG)) {
-    const globalConfig = loadKaizenConfig(KAIZEN_HOME_CONFIG);
-    const ext = extendsOverride ?? globalConfig.extends;
-    if (!ext) {
-      fatal(
-        `A named harness required.\n` +
-        `Found ${KAIZEN_HOME_CONFIG} but no --harness flag and no 'extends' field.\n` +
-        `See docs/concepts/harnesses.md.`,
-      );
-    }
-    return mergeConfigs(loadHarnessConfig(ext), globalConfig);
+  if (extendsOverride) {
+    return loadHarnessConfig(extendsOverride);
   }
 
   fatal(
-    `No config found.\n` +
-    `  Harness (required): kaizen --harness <marketplace>/<name>@<version>\n` +
-    `  Project config:     kaizen init\n` +
-    `  Global config:      kaizen init --global`,
+    `A harness is required.\n` +
+    `  kaizen --harness <marketplace>/<name>@<version>\n` +
+    `  kaizen --harness ./path/to/harness/\n` +
+    `  Set 'defaults.harness' in ~/.kaizen/kaizen.json`,
   );
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -15,7 +15,9 @@ export const KAIZEN_HOME_HARNESSES = join(KAIZEN_HOME, "harnesses");
 export const PROJECT_DIR = ".kaizen";
 export const PROJECT_HARNESSES = join(PROJECT_DIR, "harnesses");
 
-// Reserved top-level keys — not treated as plugin config namespaces.
+// Reserved top-level keys in harness kaizen.json — not treated as plugin
+// config namespaces. Used by plugin-manager to reject plugin names that
+// would collide with these.
 export const RESERVED_KEYS = new Set(["plugins", "extends"]);
 
 // ---------------------------------------------------------------------------

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -109,33 +109,30 @@ function parseAndValidateHarness(path: string, label: string): KaizenConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Resolve the final config from CLI args
+// Resolve the active harness from CLI args
 //
 // The caller is responsible for loading ~/.kaizen/kaizen.json and passing
-// defaults.harness via opts.harness before calling this function.
+// defaults.harness via opts.harness before calling this function. Returns
+// both the kaizen.json path (for lockfile derivation) and the parsed config.
 // ---------------------------------------------------------------------------
 
-export function resolveConfig(opts: {
+export function resolveHarnessOrFatal(opts: {
   harness?: string;
   /**
    * Pre-materialized extends path (set by the CLI pre-pass when the caller
    * already resolved a marketplace ref to a local harness dir).
    */
   extendsOverride?: string;
-}): KaizenConfig {
-  const { harness, extendsOverride } = opts;
-
-  if (harness) {
-    return loadHarnessConfig(harness);
+}): ResolvedHarness {
+  const ref = opts.harness ?? opts.extendsOverride;
+  if (!ref) {
+    fatal(
+      `A harness is required.\n` +
+      `  kaizen --harness <marketplace>/<name>@<version>\n` +
+      `  kaizen --harness ./path/to/harness/\n` +
+      `  Set 'defaults.harness' in ~/.kaizen/kaizen.json\n` +
+      `See docs/concepts/configuration.md.`,
+    );
   }
-  if (extendsOverride) {
-    return loadHarnessConfig(extendsOverride);
-  }
-
-  fatal(
-    `A harness is required.\n` +
-    `  kaizen --harness <marketplace>/<name>@<version>\n` +
-    `  kaizen --harness ./path/to/harness/\n` +
-    `  Set 'defaults.harness' in ~/.kaizen/kaizen.json`,
-  );
+  return resolveHarness(ref);
 }

--- a/src/core/deprecation-warn.test.ts
+++ b/src/core/deprecation-warn.test.ts
@@ -33,7 +33,9 @@ test("warnStaleProjectConfig: warns when root kaizen.json exists", () => {
   const warnings: string[] = [];
   warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
   expect(warnings.length).toBe(1);
-  expect(warnings[0]).toMatch(/^|\skaizen\.json/);
+  // Sanity: the message mentions root kaizen.json, not just .kaizen/kaizen.json.
+  expect(warnings[0]).not.toMatch(/^Found '\.kaizen\//);
+  expect(warnings[0]).toMatch(/(^|[^.])kaizen\.json/);
 });
 
 test("warnStaleProjectConfig: silent when neither file exists", () => {

--- a/src/core/deprecation-warn.test.ts
+++ b/src/core/deprecation-warn.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, afterEach, beforeEach } from "bun:test";
+import { warnStaleProjectConfig } from "./deprecation-warn.js";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let cwdBackup: string;
+let dir: string;
+
+beforeEach(() => {
+  cwdBackup = process.cwd();
+  dir = mkdtempSync(join(tmpdir(), "kaizen-stalecfg-"));
+  process.chdir(dir);
+});
+
+afterEach(() => {
+  process.chdir(cwdBackup);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("warnStaleProjectConfig: warns when .kaizen/kaizen.json exists", () => {
+  mkdirSync(".kaizen");
+  writeFileSync(".kaizen/kaizen.json", "{}", "utf8");
+  const warnings: string[] = [];
+  warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
+  expect(warnings.length).toBe(1);
+  expect(warnings[0]).toMatch(/\.kaizen\/kaizen\.json/);
+  expect(warnings[0]).toMatch(/no longer supported/);
+});
+
+test("warnStaleProjectConfig: warns when root kaizen.json exists", () => {
+  writeFileSync("kaizen.json", "{}", "utf8");
+  const warnings: string[] = [];
+  warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
+  expect(warnings.length).toBe(1);
+  expect(warnings[0]).toMatch(/^|\skaizen\.json/);
+});
+
+test("warnStaleProjectConfig: silent when neither file exists", () => {
+  const warnings: string[] = [];
+  warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
+  expect(warnings).toEqual([]);
+});
+
+test("warnStaleProjectConfig: warns for both when both exist", () => {
+  mkdirSync(".kaizen");
+  writeFileSync(".kaizen/kaizen.json", "{}", "utf8");
+  writeFileSync("kaizen.json", "{}", "utf8");
+  const warnings: string[] = [];
+  warnStaleProjectConfig({ warn: (m) => warnings.push(m) });
+  expect(warnings.length).toBe(2);
+});

--- a/src/core/deprecation-warn.ts
+++ b/src/core/deprecation-warn.ts
@@ -1,0 +1,19 @@
+import { existsSync } from "fs";
+import { join } from "path";
+
+export interface WarnSink {
+  warn: (message: string) => void;
+}
+
+const PROJECT_LOCAL = join(".kaizen", "kaizen.json");
+const LEGACY_ROOT = "kaizen.json";
+
+const MESSAGE = (path: string) =>
+  `Found '${path}'. Project-level kaizen config is no longer supported. ` +
+  `Move 'extends' to '~/.kaizen/kaizen.json' as 'defaults.harness', ` +
+  `or pass --harness explicitly. See docs/concepts/configuration.md.`;
+
+export function warnStaleProjectConfig(sink: WarnSink): void {
+  if (existsSync(PROJECT_LOCAL)) sink.warn(MESSAGE(PROJECT_LOCAL));
+  if (existsSync(LEGACY_ROOT)) sink.warn(MESSAGE(LEGACY_ROOT));
+}

--- a/src/core/integration/plugin-config.test.ts
+++ b/src/core/integration/plugin-config.test.ts
@@ -308,7 +308,7 @@ describe("Plugin Config Integration Tests", () => {
   // ============================================================================
 
   describe("Test 9: Four-layer merge precedence", () => {
-    test("merge precedence: plugin < global < harness (shallow)", () => {
+    test("merge precedence: plugin < harness < user-global (shallow)", () => {
       const declaration: PluginConfigDeclaration = {
         defaults: {
           timeout: 1000,
@@ -321,8 +321,10 @@ describe("Plugin Config Integration Tests", () => {
 
       const merged = mergePluginConfig(declaration, global, harness);
 
-      expect(merged.timeout).toBe(3000);
+      // user global wins over harness
+      expect(merged.timeout).toBe(2000);
       expect(merged.base_url).toBe("https://default.example.com");
+      // harness wins over plugin declaration (no user global for retry)
       expect((merged.retry as Record<string, unknown>).max).toBe(5);
       expect((merged.retry as Record<string, unknown>).delay).toBeUndefined();
     });

--- a/src/core/issue-34.test.ts
+++ b/src/core/issue-34.test.ts
@@ -2,7 +2,7 @@ import { test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { resolveConfig } from "./config.js";
+import { resolveHarnessOrFatal } from "./config.js";
 
 let dir: string;
 let cwdBackup: string;
@@ -47,7 +47,7 @@ test("issue #34: local .kaizen/kaizen.json cannot clobber --harness plugin list"
     "utf8",
   );
 
-  const cfg = resolveConfig({ harness: "./harness" });
+  const { config: cfg } = resolveHarnessOrFatal({ harness: "./harness" });
 
   expect(cfg.plugins).toEqual(["official/core-cli@0.1.0"]);
   // The "evil/injected" ref from project-local config must NOT appear.

--- a/src/core/issue-34.test.ts
+++ b/src/core/issue-34.test.ts
@@ -1,0 +1,55 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolveConfig } from "./config.js";
+
+let dir: string;
+let cwdBackup: string;
+let homeBackup: string | undefined;
+
+beforeEach(() => {
+  cwdBackup = process.cwd();
+  dir = mkdtempSync(join(tmpdir(), "kaizen-issue-34-"));
+  process.chdir(dir);
+  homeBackup = process.env.KAIZEN_HOME_OVERRIDE;
+  process.env.KAIZEN_HOME_OVERRIDE = join(dir, "home");
+  mkdirSync(process.env.KAIZEN_HOME_OVERRIDE, { recursive: true });
+});
+
+afterEach(() => {
+  process.chdir(cwdBackup);
+  if (homeBackup === undefined) delete process.env.KAIZEN_HOME_OVERRIDE;
+  else process.env.KAIZEN_HOME_OVERRIDE = homeBackup;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("issue #34: local .kaizen/kaizen.json cannot clobber --harness plugin list", async () => {
+  // Legacy-style project config that, under the old overlay code, would have
+  // replaced the harness's plugins array.
+  mkdirSync(".kaizen", { recursive: true });
+  writeFileSync(
+    ".kaizen/kaizen.json",
+    JSON.stringify({
+      plugins: ["evil/injected@0.0.0"],
+    }),
+    "utf8",
+  );
+
+  // Minimal local-path harness with a known plugin list.
+  const harnessDir = join(dir, "harness");
+  mkdirSync(harnessDir, { recursive: true });
+  writeFileSync(
+    join(harnessDir, "kaizen.json"),
+    JSON.stringify({
+      plugins: ["official/core-cli@0.1.0"],
+    }),
+    "utf8",
+  );
+
+  const cfg = resolveConfig({ harness: "./harness" });
+
+  expect(cfg.plugins).toEqual(["official/core-cli@0.1.0"]);
+  // The "evil/injected" ref from project-local config must NOT appear.
+  expect(JSON.stringify(cfg)).not.toContain("evil/injected");
+});

--- a/src/core/kaizen-config.test.ts
+++ b/src/core/kaizen-config.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, readFileSync, existsSync } from "fs";
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, dirname } from "path";
 import {
   kaizenHome, marketplacesDir, marketplaceDir, marketplaceRepoDir,
   pluginInstallDir, harnessInstallDir,
   ensureKaizenHome, loadKaizenGlobalConfig, saveKaizenGlobalConfig,
-  looksLikeHarnessRef,
+  looksLikeHarnessRef, kaizenHomeConfigPath,
 } from "./kaizen-config.js";
 
 let home: string;
@@ -84,5 +84,91 @@ describe("looksLikeHarnessRef", () => {
   it("rejects bare names without a slash", () => {
     expect(looksLikeHarnessRef("core-anthropic")).toBe(false);
     expect(looksLikeHarnessRef("my-local-harness")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation tests (Task 4)
+// ---------------------------------------------------------------------------
+
+describe("loadKaizenGlobalConfig validation", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = join(tmpdir(), `kaizen-cfg-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    process.env.KAIZEN_HOME_OVERRIDE = tmpHome;
+  });
+
+  afterEach(() => {
+    delete process.env.KAIZEN_HOME_OVERRIDE;
+    try { rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+  });
+
+  function writeCfg(obj: unknown) {
+    const path = kaizenHomeConfigPath();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(obj), "utf8");
+  }
+
+  it("accepts nested defaults.harness and defaults.plugin_config", async () => {
+    writeCfg({
+      defaults: {
+        harness: "official/core-shell@1.0.0",
+        plugin_config: { gitlab: { base_url: "https://gitlab.mycompany.com" } },
+      },
+    });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.defaults?.harness).toBe("official/core-shell@1.0.0");
+    expect(cfg.defaults?.plugin_config?.gitlab).toEqual({ base_url: "https://gitlab.mycompany.com" });
+  });
+
+  it("rejects top-level `plugins` key", async () => {
+    writeCfg({ plugins: ["foo/bar@1.0.0"] });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/plugins.*not allowed|not supported/i);
+  });
+
+  it("rejects top-level `extends` with 'move to defaults.harness' hint", async () => {
+    writeCfg({ extends: "foo/bar@1.0.0" });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/extends.*defaults\.harness/);
+  });
+
+  it("rejects top-level `default_harness` with 'nest under defaults' hint", async () => {
+    writeCfg({ default_harness: "foo/bar@1.0.0" });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/default_harness.*defaults\.harness/);
+  });
+
+  it("rejects top-level `plugin_config` with 'nest under defaults' hint", async () => {
+    writeCfg({ plugin_config: { gitlab: {} } });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/plugin_config.*defaults\.plugin_config/);
+  });
+
+  it("rejects old flat shape (plugin names directly under defaults)", async () => {
+    writeCfg({ defaults: { gitlab: { base_url: "x" } } });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/defaults\.gitlab|defaults\.plugin_config/);
+  });
+
+  it("rejects unknown top-level keys", async () => {
+    writeCfg({ defaults: { harness: "x/y@1" }, random_nonsense: true });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/random_nonsense/);
+  });
+
+  it("allows marketplaces and marketplaceUpdateTTL", async () => {
+    writeCfg({
+      marketplaces: [{ id: "official", url: "https://example.com/repo.git" }],
+      marketplaceUpdateTTL: 600,
+    });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.marketplaces?.[0]?.id).toBe("official");
+    expect(cfg.marketplaceUpdateTTL).toBe(600);
+  });
+
+  it("defaults.plugin_config must be an object of objects", async () => {
+    writeCfg({ defaults: { plugin_config: { gitlab: "not an object" } } });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/plugin_config/);
+  });
+
+  it("returns {} when file is absent", async () => {
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg).toEqual({});
   });
 });

--- a/src/core/kaizen-config.ts
+++ b/src/core/kaizen-config.ts
@@ -40,6 +40,13 @@ export async function ensureKaizenHome(): Promise<void> {
   mkdirSync(marketplacesDir(), { recursive: true });
 }
 
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "defaults",
+  "marketplaces",
+  "marketplaceUpdateTTL",
+]);
+const ALLOWED_DEFAULTS_KEYS = new Set(["harness", "plugin_config"]);
+
 export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
   const path = kaizenHomeConfigPath();
   if (!existsSync(path)) return {};
@@ -48,7 +55,67 @@ export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error(`${path}: expected a JSON object.`);
   }
-  return parsed as KaizenGlobalConfig;
+  const obj = parsed as Record<string, unknown>;
+
+  if ("plugins" in obj) {
+    throw new Error(
+      `${path}: top-level 'plugins' key is not allowed. The plugin set is defined by the harness; ` +
+      `user config cannot add, remove, or replace plugins. Remove the 'plugins' key. See docs/concepts/configuration.md.`,
+    );
+  }
+  if ("extends" in obj) {
+    throw new Error(
+      `${path}: top-level 'extends' has been replaced by 'defaults.harness'. ` +
+      `Move the value under \`defaults\` and try again.`,
+    );
+  }
+  if ("default_harness" in obj) {
+    throw new Error(
+      `${path}: top-level 'default_harness' is not allowed — nest it as 'defaults.harness'.`,
+    );
+  }
+  if ("plugin_config" in obj) {
+    throw new Error(
+      `${path}: top-level 'plugin_config' is not allowed — nest it as 'defaults.plugin_config'.`,
+    );
+  }
+  const unknownKeys = Object.keys(obj).filter((k) => !ALLOWED_TOP_LEVEL_KEYS.has(k));
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `${path}: unknown top-level keys: ${unknownKeys.join(", ")}. ` +
+      `Allowed keys: ${[...ALLOWED_TOP_LEVEL_KEYS].join(", ")}.`,
+    );
+  }
+
+  if (obj.defaults !== undefined) {
+    if (typeof obj.defaults !== "object" || obj.defaults === null || Array.isArray(obj.defaults)) {
+      throw new Error(`${path}: 'defaults' must be an object.`);
+    }
+    const defaults = obj.defaults as Record<string, unknown>;
+    const unknownDefaultsKeys = Object.keys(defaults).filter((k) => !ALLOWED_DEFAULTS_KEYS.has(k));
+    if (unknownDefaultsKeys.length > 0) {
+      throw new Error(
+        `${path}: unknown keys under 'defaults': ${unknownDefaultsKeys.join(", ")}. ` +
+        `Allowed: ${[...ALLOWED_DEFAULTS_KEYS].join(", ")}. ` +
+        `If these are plugin names, move them under 'defaults.plugin_config'.`,
+      );
+    }
+    if (defaults.harness !== undefined && typeof defaults.harness !== "string") {
+      throw new Error(`${path}: 'defaults.harness' must be a string.`);
+    }
+    if (defaults.plugin_config !== undefined) {
+      if (typeof defaults.plugin_config !== "object" || defaults.plugin_config === null || Array.isArray(defaults.plugin_config)) {
+        throw new Error(`${path}: 'defaults.plugin_config' must be an object.`);
+      }
+      for (const [name, value] of Object.entries(defaults.plugin_config)) {
+        if (typeof value !== "object" || value === null || Array.isArray(value)) {
+          throw new Error(`${path}: 'defaults.plugin_config.${name}' must be an object.`);
+        }
+      }
+    }
+  }
+
+  return obj as KaizenGlobalConfig;
 }
 
 /**

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -634,8 +634,8 @@ export class PluginManager {
 
     // Merge config layers
     const harnessConfig = (this.config[plugin.name] as Record<string, unknown> | undefined) ?? {};
-    const globalDefaults = (this.globalConfig?.defaults?.[plugin.name] as Record<string, unknown> | undefined) ?? {};
-    const merged = mergePluginConfig(plugin.config, globalDefaults, harnessConfig);
+    const userPluginConfig = this.globalConfig?.defaults?.plugin_config?.[plugin.name] ?? {};
+    const merged = mergePluginConfig(plugin.config, userPluginConfig, harnessConfig);
 
     // Separate secrets from non-secret config
     const { config: pluginConfig, secretRefs } = separateSecrets(merged, plugin.config?.secrets ?? []);

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -330,10 +330,17 @@ export interface MarketplaceRef {
   updatedAt?: string;              // ISO-8601
 }
 
+export interface KaizenDefaults {
+  /** Harness ref used when --harness is not passed on the CLI. */
+  harness?: string;
+  /** Per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects. */
+  plugin_config?: Record<string, Record<string, unknown>>;
+}
+
 export interface KaizenGlobalConfig {
   marketplaces?: MarketplaceRef[];
-  defaultHarness?: string;
-  defaults?: Record<string, unknown>;   // Spec 2 uses this
+  /** User-chosen defaults: default harness + per-plugin config overrides. */
+  defaults?: KaizenDefaults;
   /** Seconds between background marketplace refreshes; 0 disables. Default 900. */
   marketplaceUpdateTTL?: number;
 }


### PR DESCRIPTION
Closes #34. Also closes #50 and #51 (in-scope cleanup surfaced during review).

## Summary

- **Delete the legacy project-level config path.** `.kaizen/kaizen.json` and root `kaizen.json` are no longer consulted; `mergeConfigs`, `findProjectConfig`, `PROJECT_CONFIG`, `LEGACY_CONFIG`, `loadKaizenConfig` removed from `src/core/config.ts`.
- **One config file: `~/.kaizen/kaizen.json`.** Strict schema `{ defaults?: { harness?, plugin_config? }, marketplaces?, marketplaceUpdateTTL? }`. Validator rejects `plugins` / `extends` / intermediate top-level names with migration hints.
- **Flip `mergePluginConfig` precedence** so user globals win over harness defaults (the north-star gitlab self-hosted case).
- **Rewrite `kaizen init` as `--global`-only.** Writes the nested `defaults.harness` shape; no-clobber preserved.
- **Route `kaizen add/remove/list` + `plugin list`** through the nested schema. `plugin list` now resolves the active harness and shows its plugins + install status.
- **Deprecation warning** on startup when stale `.kaizen/kaizen.json` or root `kaizen.json` is found in cwd.
- **Regression test** at `src/core/issue-34.test.ts` prevents reintroduction of the clobber path.
- **Docs:** new `docs/concepts/configuration.md`; updates to `harnesses.md`, `plugin-authoring.md`, `plugin-api.md`, `architecture.md`, `security.md`, `core-internals.md`, `README.md`.
- **Follow-up #50** (inline vestigial `resolveConfig` → `resolveHarnessOrFatal`) and **#51** (drop `[global]` tag from `config show`) folded in since both were cleanup on code this branch just touched.
- Open follow-up: **#52** — `KAIZEN_SUPPRESS_DEPRECATION` env opt-out + help text.

## Behavioral changes users will see

- `kaizen init` without `--global` now exits 2 with a clear message.
- Running `kaizen` in a directory with a pre-existing `.kaizen/kaizen.json` prints a one-line stderr deprecation warning; the file is ignored.
- `kaizen plugin list` now reads the active harness instead of the user config (which no longer has a `plugins` key).
- Self-hosted GitLab (and similar) config overrides in `~/.kaizen/kaizen.json`'s `defaults.plugin_config` now actually win over harness-shipped defaults.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 394 pass / 3 skip / 0 fail
- [x] `bun test --integration` — same (no additional gated suites)
- [x] Regression test `src/core/issue-34.test.ts` passes
- [x] Manual smoke: `.kaizen/kaizen.json` with `plugins: ["evil/injected"]` is ignored, warning prints, `--harness ref` loads the real harness list
- [x] Manual smoke: `kaizen init --global --harness X` writes `{"defaults":{"harness":"X"}}` and loads cleanly via validator
- [ ] Reviewer: hand-walk the spec at `docs/superpowers/specs/2026-04-23-kaizen-config-simplification-design.md` vs final diff for any gaps