### PR TITLE
feat: kaizen plugin consent --all

### DIFF
--- a/docs/concepts/harnesses.md
+++ b/docs/concepts/harnesses.md
@@ -23,7 +23,9 @@ The ref format is `<marketplace-id>/<name>[@<version>]`. kaizen materializes the
 harness into `~/.kaizen/marketplaces/<id>/harnesses/<name>/kaizen.json` on first
 use, then loads it. Any marketplaces and plugins the harness references are
 bootstrapped automatically (with consent prompts unless `--non-interactive` /
-`--trust-lockfile` is set).
+`--trust-lockfile` is set). For CI environments, run
+`kaizen plugin consent --all --harness <ref>` once to pre-consent every plugin
+in the harness before the first non-interactive run.
 
 Add marketplaces with `kaizen marketplace add <url>` before referencing their
 harnesses.

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -98,7 +98,8 @@ marketplace: `~/.kaizen/marketplaces/<id>/harnesses/<name>/permissions.lock`). R
 Workflow:
 - `kaizen install <plugin>` — resolve, read manifest, run consent, write lockfile
 - `kaizen plugin review <plugin>` — diff declared manifest vs. lockfile
-- `kaizen plugin consent <plugin>` — re-consent after a version bump
+- `kaizen plugin consent <plugin> --harness <ref>` — re-consent a single plugin after a version bump
+- `kaizen plugin consent --all --harness <ref>` — bulk pre-consent all plugins in a harness non-interactively (CI/automation); grants scoped and unscoped tiers without prompting
 - `kaizen plugin audit` — list all lockfile entries; flag UNSCOPED
 
 ## Common pitfalls

--- a/docs/superpowers/plans/2026-04-27-plugin-consent-all.md
+++ b/docs/superpowers/plans/2026-04-27-plugin-consent-all.md
@@ -1,0 +1,513 @@
+# `kaizen plugin consent --all` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `kaizen plugin consent --all` — a non-interactive command that bulk pre-consents every plugin declared in a harness, printing a full summary.
+
+**Architecture:** `allowScoped` is added to `ConsentInput` so scoped plugins can be consented without prompting. A new `runPluginConsentAll` command iterates `harnessConfig.plugins`, skips local-path refs, installs+consents each marketplace plugin, collects outcomes, and prints a summary table. The CLI routes `plugin consent --all` to this new command.
+
+**Tech Stack:** TypeScript, Bun runtime, `bun:test`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/core/consent-flow.ts` | Add `allowScoped: boolean` to `ConsentInput`; update `decideConsent` scoped branch |
+| `src/core/consent-flow.test.ts` | Add two new test cases for `allowScoped` |
+| `src/commands/install.ts` | Add `allowScoped?: boolean` to `UnifiedInstallArgs`; pass to `decideConsent` |
+| `src/commands/plugin-consent-all.ts` | New — harness walk, per-plugin consent, summary renderer |
+| `src/commands/plugin-consent-all.test.ts` | New — unit tests for `formatSummary` + `decideConsent` integration |
+| `src/cli.ts` | Capture `config` from `resolveHarnessOrFatal`; detect `--all`; call `runPluginConsentAll` |
+
+---
+
+## Task 1: Add `allowScoped` to `ConsentInput` and `decideConsent`
+
+**Files:**
+- Modify: `src/core/consent-flow.ts`
+- Modify: `src/core/consent-flow.test.ts`
+
+- [ ] **Step 1: Write two failing tests**
+
+Append to `src/core/consent-flow.test.ts`:
+
+```ts
+test("scoped plugin, non-interactive, allowScoped: true → accept-and-record", () => {
+  const lf: PermissionsLockfile = { schemaVersion: 1, plugins: {} };
+  const decision = decideConsent({
+    pluginName: "p1", version: "1.0", hash: "sha256:abc",
+    permissions: { tier: "scoped", env: ["KEY"] },
+    lockfile: lf, interactive: false,
+    allowUnscoped: false, allowScoped: true,
+  });
+  expect(decision.kind).toBe("accept-and-record");
+});
+
+test("scoped plugin, non-interactive, allowScoped: false → refuse (regression guard)", () => {
+  const lf: PermissionsLockfile = { schemaVersion: 1, plugins: {} };
+  const decision = decideConsent({
+    pluginName: "p1", version: "1.0", hash: "sha256:abc",
+    permissions: { tier: "scoped", env: ["KEY"] },
+    lockfile: lf, interactive: false,
+    allowUnscoped: false, allowScoped: false,
+  });
+  expect(decision.kind).toBe("refuse");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+bun test src/core/consent-flow.test.ts 2>&1 | tail -10
+```
+
+Expected: 2 failures mentioning `allowScoped` is not a known property.
+
+- [ ] **Step 3: Add `allowScoped` to `ConsentInput` and update `decideConsent`**
+
+In `src/core/consent-flow.ts`, update `ConsentInput`:
+
+```ts
+export interface ConsentInput {
+  pluginName: string;
+  version: string;
+  hash: string;
+  permissions: PluginPermissions;
+  lockfile: PermissionsLockfile;
+  interactive: boolean;
+  allowUnscoped: boolean;
+  allowScoped: boolean;
+}
+```
+
+Update the scoped branch in `decideConsent`:
+
+```ts
+if (tier === "scoped") {
+  if (input.interactive) return { kind: "prompt-scoped", entry: nowEntry };
+  if (input.allowScoped) return { kind: "accept-and-record", entry: { ...nowEntry, consentMode: "flag" } };
+  return { kind: "refuse", reason: `plugin '${input.pluginName}' requires SCOPED-tier consent. Run interactively, or pre-consent with: kaizen plugin consent ${input.pluginName} --harness <harness-path>` };
+}
+```
+
+- [ ] **Step 4: Fix the existing `decideConsent` call in `src/commands/install.ts`**
+
+Find the `decideConsent({...})` call (around line 70) and add `allowScoped: false`:
+
+```ts
+const decision = decideConsent({
+  pluginName: resolved.entry.name,
+  version, hash, permissions, lockfile,
+  interactive: !args.nonInteractive && process.stdin.isTTY === true,
+  allowUnscoped: args.allowUnscoped,
+  allowScoped: false,
+});
+```
+
+- [ ] **Step 5: Run all tests to verify they pass**
+
+```bash
+bun test src/core/consent-flow.test.ts 2>&1 | tail -5
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run full suite to check for regressions**
+
+```bash
+bun test 2>&1 | tail -5
+```
+
+Expected: same pass count as before (394 pass, 2 skip, 0 fail).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/consent-flow.ts src/core/consent-flow.test.ts src/commands/install.ts
+git commit -m "feat(consent): add allowScoped to ConsentInput; non-interactive scoped consent path"
+```
+
+---
+
+## Task 2: Add `allowScoped` to `UnifiedInstallArgs`
+
+**Files:**
+- Modify: `src/commands/install.ts`
+
+- [ ] **Step 1: Add `allowScoped` to `UnifiedInstallArgs`**
+
+```ts
+export interface UnifiedInstallArgs {
+  ref: string;
+  lockfilePath: string;
+  allowUnscoped: boolean;
+  allowScoped?: boolean;
+  nonInteractive: boolean;
+}
+```
+
+- [ ] **Step 2: Pass it to `decideConsent` in `runUnifiedInstall`**
+
+Update the `decideConsent` call (the one you patched in Task 1, Step 4):
+
+```ts
+const decision = decideConsent({
+  pluginName: resolved.entry.name,
+  version, hash, permissions, lockfile,
+  interactive: !args.nonInteractive && process.stdin.isTTY === true,
+  allowUnscoped: args.allowUnscoped,
+  allowScoped: args.allowScoped ?? false,
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+bun test 2>&1 | tail -5
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/install.ts
+git commit -m "feat(install): thread allowScoped through UnifiedInstallArgs"
+```
+
+---
+
+## Task 3: Create `plugin-consent-all.ts`
+
+**Files:**
+- Create: `src/commands/plugin-consent-all.ts`
+- Create: `src/commands/plugin-consent-all.test.ts`
+
+- [ ] **Step 1: Write tests for `formatSummary`**
+
+Create `src/commands/plugin-consent-all.test.ts`:
+
+```ts
+import { describe, test, expect } from "bun:test";
+import { formatSummary } from "./plugin-consent-all.js";
+import type { ConsentAllOutcome } from "./plugin-consent-all.js";
+
+describe("formatSummary", () => {
+  test("renders all outcome types and correct totals", () => {
+    const outcomes: ConsentAllOutcome[] = [
+      { status: "consented", ref: "mkt/session-driver@1.0.0", tier: "scoped" },
+      { status: "consented", ref: "mkt/ui-plugin@0.4.1",      tier: "unscoped" },
+      { status: "already",   ref: "mkt/secrets@2.0.0",        tier: "trusted" },
+      { status: "skipped",   ref: "./local-plugin" },
+      { status: "refused",   ref: "mkt/bad-plugin@0.1.0",     reason: "hash mismatch" },
+    ];
+    const out = formatSummary("./kaizen.json", outcomes);
+    expect(out).toContain("✓ consented");
+    expect(out).toContain("○ already");
+    expect(out).toContain("- skipped");
+    expect(out).toContain("✗ refused");
+    expect(out).toContain("hash mismatch");
+    expect(out).toContain("5 plugins");
+    expect(out).toContain("2 consented");
+    expect(out).toContain("1 already consented");
+    expect(out).toContain("1 refused");
+    expect(out).toContain("1 skipped");
+  });
+
+  test("omits zero-count categories from totals line", () => {
+    const outcomes: ConsentAllOutcome[] = [
+      { status: "consented", ref: "mkt/plugin@1.0.0", tier: "trusted" },
+    ];
+    const out = formatSummary("./kaizen.json", outcomes);
+    expect(out).not.toContain("refused");
+    expect(out).not.toContain("skipped");
+    expect(out).toContain("1 plugins: 1 consented.");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+bun test src/commands/plugin-consent-all.test.ts 2>&1 | tail -5
+```
+
+Expected: fail — module not found.
+
+- [ ] **Step 3: Create `src/commands/plugin-consent-all.ts`**
+
+```ts
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { KaizenConfig, MarketplaceCatalog } from "../types/plugin.js";
+import { parseRef, resolveRef } from "../core/ref-resolver.js";
+import { loadKaizenGlobalConfig } from "../core/kaizen-config.js";
+import { readCatalog } from "../core/marketplace.js";
+import { installPlugin } from "../core/plugin-installer.js";
+import { loadPluginFromInstallDir } from "../core/plugin-loader.js";
+import { pluginInstallDir } from "../core/kaizen-config.js";
+import { isInstalled } from "../core/plugin-manager.js";
+import { canonicalTierGrantHash } from "../core/plugin-hash.js";
+import { decideConsent } from "../core/consent-flow.js";
+import { readLockfile, writeLockfile, upsertPluginEntry } from "../core/lockfile.js";
+
+export type ConsentAllOutcome =
+  | { status: "consented"; ref: string; tier: string }
+  | { status: "already";   ref: string; tier: string }
+  | { status: "refused";   ref: string; reason: string }
+  | { status: "skipped";   ref: string };
+
+export async function runPluginConsentAll(args: {
+  harnessConfig: KaizenConfig;
+  harnessJsonPath: string;
+  lockfilePath: string;
+}): Promise<number> {
+  const outcomes: ConsentAllOutcome[] = [];
+  const catalogs = await loadCatalogs();
+
+  for (const refStr of args.harnessConfig.plugins ?? []) {
+    if (refStr.startsWith("./") || refStr.startsWith("../") || refStr.startsWith("/")) {
+      outcomes.push({ status: "skipped", ref: refStr });
+      continue;
+    }
+
+    try {
+      const parsed = parseRef(refStr);
+      const resolved = resolveRef(parsed, catalogs);
+
+      if (resolved.entry.kind === "harness") {
+        outcomes.push({ status: "skipped", ref: refStr });
+        continue;
+      }
+
+      const { marketplaceId, version } = resolved;
+      const name = resolved.entry.name;
+
+      if (!(await isInstalled(marketplaceId, name, version))) {
+        await installPlugin(marketplaceId, name, version, resolved.pluginVersion!.source);
+      }
+
+      const dir = pluginInstallDir(marketplaceId, name, version);
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as { version?: string };
+      const pkgVersion = pkg.version ?? version;
+      const plugin = await loadPluginFromInstallDir(marketplaceId, name, version);
+      const permissions = plugin.permissions ?? { tier: "trusted" as const };
+      const hash = canonicalTierGrantHash(permissions);
+      const lockfile = readLockfile(args.lockfilePath);
+      const tier = permissions.tier ?? "trusted";
+
+      const decision = decideConsent({
+        pluginName: name, version: pkgVersion, hash, permissions, lockfile,
+        interactive: false, allowUnscoped: true, allowScoped: true,
+      });
+
+      if (decision.kind === "accept") {
+        outcomes.push({ status: "already", ref: refStr, tier });
+      } else if (decision.kind === "accept-and-record") {
+        writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, name, decision.entry));
+        outcomes.push({ status: "consented", ref: refStr, tier });
+      } else {
+        outcomes.push({ status: "refused", ref: refStr, reason: decision.reason });
+      }
+    } catch (e) {
+      outcomes.push({ status: "refused", ref: refStr, reason: (e as Error).message });
+    }
+  }
+
+  console.log(formatSummary(args.harnessJsonPath, outcomes));
+  return outcomes.some((o) => o.status === "refused") ? 1 : 0;
+}
+
+export function formatSummary(harnessPath: string, outcomes: ConsentAllOutcome[]): string {
+  const lines: string[] = [`\nplugin consent --all  (harness: ${harnessPath})\n`];
+
+  for (const o of outcomes) {
+    if (o.status === "consented") lines.push(`  ✓ consented   ${o.ref.padEnd(45)} (${o.tier})`);
+    if (o.status === "already")   lines.push(`  ○ already     ${o.ref.padEnd(45)} (${o.tier})`);
+    if (o.status === "skipped")   lines.push(`  - skipped     ${o.ref}`);
+    if (o.status === "refused") {
+      lines.push(`  ✗ refused     ${o.ref}`);
+      lines.push(`    reason: ${o.reason}`);
+    }
+  }
+
+  const consented = outcomes.filter((o) => o.status === "consented").length;
+  const already   = outcomes.filter((o) => o.status === "already").length;
+  const refused   = outcomes.filter((o) => o.status === "refused").length;
+  const skipped   = outcomes.filter((o) => o.status === "skipped").length;
+
+  const parts = [
+    consented && `${consented} consented`,
+    already   && `${already} already consented`,
+    refused   && `${refused} refused`,
+    skipped   && `${skipped} skipped`,
+  ].filter(Boolean);
+
+  lines.push(`\n${outcomes.length} plugins: ${parts.join(", ")}.`);
+  return lines.join("\n");
+}
+
+async function loadCatalogs(): Promise<Record<string, MarketplaceCatalog>> {
+  const cfg = await loadKaizenGlobalConfig();
+  const out: Record<string, MarketplaceCatalog> = {};
+  for (const ref of cfg.marketplaces ?? []) {
+    try { out[ref.id] = await readCatalog(ref.id); } catch { /* skip bad */ }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+bun test src/commands/plugin-consent-all.test.ts 2>&1 | tail -5
+```
+
+Expected: 2 pass.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+bun test 2>&1 | tail -5
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/plugin-consent-all.ts src/commands/plugin-consent-all.test.ts
+git commit -m "feat: add runPluginConsentAll command with summary output"
+```
+
+---
+
+## Task 4: Wire `--all` into the CLI
+
+**Files:**
+- Modify: `src/cli.ts`
+
+- [ ] **Step 1: Capture `config` from `resolveHarnessOrFatal` in the consent handler**
+
+In `src/cli.ts`, find the `needsHarness` block (around line 407). It currently reads:
+
+```ts
+const { kaizenJsonPath } = resolveHarnessOrFatal(harnessArg !== undefined ? { harness: harnessArg } : {});
+lockfilePath = deriveLockfilePath(kaizenJsonPath);
+```
+
+Change it to also capture `config` and the resolved path:
+
+```ts
+const { kaizenJsonPath, config: resolvedHarnessConfig } = resolveHarnessOrFatal(
+  harnessArg !== undefined ? { harness: harnessArg } : {},
+);
+lockfilePath = deriveLockfilePath(kaizenJsonPath);
+```
+
+Also declare `resolvedHarnessConfig` and `resolvedHarnessJsonPath` in the outer scope so the `--all` branch below can use them. Change the `needsHarness` block to:
+
+```ts
+let lockfilePath = "";
+let resolvedHarnessConfig: import("./types/plugin.js").KaizenConfig | undefined;
+let resolvedHarnessJsonPath = "";
+if (needsHarness) {
+  const harnessIdx = rest.indexOf("--harness");
+  let harnessArg = harnessIdx !== -1 ? rest[harnessIdx + 1] : undefined;
+  if (!harnessArg) {
+    const globalCfg = await loadKaizenGlobalConfig();
+    harnessArg = globalCfg.defaults?.harness;
+  }
+  if (harnessArg) {
+    const { looksLikeHarnessRef, materializeHarnessRef } = await import("./core/kaizen-config.js");
+    if (looksLikeHarnessRef(harnessArg)) harnessArg = await materializeHarnessRef(harnessArg);
+  }
+  const { kaizenJsonPath, config } = resolveHarnessOrFatal(
+    harnessArg !== undefined ? { harness: harnessArg } : {},
+  );
+  lockfilePath = deriveLockfilePath(kaizenJsonPath);
+  resolvedHarnessConfig = config;
+  resolvedHarnessJsonPath = kaizenJsonPath;
+}
+```
+
+- [ ] **Step 2: Add the `--all` branch in the `plugin consent` handler**
+
+Find the block:
+
+```ts
+if (pluginSub === "consent" && name) {
+```
+
+Add `--all` detection *before* it:
+
+```ts
+if (pluginSub === "consent" && rest.includes("--all")) {
+  const { runPluginConsentAll } = await import("./commands/plugin-consent-all.js");
+  const code = await runPluginConsentAll({
+    harnessConfig: resolvedHarnessConfig!,
+    harnessJsonPath: resolvedHarnessJsonPath,
+    lockfilePath,
+  });
+  process.exit(code);
+}
+
+if (pluginSub === "consent" && name) {
+```
+
+- [ ] **Step 3: Update help text to document `--all`**
+
+Find the help text line `plugin {list|consent|review|audit|dev|create|validate}`. Update the Notes section added in the previous fix to include `--all`:
+
+```
+Notes:
+  'plugin consent|review|audit' require a harness to locate the lockfile.
+  Pass --harness after the subcommand, or set defaults.harness in
+  ~/.kaizen/kaizen.json to avoid passing it every time:
+    kaizen plugin consent <name> --harness ./path/to/harness.json
+    kaizen plugin consent --all  --harness ./path/to/harness.json
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+bun run typecheck 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+bun test 2>&1 | tail -5
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli.ts
+git commit -m "feat(cli): wire kaizen plugin consent --all to runPluginConsentAll"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- ✓ CLI surface: `kaizen plugin consent --all [--harness <ref>]` — Task 4
+- ✓ `allowScoped` added to `ConsentInput` + `decideConsent` — Task 1
+- ✓ `--all` passes `allowScoped: true, allowUnscoped: true` — Task 3
+- ✓ Local-path refs skipped — Task 3
+- ✓ Already-consented plugins shown as `already` — Task 3
+- ✓ Summary format with ✓/○/-/✗ rows and totals line — Task 3
+- ✓ Exit `0` on all consented/already, `1` on any refused — Task 3
+- ✓ `--harness` resolution (flag → defaults.harness) — Task 4 (reuses existing block)
+- ✓ Tests: `allowScoped` unit cases — Task 1; `formatSummary` unit tests — Task 3
+
+**Type consistency:** `ConsentAllOutcome` defined in Task 3 and exported; imported in test — consistent. `resolvedHarnessConfig` typed as `KaizenConfig | undefined`, non-null asserted at call site where `needsHarness` guarantees it was set.
+
+**No placeholders found.**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,6 +101,7 @@ Notes:
   Pass --harness after the subcommand, or set defaults.harness in
   ~/.kaizen/kaizen.json to avoid passing it every time:
     kaizen plugin consent <name> --harness ./path/to/harness.json
+    kaizen plugin consent --all  --harness ./path/to/harness.json
   --allow-destructive                   enable destructive CLI tools
   --help, -h                            show this help
 
@@ -406,6 +407,8 @@ if (subcommand === "plugin") {
   // list/create/validate don't need an active harness; consent/review/audit do.
   const needsHarness = pluginSub === "consent" || pluginSub === "review" || pluginSub === "audit";
   let lockfilePath = "";
+  let resolvedHarnessConfig: import("./types/plugin.js").KaizenConfig | undefined;
+  let resolvedHarnessJsonPath = "";
   if (needsHarness) {
     const harnessIdx = rest.indexOf("--harness");
     let harnessArg = harnessIdx !== -1 ? rest[harnessIdx + 1] : undefined;
@@ -417,8 +420,22 @@ if (subcommand === "plugin") {
       const { looksLikeHarnessRef, materializeHarnessRef } = await import("./core/kaizen-config.js");
       if (looksLikeHarnessRef(harnessArg)) harnessArg = await materializeHarnessRef(harnessArg);
     }
-    const { kaizenJsonPath } = resolveHarnessOrFatal(harnessArg !== undefined ? { harness: harnessArg } : {});
+    const { kaizenJsonPath, config } = resolveHarnessOrFatal(
+      harnessArg !== undefined ? { harness: harnessArg } : {},
+    );
     lockfilePath = deriveLockfilePath(kaizenJsonPath);
+    resolvedHarnessConfig = config;
+    resolvedHarnessJsonPath = kaizenJsonPath;
+  }
+
+  if (pluginSub === "consent" && rest.includes("--all")) {
+    const { runPluginConsentAll } = await import("./commands/plugin-consent-all.js");
+    const code = await runPluginConsentAll({
+      harnessConfig: resolvedHarnessConfig!,
+      harnessJsonPath: resolvedHarnessJsonPath,
+      lockfilePath,
+    });
+    process.exit(code);
   }
 
   if (pluginSub === "consent" && name) {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -19,6 +19,7 @@ export interface UnifiedInstallArgs {
   ref: string;
   lockfilePath: string;
   allowUnscoped: boolean;
+  allowScoped?: boolean;
   nonInteractive: boolean;
 }
 
@@ -67,7 +68,7 @@ export async function runUnifiedInstall(args: UnifiedInstallArgs): Promise<numbe
     version, hash, permissions, lockfile,
     interactive: !args.nonInteractive && process.stdin.isTTY === true,
     allowUnscoped: args.allowUnscoped,
-    allowScoped: false,
+    allowScoped: args.allowScoped ?? false,
   });
 
   const canonical = `${resolved.marketplaceId}/${resolved.entry.name}@${resolved.version}`;

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -67,6 +67,7 @@ export async function runUnifiedInstall(args: UnifiedInstallArgs): Promise<numbe
     version, hash, permissions, lockfile,
     interactive: !args.nonInteractive && process.stdin.isTTY === true,
     allowUnscoped: args.allowUnscoped,
+    allowScoped: false,
   });
 
   const canonical = `${resolved.marketplaceId}/${resolved.entry.name}@${resolved.version}`;

--- a/src/commands/plugin-consent-all.test.ts
+++ b/src/commands/plugin-consent-all.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "bun:test";
+import { formatSummary } from "./plugin-consent-all.js";
+import type { ConsentAllOutcome } from "./plugin-consent-all.js";
+
+describe("formatSummary", () => {
+  test("renders all outcome types and correct totals", () => {
+    const outcomes: ConsentAllOutcome[] = [
+      { status: "consented", ref: "mkt/session-driver@1.0.0", tier: "scoped" },
+      { status: "consented", ref: "mkt/ui-plugin@0.4.1",      tier: "unscoped" },
+      { status: "already",   ref: "mkt/secrets@2.0.0",        tier: "trusted" },
+      { status: "skipped",   ref: "./local-plugin" },
+      { status: "refused",   ref: "mkt/bad-plugin@0.1.0",     reason: "hash mismatch" },
+    ];
+    const out = formatSummary("./kaizen.json", outcomes);
+    expect(out).toContain("✓ consented");
+    expect(out).toContain("○ already");
+    expect(out).toContain("- skipped");
+    expect(out).toContain("✗ refused");
+    expect(out).toContain("hash mismatch");
+    expect(out).toContain("5 plugins");
+    expect(out).toContain("2 consented");
+    expect(out).toContain("1 already consented");
+    expect(out).toContain("1 refused");
+    expect(out).toContain("1 skipped");
+  });
+
+  test("omits zero-count categories from totals line", () => {
+    const outcomes: ConsentAllOutcome[] = [
+      { status: "consented", ref: "mkt/plugin@1.0.0", tier: "trusted" },
+    ];
+    const out = formatSummary("./kaizen.json", outcomes);
+    expect(out).not.toContain("refused");
+    expect(out).not.toContain("skipped");
+    expect(out).toContain("1 plugins: 1 consented.");
+  });
+});

--- a/src/commands/plugin-consent-all.ts
+++ b/src/commands/plugin-consent-all.ts
@@ -74,7 +74,7 @@ export async function runPluginConsentAll(args: {
         outcomes.push({ status: "refused", ref: refStr, reason: `interactive consent required (${decision.kind})` });
       }
     } catch (e) {
-      outcomes.push({ status: "refused", ref: refStr, reason: (e as Error).message });
+      outcomes.push({ status: "refused", ref: refStr, reason: e instanceof Error ? e.message : String(e) });
     }
   }
 
@@ -115,7 +115,7 @@ async function loadCatalogs(): Promise<Record<string, MarketplaceCatalog>> {
   const cfg = await loadKaizenGlobalConfig();
   const out: Record<string, MarketplaceCatalog> = {};
   for (const ref of cfg.marketplaces ?? []) {
-    try { out[ref.id] = await readCatalog(ref.id); } catch { /* skip bad */ }
+    try { out[ref.id] = await readCatalog(ref.id); } catch (e) { console.warn(`[kaizen] warn: could not load catalog '${ref.id}': ${(e as Error).message}`); }
   }
   return out;
 }

--- a/src/commands/plugin-consent-all.ts
+++ b/src/commands/plugin-consent-all.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { KaizenConfig, MarketplaceCatalog } from "../types/plugin.js";
+import { parseRef, resolveRef } from "../core/ref-resolver.js";
+import { loadKaizenGlobalConfig } from "../core/kaizen-config.js";
+import { readCatalog } from "../core/marketplace.js";
+import { installPlugin } from "../core/plugin-installer.js";
+import { loadPluginFromInstallDir } from "../core/plugin-loader.js";
+import { pluginInstallDir } from "../core/kaizen-config.js";
+import { isInstalled } from "../core/plugin-manager.js";
+import { canonicalTierGrantHash } from "../core/plugin-hash.js";
+import { decideConsent } from "../core/consent-flow.js";
+import { readLockfile, writeLockfile, upsertPluginEntry } from "../core/lockfile.js";
+
+export type ConsentAllOutcome =
+  | { status: "consented"; ref: string; tier: string }
+  | { status: "already";   ref: string; tier: string }
+  | { status: "refused";   ref: string; reason: string }
+  | { status: "skipped";   ref: string };
+
+export async function runPluginConsentAll(args: {
+  harnessConfig: KaizenConfig;
+  harnessJsonPath: string;
+  lockfilePath: string;
+}): Promise<number> {
+  const outcomes: ConsentAllOutcome[] = [];
+  const catalogs = await loadCatalogs();
+
+  for (const refStr of args.harnessConfig.plugins ?? []) {
+    if (refStr.startsWith("./") || refStr.startsWith("../") || refStr.startsWith("/")) {
+      outcomes.push({ status: "skipped", ref: refStr });
+      continue;
+    }
+
+    try {
+      const parsed = parseRef(refStr);
+      const resolved = resolveRef(parsed, catalogs);
+
+      if (resolved.entry.kind === "harness") {
+        outcomes.push({ status: "skipped", ref: refStr });
+        continue;
+      }
+
+      const { marketplaceId, version } = resolved;
+      const name = resolved.entry.name;
+
+      if (!(await isInstalled(marketplaceId, name, version))) {
+        await installPlugin(marketplaceId, name, version, resolved.pluginVersion!.source);
+      }
+
+      const dir = pluginInstallDir(marketplaceId, name, version);
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as { version?: string };
+      const pkgVersion = pkg.version ?? version;
+      const plugin = await loadPluginFromInstallDir(marketplaceId, name, version);
+      const permissions = plugin.permissions ?? { tier: "trusted" as const };
+      const hash = canonicalTierGrantHash(permissions);
+      const lockfile = readLockfile(args.lockfilePath);
+      const tier = permissions.tier ?? "trusted";
+
+      const decision = decideConsent({
+        pluginName: name, version: pkgVersion, hash, permissions, lockfile,
+        interactive: false, allowUnscoped: true, allowScoped: true,
+      });
+
+      if (decision.kind === "accept") {
+        outcomes.push({ status: "already", ref: refStr, tier });
+      } else if (decision.kind === "accept-and-record") {
+        writeLockfile(args.lockfilePath, upsertPluginEntry(lockfile, name, decision.entry));
+        outcomes.push({ status: "consented", ref: refStr, tier });
+      } else if (decision.kind === "refuse") {
+        outcomes.push({ status: "refused", ref: refStr, reason: decision.reason });
+      } else {
+        // prompt-scoped / prompt-unscoped — non-interactive, treat as refused
+        outcomes.push({ status: "refused", ref: refStr, reason: `interactive consent required (${decision.kind})` });
+      }
+    } catch (e) {
+      outcomes.push({ status: "refused", ref: refStr, reason: (e as Error).message });
+    }
+  }
+
+  console.log(formatSummary(args.harnessJsonPath, outcomes));
+  return outcomes.some((o) => o.status === "refused") ? 1 : 0;
+}
+
+export function formatSummary(harnessPath: string, outcomes: ConsentAllOutcome[]): string {
+  const lines: string[] = [`\nplugin consent --all  (harness: ${harnessPath})\n`];
+
+  for (const o of outcomes) {
+    if (o.status === "consented") lines.push(`  ✓ consented   ${o.ref.padEnd(45)} (${o.tier})`);
+    if (o.status === "already")   lines.push(`  ○ already     ${o.ref.padEnd(45)} (${o.tier})`);
+    if (o.status === "skipped")   lines.push(`  - skipped     ${o.ref}`);
+    if (o.status === "refused") {
+      lines.push(`  ✗ refused     ${o.ref}`);
+      lines.push(`    reason: ${o.reason}`);
+    }
+  }
+
+  const consented = outcomes.filter((o) => o.status === "consented").length;
+  const already   = outcomes.filter((o) => o.status === "already").length;
+  const refused   = outcomes.filter((o) => o.status === "refused").length;
+  const skipped   = outcomes.filter((o) => o.status === "skipped").length;
+
+  const parts = [
+    consented && `${consented} consented`,
+    already   && `${already} already consented`,
+    refused   && `${refused} refused`,
+    skipped   && `${skipped} skipped`,
+  ].filter(Boolean);
+
+  lines.push(`\n${outcomes.length} plugins: ${parts.join(", ")}.`);
+  return lines.join("\n");
+}
+
+async function loadCatalogs(): Promise<Record<string, MarketplaceCatalog>> {
+  const cfg = await loadKaizenGlobalConfig();
+  const out: Record<string, MarketplaceCatalog> = {};
+  for (const ref of cfg.marketplaces ?? []) {
+    try { out[ref.id] = await readCatalog(ref.id); } catch { /* skip bad */ }
+  }
+  return out;
+}

--- a/src/core/consent-flow.test.ts
+++ b/src/core/consent-flow.test.ts
@@ -19,7 +19,7 @@ describe("decideConsent", () => {
     const decision = decideConsent({
       pluginName: "p1", version: "1.0", hash: "sha256:abc",
       permissions: BASE_MANIFEST, lockfile: lf, interactive: false,
-      allowUnscoped: false,
+      allowUnscoped: false, allowScoped: false,
     });
     expect(decision.kind).toBe("accept");
   });
@@ -38,7 +38,7 @@ describe("decideConsent", () => {
     const decision = decideConsent({
       pluginName: "p1", version: "1.0", hash: "sha256:new",
       permissions: BASE_MANIFEST, lockfile: lf, interactive: false,
-      allowUnscoped: false,
+      allowUnscoped: false, allowScoped: false,
     });
     expect(decision.kind).toBe("refuse");
     if (decision.kind === "refuse") expect(decision.reason).toMatch(/hash/i);
@@ -58,7 +58,7 @@ describe("decideConsent", () => {
     const decision = decideConsent({
       pluginName: "p1", version: "1.0", hash: "sha256:abc",
       permissions: BASE_MANIFEST, lockfile: lf, interactive: false,
-      allowUnscoped: false,
+      allowUnscoped: false, allowScoped: false,
     });
     expect(decision.kind).toBe("refuse");
     if (decision.kind === "refuse") expect(decision.reason).toMatch(/permission/i);
@@ -69,7 +69,7 @@ describe("decideConsent", () => {
       pluginName: "p1", version: "1.0", hash: "sha256:abc",
       permissions: { tier: "trusted" },
       lockfile: { schemaVersion: 1, plugins: {} },
-      interactive: false, allowUnscoped: false,
+      interactive: false, allowUnscoped: false, allowScoped: false,
     });
     expect(decision.kind).toBe("accept-and-record");
   });
@@ -79,7 +79,7 @@ describe("decideConsent", () => {
       pluginName: "p1", version: "1.0", hash: "sha256:abc",
       permissions: BASE_MANIFEST,
       lockfile: { schemaVersion: 1, plugins: {} },
-      interactive: false, allowUnscoped: false,
+      interactive: false, allowUnscoped: false, allowScoped: false,
     });
     expect(decision.kind).toBe("refuse");
     if (decision.kind === "refuse") expect(decision.reason).toMatch(/consent/i);
@@ -90,7 +90,7 @@ describe("decideConsent", () => {
       pluginName: "p1", version: "1.0", hash: "sha256:abc",
       permissions: BASE_MANIFEST,
       lockfile: { schemaVersion: 1, plugins: {} },
-      interactive: true, allowUnscoped: false,
+      interactive: true, allowUnscoped: false, allowScoped: false,
     });
     expect(decision.kind).toBe("prompt-scoped");
     if (decision.kind === "prompt-scoped") {
@@ -104,7 +104,7 @@ describe("decideConsent", () => {
       pluginName: "p1", version: "1.0", hash: "sha256:abc",
       permissions: { tier: "unscoped" },
       lockfile: { schemaVersion: 1, plugins: {} },
-      interactive: true, allowUnscoped: true,
+      interactive: true, allowUnscoped: true, allowScoped: false,
     });
     expect(decision.kind).toBe("prompt-unscoped");
     if (decision.kind === "prompt-unscoped") {
@@ -118,7 +118,7 @@ describe("decideConsent", () => {
       pluginName: "p1", version: "1.0", hash: "sha256:abc",
       permissions: { tier: "unscoped" },
       lockfile: { schemaVersion: 1, plugins: {} },
-      interactive: false, allowUnscoped: false,
+      interactive: false, allowUnscoped: false, allowScoped: false,
     });
     expect(decision.kind).toBe("refuse");
     if (decision.kind === "refuse") expect(decision.reason).toMatch(/unscoped/i);
@@ -139,10 +139,32 @@ describe("decideConsent", () => {
     const decision = decideConsent({
       pluginName: "p1", version: "1.0", hash: "sha256:abc",
       permissions: { tier: "scoped", env: ["A", "B"] },
-      lockfile: lf, interactive: false, allowUnscoped: false,
+      lockfile: lf, interactive: false, allowUnscoped: false, allowScoped: false,
     });
     expect(decision.kind).toBe("accept");
   });
+});
+
+test("scoped plugin, non-interactive, allowScoped: true → accept-and-record", () => {
+  const lf: PermissionsLockfile = { schemaVersion: 1, plugins: {} };
+  const decision = decideConsent({
+    pluginName: "p1", version: "1.0", hash: "sha256:abc",
+    permissions: { tier: "scoped", env: ["KEY"] },
+    lockfile: lf, interactive: false,
+    allowUnscoped: false, allowScoped: true,
+  });
+  expect(decision.kind).toBe("accept-and-record");
+});
+
+test("scoped plugin, non-interactive, allowScoped: false → refuse (regression guard)", () => {
+  const lf: PermissionsLockfile = { schemaVersion: 1, plugins: {} };
+  const decision = decideConsent({
+    pluginName: "p1", version: "1.0", hash: "sha256:abc",
+    permissions: { tier: "scoped", env: ["KEY"] },
+    lockfile: lf, interactive: false,
+    allowUnscoped: false, allowScoped: false,
+  });
+  expect(decision.kind).toBe("refuse");
 });
 
 describe("normalizeSort", () => {

--- a/src/core/consent-flow.test.ts
+++ b/src/core/consent-flow.test.ts
@@ -143,28 +143,17 @@ describe("decideConsent", () => {
     });
     expect(decision.kind).toBe("accept");
   });
-});
 
-test("scoped plugin, non-interactive, allowScoped: true → accept-and-record", () => {
-  const lf: PermissionsLockfile = { schemaVersion: 1, plugins: {} };
-  const decision = decideConsent({
-    pluginName: "p1", version: "1.0", hash: "sha256:abc",
-    permissions: { tier: "scoped", env: ["KEY"] },
-    lockfile: lf, interactive: false,
-    allowUnscoped: false, allowScoped: true,
+  test("scoped plugin, non-interactive, allowScoped: true → accept-and-record", () => {
+    const lf: PermissionsLockfile = { schemaVersion: 1, plugins: {} };
+    const decision = decideConsent({
+      pluginName: "p1", version: "1.0", hash: "sha256:abc",
+      permissions: { tier: "scoped", env: ["KEY"] },
+      lockfile: lf, interactive: false,
+      allowUnscoped: false, allowScoped: true,
+    });
+    expect(decision.kind).toBe("accept-and-record");
   });
-  expect(decision.kind).toBe("accept-and-record");
-});
-
-test("scoped plugin, non-interactive, allowScoped: false → refuse (regression guard)", () => {
-  const lf: PermissionsLockfile = { schemaVersion: 1, plugins: {} };
-  const decision = decideConsent({
-    pluginName: "p1", version: "1.0", hash: "sha256:abc",
-    permissions: { tier: "scoped", env: ["KEY"] },
-    lockfile: lf, interactive: false,
-    allowUnscoped: false, allowScoped: false,
-  });
-  expect(decision.kind).toBe("refuse");
 });
 
 describe("normalizeSort", () => {

--- a/src/core/consent-flow.ts
+++ b/src/core/consent-flow.ts
@@ -9,6 +9,7 @@ export interface ConsentInput {
   lockfile: PermissionsLockfile;
   interactive: boolean;
   allowUnscoped: boolean;
+  allowScoped: boolean;
 }
 
 export type ConsentDecision =
@@ -49,9 +50,9 @@ export function decideConsent(input: ConsentInput): ConsentDecision {
   if (tier === "trusted") return { kind: "accept-and-record", entry: nowEntry };
 
   if (tier === "scoped") {
-    return input.interactive
-      ? { kind: "prompt-scoped", entry: nowEntry }
-      : { kind: "refuse", reason: `plugin '${input.pluginName}' requires SCOPED-tier consent. Run interactively, or pre-consent with: kaizen plugin consent ${input.pluginName} --harness <harness-path>` };
+    if (input.interactive) return { kind: "prompt-scoped", entry: nowEntry };
+    if (input.allowScoped) return { kind: "accept-and-record", entry: { ...nowEntry, consentMode: "flag" } };
+    return { kind: "refuse", reason: `plugin '${input.pluginName}' requires SCOPED-tier consent. Run interactively, or pre-consent with: kaizen plugin consent ${input.pluginName} --harness <harness-path>` };
   }
 
   // tier === "unscoped"

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -342,6 +342,7 @@ export class PluginManager {
       lockfile: lf,
       interactive: !this.options.nonInteractive && process.stdin.isTTY === true,
       allowUnscoped: this.options.allowUnscoped,
+      allowScoped: false,
     });
 
     switch (decision.kind) {

--- a/tests/install-sh-test.sh
+++ b/tests/install-sh-test.sh
@@ -72,7 +72,7 @@ KAIZEN_FAKE_LOG="$btmp/log" PATH="$btmp/bin:$PATH" bash -c '
 ' _ "$INSTALLER" || fail "bootstrap errored"
 
 expected_market="kaizen marketplace add https://github.com/CraightonH/kaizen-official-plugins.git --id official"
-expected_install="kaizen install official/core-shell@1.0.0"
+expected_install="kaizen install official/minimum-shell"
 
 grep -Fxq "$expected_market" "$btmp/log" || fail "bootstrap did not run: $expected_market"
 grep -Fxq "$expected_install" "$btmp/log" || fail "bootstrap did not run: $expected_install"


### PR DESCRIPTION
## Summary

- Adds `kaizen plugin consent --all [--harness <ref>]` — bulk pre-consents every plugin in a harness non-interactively, for CI/automation workflows
- Adds `allowScoped: boolean` to `ConsentInput` so scoped plugins can be consented without interactive prompts; threads `allowScoped?` through `UnifiedInstallArgs`
- Prints a full summary table (✓ consented / ○ already / - skipped / ✗ refused) with totals; exits 1 if any plugin refused

## Test Plan

- [ ] `bun test` — 397 pass, 0 fail
- [ ] `bun run typecheck` — clean
- [ ] `kaizen plugin consent --all --harness <ref>` pre-consents all plugins and prints summary
- [ ] Already-consented plugins show `○ already`, local-path refs show `- skipped`
- [ ] Exit code is 0 on clean run, 1 if any plugin refused (e.g. hash mismatch)
- [ ] `kaizen plugin consent <name> --harness <ref>` (single-plugin) still refuses scoped non-interactively (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)