### PR TITLE
feat: allow version-less harness and plugin refs (#49)

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -159,7 +159,7 @@ harnesses — ones the user writes by hand.
 
 ### Plugin resolution order
 
-1. **Canonical marketplace ref** (`<marketplace>/<name>@<version>`):
+1. **Canonical marketplace ref** (`<marketplace>/<name>[@<version>]`):
    `~/.kaizen/marketplaces/<id>/plugins/<name>@<version>/`, loaded by absolute
    path.
 2. **Local path** (`./`, `../`, or `/`): loaded directly.

--- a/docs/concepts/harnesses.md
+++ b/docs/concepts/harnesses.md
@@ -19,7 +19,7 @@ entry in a marketplace catalog points at a versioned directory containing a
 kaizen --harness official/core-anthropic@0.1.0
 ```
 
-The ref format is `<marketplace-id>/<name>@<version>`. kaizen materializes the
+The ref format is `<marketplace-id>/<name>[@<version>]`. kaizen materializes the
 harness into `~/.kaizen/marketplaces/<id>/harnesses/<name>/kaizen.json` on first
 use, then loads it. Any marketplaces and plugins the harness references are
 bootstrapped automatically (with consent prompts unless `--non-interactive` /
@@ -53,7 +53,7 @@ kaizen --harness my-local-harness       # looks in .kaizen/harnesses/, then ~/.k
 
 Bare-name lookup does **not** scan `~/.kaizen/marketplaces/<id>/harnesses/`.
 To use a marketplace harness, reference it by its full ref
-(`<marketplace-id>/<name>@<version>`), either via `--harness` or via `extends`.
+(`<marketplace-id>/<name>[@<version>]`), either via `--harness` or via `extends`.
 
 ### URL harnesses are not supported
 
@@ -99,7 +99,7 @@ The `kaizen.json` lists plugins (by marketplace ref) and their config:
 }
 ```
 
-Plugin entries must be full marketplace refs (`<marketplace>/<name>@<version>`)
+Plugin entries must be marketplace refs (`<marketplace>/<name>[@<version>]`)
 for the harness to be portable. Bare short names only resolve against locally
 installed plugins and won't work for others.
 
@@ -113,7 +113,7 @@ Consumers then use:
 
 ```bash
 kaizen marketplace add <your-marketplace-url>
-kaizen --harness <your-marketplace-id>/<harness-name>@<version>
+kaizen --harness <your-marketplace-id>/<harness-name>[@<version>]
 ```
 
 For private or ad-hoc sharing, consumers can also drop the harness directory

--- a/docs/concepts/plugin-model.md
+++ b/docs/concepts/plugin-model.md
@@ -58,7 +58,7 @@ core stack — reaches a session through the **marketplace install path**.
 The high-level sequence when you run `kaizen --harness <something>`:
 
 1. **Resolution.** Each plugin ref in `kaizen.json` is either a canonical
-   `<marketplace>/<name>@<version>` or a legacy bare name. Canonical refs
+   `<marketplace>/<name>[@<version>]` or a legacy bare name. Canonical refs
    resolve against installed marketplace trees under
    `~/.kaizen/marketplaces/<id>/plugins/<name>@<version>/`; legacy names fall
    back through authored-plugin and npm directories.

--- a/docs/guides/marketplace-authoring.md
+++ b/docs/guides/marketplace-authoring.md
@@ -16,7 +16,7 @@ resolves plugin and harness references against. It contains a
 `.kaizen/marketplace.json` catalog, optional in-tree `plugins/` and
 `harnesses/` directories, and whatever else you want to ship alongside.
 
-When a user runs `kaizen install <marketplace-id>/<plugin>@<version>`, kaizen
+When a user runs `kaizen install <marketplace-id>/<plugin>[@<version>]`, kaizen
 reads the marketplace catalog, resolves the version entry, and fetches the
 plugin source from the declared `source` (npm, tarball, or in-repo file).
 
@@ -108,7 +108,7 @@ message.
 
 Harness entries reference an in-tree `kaizen.json` via `path` (relative to the
 marketplace root). Every plugin ref inside a harness must be the canonical
-`<marketplace>/<name>@<version>` form — bare names are rejected.
+`<marketplace>/<name>[@<version>]` form — bare names are rejected.
 
 ## Validate
 

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -286,7 +286,7 @@ harness-authored providers.
 
 ```ts
 export interface KaizenConfig {
-  plugins: string[];           // canonical marketplace refs "<marketplace-id>/<name>@<version>"
+  plugins: string[];           // canonical marketplace refs "<marketplace-id>/<name>[@<version>]"
   extends?: string;            // harness to extend: marketplace ref or local path
   marketplaces?: MarketplaceRef[];
   [pluginName: string]: unknown;  // per-plugin config slices

--- a/docs/superpowers/plans/2026-04-23-version-less-refs.md
+++ b/docs/superpowers/plans/2026-04-23-version-less-refs.md
@@ -1,0 +1,342 @@
+# Version-less Harness and Plugin Refs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `@<version>` to be omitted from harness refs and plugin refs inside harness `kaizen.json` files; a version-less ref resolves to the latest in the marketplace catalog.
+
+**Architecture:** The parser and resolver already handle version-less refs. The only code gate is in `bootstrap.ts`, which explicitly throws when `version` is absent. Removing that gate requires resolving the concrete version from the catalog first (to preserve the `isInstalled` short-circuit that prevents re-running the consent flow). Everything else is error-message and docs updates.
+
+**Tech Stack:** TypeScript, Bun (test runner: `bun test`)
+
+---
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/core/bootstrap.ts` | Remove version guard; add lazy catalog loading + `resolveRef` for version-less refs; update error message |
+| `src/core/bootstrap.test.ts` | Add two tests for version-less plugin refs |
+| `src/cli.ts` | Update 3 format strings |
+| `src/core/config.ts` | Update 3 error messages |
+| `src/core/plugin-manager.ts` | Update 1 comment, 1 error message |
+| `src/types/plugin.ts` | Update 1 JSDoc comment |
+| `docs/concepts/harnesses.md` | Update 4 ref format mentions |
+| `docs/guides/marketplace-authoring.md` | Update 2 ref format mentions |
+
+---
+
+## Task 1: Write failing tests for version-less plugin refs
+
+**Files:**
+- Modify: `src/core/bootstrap.test.ts`
+
+The existing test fixture already has a `demo` plugin at `1.0.0` in a local git-backed marketplace. A version-less ref `m/demo` will resolve to `1.0.0` from that catalog.
+
+- [ ] **Step 1: Add the two new tests after the existing ones in `bootstrap.test.ts`**
+
+Open `src/core/bootstrap.test.ts`. After the `"--trust-lockfile + --non-interactive fails fast..."` test (line 61), add:
+
+```ts
+  it("version-less ref resolves to latest and installs", async () => {
+    const lockfilePath = join(home, "permissions.lock");
+    const report = await bootstrapMissingPlugins(
+      { plugins: ["m/demo"], marketplaces: [{ id: "m", url: upstream }] },
+      { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: true },
+    );
+    expect(report.pluginsInstalled).toContain("m/demo");
+    expect(existsSync(pluginInstallDir("m", "demo", "1.0.0"))).toBe(true);
+  });
+
+  it("version-less ref skips reinstall when already installed", async () => {
+    await addMarketplace(upstream, { id: "m", local: true });
+    const lockfilePath = join(home, "permissions.lock");
+    // First run installs it.
+    await bootstrapMissingPlugins(
+      { plugins: ["m/demo"], marketplaces: [] },
+      { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: true },
+    );
+    // Second run should not add to pluginsInstalled.
+    const report = await bootstrapMissingPlugins(
+      { plugins: ["m/demo"], marketplaces: [] },
+      { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: true },
+    );
+    expect(report.pluginsInstalled).toHaveLength(0);
+  });
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+bun test src/core/bootstrap.test.ts
+```
+
+Expected: the two new tests fail with `harness plugin ref 'm/demo' must include an explicit version`.
+
+---
+
+## Task 2: Remove version guard and add lazy catalog resolution
+
+**Files:**
+- Modify: `src/core/bootstrap.ts`
+
+The goal: when `version` is `undefined`, resolve it from the catalog before the `isInstalled` check.
+
+- [ ] **Step 1: Add `readCatalog` and `resolveRef` imports and `MarketplaceCatalog` type**
+
+At the top of `src/core/bootstrap.ts`, update the imports:
+
+```ts
+import type { KaizenConfig, MarketplaceRef, MarketplaceCatalog } from "../types/plugin.js";
+import { loadKaizenGlobalConfig } from "./kaizen-config.js";
+import { addMarketplace, readCatalog } from "./marketplace.js";
+import { parseRef, resolveRef } from "./ref-resolver.js";
+import { readLockfile } from "./lockfile.js";
+import { runUnifiedInstall } from "../commands/install.js";
+import { isInstalled } from "./plugin-manager.js";
+```
+
+- [ ] **Step 2: Replace the version guard block with lazy catalog resolution**
+
+In `src/core/bootstrap.ts`, replace everything from the opening of the plugin loop (`// 2. Install missing plugins.`) through to (but not including) the `if (await isInstalled(...))` line with the following. The full replacement for lines 46–75:
+
+```ts
+  // 2. Install missing plugins.
+  const lockfile = readLockfile(opts.lockfilePath);
+  let catalogs: Record<string, MarketplaceCatalog> | undefined;
+
+  for (const refStr of harness.plugins ?? []) {
+    const parsed = parseRef(refStr);
+
+    if (parsed.kind === "shorthand") {
+      throw new Error(
+        `harness plugin ref '${refStr}' is shorthand. ` +
+        `Harness plugin refs must be canonical '<marketplace>/<name>[@<version>]'.`,
+      );
+    }
+
+    let marketplaceId: string;
+    let name: string;
+    let version: string | undefined;
+    if (parsed.kind === "marketplace") {
+      marketplaceId = parsed.marketplaceId;
+      name = parsed.name;
+      version = parsed.version;
+    } else {
+      // legacy-npm
+      marketplaceId = "official";
+      name = parsed.name.replace(/^kaizen-plugin-/, "");
+      version = undefined;
+    }
+
+    // Version-less ref: resolve against the catalog to get the concrete version
+    // so we can use the isInstalled short-circuit below.
+    if (!version) {
+      if (!catalogs) {
+        catalogs = {};
+        const cfg = await loadKaizenGlobalConfig();
+        for (const m of cfg.marketplaces ?? []) {
+          try { catalogs[m.id] = await readCatalog(m.id); } catch { /* skip bad */ }
+        }
+      }
+      version = resolveRef(parsed, catalogs).version;
+    }
+
+    if (await isInstalled(marketplaceId, name, version)) continue;
+```
+
+The rest of the function (trust-lockfile block, `runUnifiedInstall` call, report push) remains unchanged.
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+bun test src/core/bootstrap.test.ts
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 4: Run the full test suite to check for regressions**
+
+```bash
+bun test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/bootstrap.ts src/core/bootstrap.test.ts
+git commit -m "feat: allow version-less plugin refs in harness kaizen.json (#49)"
+```
+
+---
+
+## Task 3: Update error messages in source files
+
+**Files:**
+- Modify: `src/cli.ts`
+- Modify: `src/core/config.ts`
+- Modify: `src/core/plugin-manager.ts`
+- Modify: `src/types/plugin.ts`
+
+Change every `<marketplace>/<name>@<version>` format string (where `@<version>` is presented as required) to `<marketplace>/<name>[@<version>]`. These are strings that reach users as error messages, help text, or log output.
+
+- [ ] **Step 1: Update `src/cli.ts` — 3 occurrences**
+
+Line 100 (help text `--harness` flag description):
+```
+  --harness <ref>                       harness ref (marketplace/name[@version])
+```
+
+Line 517 (plugin list error):
+```
+      `  Install a plugin:   kaizen install <marketplace>/<name>[@<version>]\n` +
+```
+
+Line 518 (plugin list error):
+```
+      `  Uninstall a plugin: kaizen uninstall <marketplace>/<name>[@<version>]`,
+```
+
+Line 602 (URL harness fatal):
+```
+  fatal("raw URL harnesses are not supported — publish the harness in a marketplace and use --harness <id>/<name>[@<version>]");
+```
+
+- [ ] **Step 2: Update `src/core/config.ts` — 3 occurrences**
+
+Line 65 (URL harness fatal):
+```
+      `Publish the harness in a marketplace and reference it as '<marketplace>/<name>[@<version>]'.`,
+```
+
+Line 71 (install hint in fatal):
+```
+    `  Marketplace:    kaizen install <marketplace>/${nameOrPath}[@<version>]\n` +
+```
+
+Line 131 (harness not found hint — this is the `resolveHarness` fatal):
+```
+      `  kaizen --harness <marketplace>/<name>[@<version>]\n` +
+```
+
+- [ ] **Step 3: Update `src/core/plugin-manager.ts` — 2 occurrences**
+
+Line 139 (comment):
+```
+  // Canonical marketplace ref: "<id>/<name>[@<version>]" → marketplace install dir.
+```
+
+Line 160 (error message install hint):
+```
+    `  Install from marketplace: kaizen install <marketplace>/${name}[@<version>]\n` +
+```
+
+- [ ] **Step 4: Update `src/types/plugin.ts` — 1 occurrence**
+
+Line 239 (JSDoc):
+```
+  /** Canonical refs (`<marketplace>/<name>[@<version>]`) or legacy bare npm names. */
+```
+
+- [ ] **Step 5: Run tests to verify nothing broke**
+
+```bash
+bun test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli.ts src/core/config.ts src/core/plugin-manager.ts src/types/plugin.ts
+git commit -m "fix: update ref format strings to show @version as optional (#49)"
+```
+
+---
+
+## Task 4: Update documentation
+
+**Files:**
+- Modify: `docs/concepts/harnesses.md`
+- Modify: `docs/guides/marketplace-authoring.md`
+
+- [ ] **Step 1: Update `docs/concepts/harnesses.md`**
+
+Line 22 — change:
+```
+The ref format is `<marketplace-id>/<name>@<version>`. kaizen materializes the
+```
+to:
+```
+The ref format is `<marketplace-id>/<name>[@<version>]`. kaizen materializes the
+```
+
+Line 56 — change:
+```
+(`<marketplace-id>/<name>@<version>`), either via `--harness` or via `extends`.
+```
+to:
+```
+(`<marketplace-id>/<name>[@<version>]`), either via `--harness` or via `extends`.
+```
+
+Line 102 — change:
+```
+Plugin entries must be full marketplace refs (`<marketplace>/<name>@<version>`)
+```
+to:
+```
+Plugin entries must be marketplace refs (`<marketplace>/<name>[@<version>]`)
+```
+
+Line 116 — change:
+```
+kaizen --harness <your-marketplace-id>/<harness-name>@<version>
+```
+to:
+```
+kaizen --harness <your-marketplace-id>/<harness-name>[@<version>]
+```
+
+- [ ] **Step 2: Update `docs/guides/marketplace-authoring.md`**
+
+Line 19 — change:
+```
+When a user runs `kaizen install <marketplace-id>/<plugin>@<version>`, kaizen
+```
+to:
+```
+When a user runs `kaizen install <marketplace-id>/<plugin>[@<version>]`, kaizen
+```
+
+Line 111 — change:
+```
+`<marketplace>/<name>@<version>` form — bare names are rejected.
+```
+to:
+```
+`<marketplace>/<name>[@<version>]` form — bare names are rejected.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/concepts/harnesses.md docs/guides/marketplace-authoring.md
+git commit -m "docs: update ref format to show @version as optional (#49)"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec: harness refs already work — confirmed, no code change needed there. ✓
+- Spec: plugin refs inside harness blocked by version guard — covered in Task 2. ✓
+- Spec: shorthand still rejected — preserved and message updated. ✓
+- Spec: auto-install (silent) — existing `runUnifiedInstall` path handles this. ✓
+- Spec: no new auto-update behavior — no marketplace TTL changes. ✓
+- Spec: lockfile unchanged — no lockfile changes in any task. ✓
+- Spec: docs + ~10 error message locations — Tasks 3 and 4 cover all listed locations. ✓
+- Type consistency: `MarketplaceCatalog` imported from `../types/plugin.js` in Task 2, used as `Record<string, MarketplaceCatalog>` — matches the same pattern as `install.ts`. ✓
+- `resolveRef` imported already in bootstrap via `parseRef` import — need to add it explicitly (Task 2 step 1 does this). ✓

--- a/docs/superpowers/specs/2026-04-23-version-less-refs-design.md
+++ b/docs/superpowers/specs/2026-04-23-version-less-refs-design.md
@@ -1,0 +1,105 @@
+# Version-less Harness and Plugin Refs
+
+**Issue:** [#49](https://github.com/CraightonH/kaizen/issues/49)
+**Date:** 2026-04-23
+**Status:** Approved
+
+## Summary
+
+Allow omitting `@<version>` from harness refs and plugin refs inside harness
+`kaizen.json` files. A version-less ref resolves to the latest version available
+in the marketplace catalog. If the entry is not installed, it is auto-installed
+silently.
+
+## Current State
+
+`parseRef` and `resolveRef` already handle version-less refs — `version` is
+optional in `ParsedRef`, and `pickLatestSemver` fires when no version is given.
+
+**Harness refs** (`--harness official/core-shell` or `defaults.harness:
+"official/core-shell"`) already work end-to-end. `materializeHarnessRef` calls
+`parseRef` → `resolveRef` → `installHarness`, none of which require a version.
+
+**Plugin refs inside harness `kaizen.json`** are blocked. `bootstrap.ts:71-73`
+throws if `version` is absent:
+
+```ts
+if (!version) {
+  throw new Error(`harness plugin ref '${refStr}' must include an explicit version`);
+}
+```
+
+In addition, approximately 10 places in source and docs document the ref format
+as `<marketplace>/<name>@<version>` (version required).
+
+## Design Decisions
+
+**Resolution strategy:** latest from marketplace catalog, via the existing
+`pickLatestSemver` path. No new resolution logic needed.
+
+**Auto-install:** silent. If the entry is not installed, resolve from catalog
+and install without prompting. Specifying a ref is sufficient expression of
+intent.
+
+**No auto-update:** this feature does not add any auto-update behavior.
+`kaizen update` remains the explicit upgrade path. Marketplace catalog refreshes
+already run in the background on a TTL; that is unchanged.
+
+**Lockfile:** no changes. The lockfile tracks plugin permission consent keyed by
+plugin name + version + hash. A version bump in the harness triggers a hash
+change, which already causes re-consent. No harness-level version tracking is
+needed.
+
+**Scope:** both harness refs and plugin refs inside `kaizen.json`. Symmetry is
+intentional — version-less means "give me latest now; pin when you need
+stability."
+
+**Shorthand plugin refs remain rejected.** A plugin ref like `timestamps`
+(no marketplace prefix) inside a harness `kaizen.json` is still an error.
+Marketplace qualification (`official/timestamps`) is required; only the
+`@version` suffix becomes optional.
+
+## Changes Required
+
+### 1. `src/core/bootstrap.ts` — remove the version guard
+
+Delete lines 71-73:
+
+```ts
+// REMOVE:
+if (!version) {
+  throw new Error(`harness plugin ref '${refStr}' must include an explicit version`);
+}
+```
+
+When `version` is `undefined`, `runUnifiedInstall` is called with the
+version-less ref string (e.g. `official/timestamps`). The install path already
+calls `resolveRef`, which picks latest and proceeds.
+
+### 2. Error messages and docs — update ref format notation
+
+Replace `<marketplace>/<name>@<version>` with `<marketplace>/<name>[@<version>]`
+(brackets indicate optional) in:
+
+| File | Location |
+|------|----------|
+| `src/core/bootstrap.ts` | shorthand error message (line 54) |
+| `src/core/config.ts` | fatal error messages (lines 65, 71, 131) |
+| `src/cli.ts` | help text and fatal message (lines 100, 517, 518, 602) |
+| `src/core/plugin-manager.ts` | comment and error (lines 139, 160) |
+| `src/types/plugin.ts` | JSDoc comment (line 239) |
+| `docs/concepts/harnesses.md` | ref format descriptions (lines 22, 56, 102, 116) |
+| `docs/guides/marketplace-authoring.md` | ref format (lines 19, 111) |
+
+### 3. Tests
+
+- Add `bootstrap.ts` test: version-less plugin ref resolves and installs without error.
+- Add `bootstrap.ts` test: shorthand (no marketplace prefix) still throws.
+- Update any existing tests that assert version is required in plugin refs.
+
+## Out of Scope
+
+- Bare shorthand plugin refs (`timestamps` without marketplace prefix) — still rejected.
+- Any new auto-update or version-drift behavior.
+- Changes to the lockfile schema.
+- Changes to `kaizen update`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,7 +97,7 @@ Subcommands:
   config {show|get|set|set-secret}
 
 Flags:
-  --harness <ref>                       harness ref (marketplace/name@version)
+  --harness <ref>                       harness ref (marketplace/name[@version])
   --trust-lockfile                      reuse existing lockfile; no prompts
   --non-interactive                     refuse any prompt-requiring consent
   --allow-unscoped                      permit non-interactive UNSCOPED consent
@@ -514,8 +514,8 @@ if (subcommand === "plugin") {
     case "remove":
       console.error(
         `'kaizen plugin ${pluginSub}' has been removed.\n` +
-        `  Install a plugin:   kaizen install <marketplace>/<name>@<version>\n` +
-        `  Uninstall a plugin: kaizen uninstall <marketplace>/<name>@<version>`,
+        `  Install a plugin:   kaizen install <marketplace>/<name>[@<version>]\n` +
+        `  Uninstall a plugin: kaizen uninstall <marketplace>/<name>[@<version>]`,
       );
       process.exit(2);
       break;
@@ -599,7 +599,7 @@ function parseRunArgs(args: string[]): {
 const parsed = parseRunArgs(rawArgs);
 
 if (parsed.harness !== undefined && /^https?:\/\//i.test(parsed.harness)) {
-  fatal("raw URL harnesses are not supported — publish the harness in a marketplace and use --harness <id>/<name>@<version>");
+  fatal("raw URL harnesses are not supported — publish the harness in a marketplace and use --harness <id>/<name>[@<version>]");
 }
 
 const trustLockfile = rawArgs.includes("--trust-lockfile");

--- a/src/core/bootstrap.test.ts
+++ b/src/core/bootstrap.test.ts
@@ -66,4 +66,25 @@ describe("bootstrapMissingPlugins", () => {
       { lockfilePath, trustLockfile: true, nonInteractive: true, allowUnscoped: false },
     )).rejects.toThrow(/not in lockfile/i);
   });
+
+  it("version-less ref installs latest version (1.0.0 from fixture catalog)", async () => {
+    await addMarketplace(upstream, { id: "m", local: true });
+    const lockfilePath = join(home, "permissions.lock");
+    const report = await bootstrapMissingPlugins(
+      { plugins: ["m/demo"], marketplaces: [] },
+      { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: false },
+    );
+    expect(report.pluginsInstalled).toContain("m/demo");
+    expect(existsSync(pluginInstallDir("m", "demo", "1.0.0"))).toBe(true);
+  });
+
+  it("version-less ref skips reinstall on second bootstrap run", async () => {
+    await addMarketplace(upstream, { id: "m", local: true });
+    const lockfilePath = join(home, "permissions.lock");
+    const opts = { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: false };
+    await bootstrapMissingPlugins({ plugins: ["m/demo"], marketplaces: [] }, opts);
+    expect(existsSync(pluginInstallDir("m", "demo", "1.0.0"))).toBe(true);
+    const report2 = await bootstrapMissingPlugins({ plugins: ["m/demo"], marketplaces: [] }, opts);
+    expect(report2.pluginsInstalled).toHaveLength(0);
+  });
 });

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -1,7 +1,7 @@
-import type { KaizenConfig, MarketplaceRef } from "../types/plugin.js";
+import type { KaizenConfig, MarketplaceRef, MarketplaceCatalog } from "../types/plugin.js";
 import { loadKaizenGlobalConfig } from "./kaizen-config.js";
-import { addMarketplace } from "./marketplace.js";
-import { parseRef } from "./ref-resolver.js";
+import { addMarketplace, readCatalog } from "./marketplace.js";
+import { parseRef, resolveRef } from "./ref-resolver.js";
 import { readLockfile } from "./lockfile.js";
 import { runUnifiedInstall } from "../commands/install.js";
 import { isInstalled } from "./plugin-manager.js";
@@ -45,13 +45,15 @@ export async function bootstrapMissingPlugins(
 
   // 2. Install missing plugins.
   const lockfile = readLockfile(opts.lockfilePath);
+  let catalogs: Record<string, MarketplaceCatalog> | undefined;
+
   for (const refStr of harness.plugins ?? []) {
     const parsed = parseRef(refStr);
 
     if (parsed.kind === "shorthand") {
       throw new Error(
         `harness plugin ref '${refStr}' is shorthand. ` +
-        `Harness plugin refs must be canonical '<marketplace>/<name>@<version>'.`,
+        `Harness plugin refs must be canonical '<marketplace>/<name>[@<version>]'.`,
       );
     }
 
@@ -67,9 +69,23 @@ export async function bootstrapMissingPlugins(
       marketplaceId = "official";
       name = parsed.name.replace(/^kaizen-plugin-/, "");
       version = undefined;
+      // resolveRef strips the same prefix from parsed.name independently; both strip the same prefix once.
     }
+
+    // Version-less ref: resolve against the catalog to get the concrete version
+    // so we can use the isInstalled short-circuit below.
     if (!version) {
-      throw new Error(`harness plugin ref '${refStr}' must include an explicit version`);
+      if (!catalogs) {
+        catalogs = {};
+        for (const m of global.marketplaces ?? []) {
+          try { catalogs[m.id] = await readCatalog(m.id); } catch { /* skip bad */ }
+        }
+      }
+      try {
+        version = resolveRef(parsed, catalogs).version;
+      } catch (e) {
+        throw new Error(`cannot resolve version for harness ref '${refStr}': ${(e as Error).message}`);
+      }
     }
 
     if (await isInstalled(marketplaceId, name, version)) continue;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -24,7 +24,7 @@ export const RESERVED_KEYS = new Set(["plugins", "extends"]);
 // Harness resolution
 //
 // Harnesses are resolved through the marketplace install path. A canonical
-// ref (`<marketplace>/<name>@<version>`) is materialized by cli.ts before
+// ref (`<marketplace>/<name>[@<version>]`) is materialized by cli.ts before
 // reaching this function; here we handle the resulting local paths and the
 // project/home fallback directories.
 // ---------------------------------------------------------------------------
@@ -62,13 +62,13 @@ export function resolveHarness(nameOrPath: string): ResolvedHarness {
   if (nameOrPath.startsWith("http://") || nameOrPath.startsWith("https://")) {
     fatal(
       `URL harnesses are not supported.\n` +
-      `Publish the harness in a marketplace and reference it as '<marketplace>/<name>@<version>'.`,
+      `Publish the harness in a marketplace and reference it as '<marketplace>/<name>[@<version>]'.`,
     );
   }
 
   fatal(
     `Harness '${nameOrPath}' not found.\n` +
-    `  Marketplace:    kaizen install <marketplace>/${nameOrPath}@<version>\n` +
+    `  Marketplace:    kaizen install <marketplace>/${nameOrPath}[@<version>]\n` +
     `  Project-scoped: .kaizen/harnesses/${nameOrPath}/kaizen.json\n` +
     `  Global:         ~/.kaizen/harnesses/${nameOrPath}/kaizen.json\n` +
     `  Path:           ./path/to/kaizen.json`,
@@ -128,7 +128,7 @@ export function resolveHarnessOrFatal(opts: {
   if (!ref) {
     fatal(
       `A harness is required.\n` +
-      `  kaizen --harness <marketplace>/<name>@<version>\n` +
+      `  kaizen --harness <marketplace>/<name>[@<version>]\n` +
       `  kaizen --harness ./path/to/harness/\n` +
       `  Set 'defaults.harness' in ~/.kaizen/kaizen.json\n` +
       `See docs/concepts/configuration.md.`,

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -136,7 +136,7 @@ async function loadPluginFromMarketplaceInstall(
 async function resolvePlugin(name: string): Promise<LoadedPlugin | null> {
   const isPath = name.startsWith("./") || name.startsWith("/") || name.startsWith("../");
 
-  // Canonical marketplace ref: "<id>/<name>@<version>" → marketplace install dir.
+  // Canonical marketplace ref: "<id>/<name>[@<version>]" → marketplace install dir.
   if (!isPath) {
     try {
       const parsed = parseRef(name);
@@ -157,7 +157,7 @@ async function resolvePlugin(name: string): Promise<LoadedPlugin | null> {
 
   warn(
     `Cannot find plugin '${name}'.\n` +
-    `  Install from marketplace: kaizen install <marketplace>/${name}@<version>\n` +
+    `  Install from marketplace: kaizen install <marketplace>/${name}[@<version>]\n` +
     `  Or reference a local path: "./path/to/plugin"`,
   );
   return null;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -236,7 +236,7 @@ export interface KaizenPlugin {
 // ---------------------------------------------------------------------------
 
 export interface KaizenConfig {
-  /** Canonical refs (`<marketplace>/<name>@<version>`) or legacy bare npm names. */
+  /** Canonical refs (`<marketplace>/<name>[@<version>]`) or legacy bare npm names. */
   plugins: string[];
   /**
    * Name of a built-in or installed harness to extend.


### PR DESCRIPTION
## Summary

- `@<version>` is now optional in harness refs (`--harness official/core-shell`) and plugin refs inside harness `kaizen.json` (`official/timestamps`)
- Version-less refs resolve to the latest version in the marketplace catalog; if not installed, auto-install silently
- No auto-update behavior added — `kaizen update` remains the explicit upgrade path
- Lockfile unchanged; plugin permission re-consent is still triggered by version/hash changes as before

## Changes

- `src/core/bootstrap.ts`: removed version guard; added lazy catalog loading + `resolveRef` to get concrete version for the `isInstalled` short-circuit
- Error messages and help text updated from `<name>@<version>` to `<name>[@<version>]` across `cli.ts`, `config.ts`, `plugin-manager.ts`, `types/plugin.ts`
- Docs updated: `harnesses.md`, `marketplace-authoring.md`, `architecture.md`, `plugin-model.md`, `plugin-api.md`

## Test Plan

- [ ] `bun test` passes (399 tests)
- [ ] `kaizen --harness official/core-shell` (no version) resolves and installs
- [ ] Harness with `plugins: ["official/timestamps"]` bootstraps without error
- [ ] Second run with same version-less plugin ref skips reinstall

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)