### PR TITLE
fix(bootstrap): support local-path plugin refs in harness (#36)

### DIFF
--- a/docs/concepts/harnesses.md
+++ b/docs/concepts/harnesses.md
@@ -99,9 +99,11 @@ The `kaizen.json` lists plugins (by marketplace ref) and their config:
 }
 ```
 
-Plugin entries must be marketplace refs (`<marketplace>/<name>[@<version>]`)
-for the harness to be portable. Bare short names only resolve against locally
-installed plugins and won't work for others.
+Plugin entries may be marketplace refs (`<marketplace>/<name>[@<version>]`) or
+local paths (`./`, `../`, `/`). Local paths are loaded directly by the plugin
+manager and skipped during bootstrap install — useful for dev-time iteration on
+first-party plugins. Use marketplace refs for portable harnesses you intend to
+share.
 
 ## Sharing a harness
 

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -286,7 +286,7 @@ harness-authored providers.
 
 ```ts
 export interface KaizenConfig {
-  plugins: string[];           // canonical marketplace refs "<marketplace-id>/<name>[@<version>]"
+  plugins: string[];           // marketplace refs "<marketplace-id>/<name>[@<version>]" or local paths ("./", "../", "/")
   extends?: string;            // harness to extend: marketplace ref or local path
   marketplaces?: MarketplaceRef[];
   [pluginName: string]: unknown;  // per-plugin config slices

--- a/src/core/bootstrap.test.ts
+++ b/src/core/bootstrap.test.ts
@@ -78,6 +78,15 @@ describe("bootstrapMissingPlugins", () => {
     expect(existsSync(pluginInstallDir("m", "demo", "1.0.0"))).toBe(true);
   });
 
+  it("skips local-path plugin refs without attempting install", async () => {
+    const lockfilePath = join(home, "permissions.lock");
+    const report = await bootstrapMissingPlugins(
+      { plugins: ["./some/local-plugin", "../other-plugin", "/abs/plugin"], marketplaces: [] },
+      { lockfilePath, trustLockfile: false, nonInteractive: true, allowUnscoped: false },
+    );
+    expect(report.pluginsInstalled).toHaveLength(0);
+  });
+
   it("version-less ref skips reinstall on second bootstrap run", async () => {
     await addMarketplace(upstream, { id: "m", local: true });
     const lockfilePath = join(home, "permissions.lock");

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -48,6 +48,9 @@ export async function bootstrapMissingPlugins(
   let catalogs: Record<string, MarketplaceCatalog> | undefined;
 
   for (const refStr of harness.plugins ?? []) {
+    // Local-path plugins don't need marketplace install — resolvePlugin loads them directly.
+    if (refStr.startsWith("./") || refStr.startsWith("../") || refStr.startsWith("/")) continue;
+
     const parsed = parseRef(refStr);
 
     if (parsed.kind === "shorthand") {


### PR DESCRIPTION
## Summary

- `bootstrapMissingPlugins` now skips local-path refs (`./`, `../`, `/`) instead of calling `parseRef` and throwing `RefParseError`
- Local-path plugins don't need marketplace install — `resolvePlugin` loads them directly at runtime
- Fixes end-to-end boot for harnesses that use local-path plugins (e.g. dev iteration on first-party plugin suites)
- Docs updated: `plugin-api.md` and `harnesses.md` now reflect that `plugins[]` accepts both marketplace refs and local paths

Closes #36.

## Test Plan

- [x] New test: `bootstrapMissingPlugins` with `./`, `../`, `/` refs completes without error and reports zero installs
- [x] All 397 existing tests pass