### PR TITLE
feat(installer): resolve plugin runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,17 @@ on your `PATH`:
 curl -fsSL https://raw.githubusercontent.com/CraightonH/kaizen/master/scripts/install.sh | INSTALL_DIR=$HOME/.local/bin bash
 ```
 
+The installer also ensures [Bun](https://bun.sh) is present (used to resolve
+plugin runtime dependencies at install time). Set `KAIZEN_NO_BUN=1` to skip
+this step if you already manage bun yourself.
+
 Environment overrides:
 
 - `KAIZEN_HOME` — marketplace/state dir (default `~/.kaizen`)
 - `INSTALL_DIR` — binary install dir (default `/usr/local/bin`)
 - `KAIZEN_REPO` — GitHub repo to pull releases from (default `CraightonH/kaizen`)
+- `KAIZEN_NO_BUN=1` — skip auto-installing Bun
+- `KAIZEN_NO_BOOTSTRAP=1` — skip seeding the `official` marketplace
 
 ## Concepts
 

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -432,6 +432,33 @@ manifest) so kaizen can validate user-supplied values. Secret keys additionally
 go in `plugin.config.secrets`. See [`reference/plugin-api.md`](../reference/plugin-api.md)
 for the full `config` field shape.
 
+## Runtime dependencies
+
+If your plugin imports any runtime npm package (e.g., `react`, `ink`, `zod`),
+declare it under `dependencies` in your `package.json`. Kaizen will resolve
+those dependencies automatically when the plugin is installed by running
+`bun install --production` in the install dir.
+
+**Best practices:**
+
+- **Commit your `bun.lock`** (or other lockfile) for reproducible installs.
+  Without a lockfile, two users installing "the same plugin version" can get
+  different transitive deps based on when they install.
+- **Keep build-only tools in `devDependencies`.** TypeScript, bundlers,
+  test runners, type packages — none of these need to land on user machines
+  at plugin install time.
+- **Postinstall lifecycle scripts are disabled by Bun by default.** If your
+  plugin (or one of its deps) needs to run a postinstall script — e.g., a
+  package with a native binding — declare the dep in `trustedDependencies`
+  in your `package.json`. See [Bun's lifecycle scripts docs](https://bun.com/docs/cli/install#trusted-dependencies).
+- **Prefer pure-JS or `optionalDependencies`-distributed native packages.**
+  Modern packages (`esbuild`, `lightningcss`, recent `sharp`) ship platform
+  binaries via `optionalDependencies` and install reliably without a build
+  step.
+
+If `package.json` has no `dependencies` field, no install step runs — your
+plugin is copied into place and that's it.
+
 ## Next steps
 
 Once your plugin validates, publish it:

--- a/docs/superpowers/plans/2026-04-30-plugin-runtime-deps.md
+++ b/docs/superpowers/plans/2026-04-30-plugin-runtime-deps.md
@@ -1,0 +1,994 @@
+# Plugin Runtime Dependency Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When kaizen installs a plugin whose `package.json` declares runtime `dependencies`, run `bun install --production` in the install dir so the plugin's imports resolve at load time. Ensure `bun` is available end-to-end via `scripts/install.sh`.
+
+**Architecture:** Add a single post-step at the end of `installPlugin` (in `src/core/plugin-installer.ts`) that runs uniformly across all source types (`file`, `tarball`, `npm`). Resolve `bun` via PATH or `~/.bun/bin/bun`; hard-fail on `bun install` errors and clean up the target dir. In `scripts/install.sh`, add an idempotent `ensure_bun` step before the existing `bootstrap` so a fresh kaizen install always has bun available.
+
+**Tech Stack:** TypeScript, Bun (runtime + package manager), `bun:test`, Bash.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-plugin-runtime-deps-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- None.
+
+**Modified files:**
+- `src/core/plugin-installer.ts` — add the bun-resolver helper and the `installDeps` post-step; call it from `installPlugin` after each source-type case.
+- `src/core/plugin-installer.test.ts` — extend with unit tests for the new behavior.
+- `scripts/install.sh` — add `ensure_bun` and call it before `bootstrap` in `main`.
+- `tests/install-sh-test.sh` — add tests for `ensure_bun`.
+- `docs/guides/plugin-authoring.md` — document automatic dep resolution, lockfile guidance, `trustedDependencies` gotcha.
+- `README.md` — note `install.sh` installs bun and the `KAIZEN_NO_BUN` opt-out.
+
+Each file has one responsibility. The installer logic stays in one focused module (`plugin-installer.ts` is currently 77 lines; will grow modestly).
+
+---
+
+## Task 1: Add bun executable resolver
+
+**Files:**
+- Modify: `src/core/plugin-installer.ts` (add helper)
+- Test: `src/core/plugin-installer.test.ts` (add describe block)
+
+Resolve a usable `bun` binary path, preferring `bun` on PATH and falling back to `~/.bun/bin/bun`. Returns the path string or `null`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/plugin-installer.test.ts`:
+
+```typescript
+import { resolveBunExecutable } from "./plugin-installer.js";
+
+describe("resolveBunExecutable", () => {
+  it("returns 'bun' when bun is on PATH", () => {
+    // The test runner is bun itself, so `bun` resolves on PATH.
+    const got = resolveBunExecutable();
+    expect(got).not.toBeNull();
+    // Either "bun" (PATH hit) or an absolute path ending with /bin/bun.
+    expect(got === "bun" || got!.endsWith("/bin/bun")).toBe(true);
+  });
+
+  it("falls back to ~/.bun/bin/bun when not on PATH", () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "kz-bun-home-"));
+    const fakeBunDir = join(fakeHome, ".bun", "bin");
+    mkdirSync(fakeBunDir, { recursive: true });
+    const fakeBun = join(fakeBunDir, "bun");
+    writeFileSync(fakeBun, "#!/bin/sh\nexit 0\n");
+    chmodSync(fakeBun, 0o755);
+
+    const origPath = process.env.PATH;
+    const origHome = process.env.HOME;
+    process.env.PATH = "/nonexistent-empty-path";
+    process.env.HOME = fakeHome;
+    try {
+      expect(resolveBunExecutable()).toBe(fakeBun);
+    } finally {
+      process.env.PATH = origPath;
+      process.env.HOME = origHome;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when bun is nowhere", () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "kz-bun-home-"));
+    const origPath = process.env.PATH;
+    const origHome = process.env.HOME;
+    process.env.PATH = "/nonexistent-empty-path";
+    process.env.HOME = fakeHome;
+    try {
+      expect(resolveBunExecutable()).toBeNull();
+    } finally {
+      process.env.PATH = origPath;
+      process.env.HOME = origHome;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+Add `chmodSync` to the existing `fs` import line at the top of the test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/plugin-installer.test.ts`
+Expected: FAIL — `resolveBunExecutable is not exported` (or similar).
+
+- [ ] **Step 3: Implement the resolver**
+
+Append to `src/core/plugin-installer.ts`:
+
+```typescript
+import { homedir } from "os";
+
+/**
+ * Resolve a usable `bun` executable path.
+ * Preference: `bun` on PATH → `~/.bun/bin/bun` → null.
+ *
+ * Exported for testing. Internal callers use it via installDeps.
+ */
+export function resolveBunExecutable(): string | null {
+  // PATH lookup: probe with `which` semantics via Bun.which.
+  const onPath = Bun.which("bun");
+  if (onPath) return "bun";
+  const fallback = join(homedir(), ".bun", "bin", "bun");
+  if (existsSync(fallback)) return fallback;
+  return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test src/core/plugin-installer.test.ts`
+Expected: PASS for the three new tests, plus existing tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-installer.ts src/core/plugin-installer.test.ts
+git commit -m "feat(installer): add bun executable resolver"
+```
+
+---
+
+## Task 2: Add `installDeps` helper that no-ops when no deps declared
+
+**Files:**
+- Modify: `src/core/plugin-installer.ts`
+- Test: `src/core/plugin-installer.test.ts`
+
+Internal helper: given a populated plugin install dir, decide whether to run `bun install`. Skip when there's no `package.json`, when JSON is malformed, or when `dependencies` is missing/empty.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/core/plugin-installer.test.ts`:
+
+```typescript
+import { installDepsForTesting } from "./plugin-installer.js";
+
+describe("installDeps — no-op cases", () => {
+  let target: string;
+  beforeEach(() => { target = mkdtempSync(join(tmpdir(), "kz-deps-")); });
+  afterEach(() => { rmSync(target, { recursive: true, force: true }); });
+
+  it("no-ops when package.json missing", async () => {
+    await installDepsForTesting(target, "demo", "1.0.0");
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  });
+
+  it("no-ops when package.json has no dependencies field", async () => {
+    writeFileSync(join(target, "package.json"), JSON.stringify({ name: "demo", version: "1.0.0" }));
+    await installDepsForTesting(target, "demo", "1.0.0");
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  });
+
+  it("no-ops when dependencies is an empty object", async () => {
+    writeFileSync(join(target, "package.json"), JSON.stringify({ name: "demo", version: "1.0.0", dependencies: {} }));
+    await installDepsForTesting(target, "demo", "1.0.0");
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  });
+
+  it("no-ops when package.json is malformed", async () => {
+    writeFileSync(join(target, "package.json"), "{ not valid json");
+    await installDepsForTesting(target, "demo", "1.0.0");
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/plugin-installer.test.ts`
+Expected: FAIL — `installDepsForTesting` is not exported.
+
+- [ ] **Step 3: Implement `installDeps`**
+
+In `src/core/plugin-installer.ts`, add:
+
+```typescript
+/**
+ * If `target` contains a package.json with non-empty runtime dependencies,
+ * run `bun install --production` in it. Otherwise no-op.
+ *
+ * On bun-install failure: rmSync(target) and throw with bun's stderr.
+ * On missing bun: throw with install instructions.
+ */
+async function installDeps(target: string, name: string, version: string): Promise<void> {
+  const pkgPath = join(target, "package.json");
+  if (!existsSync(pkgPath)) return;
+
+  let pkg: { dependencies?: Record<string, string> };
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch {
+    // Malformed package.json — let plugin load surface the real error.
+    return;
+  }
+
+  const deps = pkg.dependencies;
+  if (!deps || Object.keys(deps).length === 0) return;
+
+  const bun = resolveBunExecutable();
+  if (!bun) {
+    throw new Error(
+      `plugin '${name}@${version}' declares runtime dependencies but bun is not on PATH or at ~/.bun/bin/bun.\n` +
+      `Install bun: curl -fsSL https://bun.sh/install | bash`,
+    );
+  }
+
+  const proc = Bun.spawnSync({
+    cmd: [bun, "install", "--production"],
+    cwd: target,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (proc.exitCode !== 0) {
+    const stderr = proc.stderr ? new TextDecoder().decode(proc.stderr) : "";
+    rmSync(target, { recursive: true, force: true });
+    throw new Error(
+      `bun install failed for plugin '${name}@${version}' at ${target}\n` +
+      stderr.split("\n").map((l) => `  ${l}`).join("\n"),
+    );
+  }
+}
+
+// Test-only export. Not part of the public API.
+export const installDepsForTesting = installDeps;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/plugin-installer.test.ts`
+Expected: PASS for the four new no-op cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-installer.ts src/core/plugin-installer.test.ts
+git commit -m "feat(installer): add installDeps no-op cases"
+```
+
+---
+
+## Task 3: `installDeps` runs bun install for real deps
+
+**Files:**
+- Modify: `src/core/plugin-installer.test.ts`
+
+Cover the happy path: a `package.json` with a real, tiny pure-JS dep gets `node_modules/<dep>` after install.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `describe("installDeps — no-op cases", ...)` file (new describe):
+
+```typescript
+describe("installDeps — runs bun install", () => {
+  it("creates node_modules/<dep> for a declared runtime dep", async () => {
+    const target = mkdtempSync(join(tmpdir(), "kz-deps-real-"));
+    try {
+      writeFileSync(
+        join(target, "package.json"),
+        JSON.stringify({
+          name: "demo",
+          version: "1.0.0",
+          dependencies: { "is-odd": "3.0.1" },
+        }),
+      );
+
+      await installDepsForTesting(target, "demo", "1.0.0");
+
+      expect(existsSync(join(target, "node_modules", "is-odd"))).toBe(true);
+    } finally {
+      rmSync(target, { recursive: true, force: true });
+    }
+  }, 30_000); // network + cache pull on first run
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes if dep tree already cached)**
+
+Run: `bun test src/core/plugin-installer.test.ts -t "creates node_modules"`
+Expected: depending on cache, may already PASS once Task 2's implementation is in. The point is to lock in coverage. If failing, the failure should be a network/registry problem, not code.
+
+- [ ] **Step 3: No code change required — Task 2's implementation already covers it**
+
+Verify no implementation changes are needed; the test exists to lock in the contract.
+
+- [ ] **Step 4: Run the full test file**
+
+Run: `bun test src/core/plugin-installer.test.ts`
+Expected: PASS for all installer tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-installer.test.ts
+git commit -m "test(installer): cover installDeps happy path with real dep"
+```
+
+---
+
+## Task 4: `installDeps` failure path wipes target and surfaces stderr
+
+**Files:**
+- Modify: `src/core/plugin-installer.test.ts`
+
+Cover the failure path with a deliberately bad dep name (unresolvable), so the test does not depend on registry contents and surfaces an error fast.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/plugin-installer.test.ts`:
+
+```typescript
+describe("installDeps — failure path", () => {
+  it("wipes target and throws with bun stderr when bun install fails", async () => {
+    const target = mkdtempSync(join(tmpdir(), "kz-deps-fail-"));
+    try {
+      writeFileSync(
+        join(target, "package.json"),
+        JSON.stringify({
+          name: "demo",
+          version: "1.0.0",
+          // Scoped name in a kaizen-reserved scope guaranteed not to exist.
+          dependencies: { "@kaizen-test-does-not-exist/nope": "1.0.0" },
+        }),
+      );
+      writeFileSync(join(target, "marker.txt"), "x");
+
+      let err: Error | null = null;
+      try {
+        await installDepsForTesting(target, "demo", "1.0.0");
+      } catch (e) {
+        err = e as Error;
+      }
+
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain("bun install failed for plugin 'demo@1.0.0'");
+      expect(existsSync(target)).toBe(false); // wiped
+    } finally {
+      rmSync(target, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes (Task 2's impl already handles this)**
+
+Run: `bun test src/core/plugin-installer.test.ts -t "wipes target"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/plugin-installer.test.ts
+git commit -m "test(installer): cover installDeps failure path"
+```
+
+---
+
+## Task 5: `installDeps` errors clearly when bun is missing
+
+**Files:**
+- Modify: `src/core/plugin-installer.ts`
+- Modify: `src/core/plugin-installer.test.ts`
+
+The current `installDeps` calls `resolveBunExecutable()` directly, which makes "bun missing" hard to test in an environment where bun is the test runner. Inject a resolver override for testability.
+
+- [ ] **Step 1: Refactor `installDeps` to accept an injected resolver (default = `resolveBunExecutable`)**
+
+In `src/core/plugin-installer.ts`, change the signature:
+
+```typescript
+async function installDeps(
+  target: string,
+  name: string,
+  version: string,
+  bunResolver: () => string | null = resolveBunExecutable,
+): Promise<void> {
+  const pkgPath = join(target, "package.json");
+  if (!existsSync(pkgPath)) return;
+
+  let pkg: { dependencies?: Record<string, string> };
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch {
+    return;
+  }
+
+  const deps = pkg.dependencies;
+  if (!deps || Object.keys(deps).length === 0) return;
+
+  const bun = bunResolver();
+  if (!bun) {
+    throw new Error(
+      `plugin '${name}@${version}' declares runtime dependencies but bun is not on PATH or at ~/.bun/bin/bun.\n` +
+      `Install bun: curl -fsSL https://bun.sh/install | bash`,
+    );
+  }
+  // ... rest unchanged
+}
+```
+
+Update the test export accordingly (still `installDepsForTesting = installDeps`).
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `src/core/plugin-installer.test.ts`:
+
+```typescript
+describe("installDeps — bun missing", () => {
+  it("throws with install instructions when no bun is resolvable", async () => {
+    const target = mkdtempSync(join(tmpdir(), "kz-deps-nobun-"));
+    try {
+      writeFileSync(
+        join(target, "package.json"),
+        JSON.stringify({ name: "demo", version: "1.0.0", dependencies: { "is-odd": "3.0.1" } }),
+      );
+
+      let err: Error | null = null;
+      try {
+        await installDepsForTesting(target, "demo", "1.0.0", () => null);
+      } catch (e) {
+        err = e as Error;
+      }
+
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain("bun is not on PATH or at ~/.bun/bin/bun");
+      expect(err!.message).toContain("curl -fsSL https://bun.sh/install | bash");
+    } finally {
+      rmSync(target, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `bun test src/core/plugin-installer.test.ts -t "bun missing"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/plugin-installer.ts src/core/plugin-installer.test.ts
+git commit -m "test(installer): cover bun-missing error path"
+```
+
+---
+
+## Task 6: Wire `installDeps` into `installPlugin` for all source types
+
+**Files:**
+- Modify: `src/core/plugin-installer.ts`
+- Modify: `src/core/plugin-installer.test.ts`
+
+Call `installDeps` after each source-type branch so `file`, `tarball`, and `npm` all benefit.
+
+- [ ] **Step 1: Write a failing test (file source with deps end-to-end)**
+
+Append to `src/core/plugin-installer.test.ts` inside `describe("installPlugin — file source", ...)`:
+
+```typescript
+it("resolves runtime deps after copying file source", async () => {
+  const pluginSrc = join(upstream, "plugins", "with-deps");
+  mkdirSync(pluginSrc, { recursive: true });
+  writeFileSync(
+    join(pluginSrc, "package.json"),
+    JSON.stringify({
+      name: "with-deps",
+      version: "1.0.0",
+      main: "index.js",
+      dependencies: { "is-odd": "3.0.1" },
+    }),
+  );
+  writeFileSync(join(pluginSrc, "index.js"), "export default { name: 'with-deps', apiVersion: '2', setup(){} };");
+
+  await installPlugin("m", "with-deps", "1.0.0", { type: "file", path: "plugins/with-deps" });
+
+  const target = pluginInstallDir("m", "with-deps", "1.0.0");
+  expect(existsSync(join(target, "node_modules", "is-odd"))).toBe(true);
+}, 30_000);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/plugin-installer.test.ts -t "resolves runtime deps after copying"`
+Expected: FAIL — `node_modules/is-odd` not found (no call to `installDeps` yet).
+
+- [ ] **Step 3: Modify `installPlugin` to call `installDeps`**
+
+In `src/core/plugin-installer.ts`, restructure the function. Replace the `switch` block with:
+
+```typescript
+export async function installPlugin(
+  marketplaceId: string, name: string, version: string, source: PluginSource,
+): Promise<void> {
+  const target = pluginInstallDir(marketplaceId, name, version);
+  rmSync(target, { recursive: true, force: true });
+  mkdirSync(target, { recursive: true });
+
+  switch (source.type) {
+    case "file": {
+      const src = join(marketplaceRepoDir(marketplaceId), source.path);
+      if (!existsSync(src)) throw new Error(`file source not found in marketplace: ${source.path}`);
+      cpSync(src, target, { recursive: true });
+      break;
+    }
+    case "tarball": {
+      await installTarball(source.url, target, source.sha256);
+      break;
+    }
+    case "npm": {
+      await installNpm(source.name, source.version, target);
+      break;
+    }
+  }
+
+  await installDeps(target, name, version);
+}
+```
+
+(Note: `return` becomes `break` so all source types fall through to `installDeps`.)
+
+- [ ] **Step 4: Run all installer tests**
+
+Run: `bun test src/core/plugin-installer.test.ts`
+Expected: PASS for all tests, including the new `resolves runtime deps after copying`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/plugin-installer.ts src/core/plugin-installer.test.ts
+git commit -m "feat(installer): resolve runtime deps after every plugin install"
+```
+
+---
+
+## Task 7: Lockfile is honored when present
+
+**Files:**
+- Modify: `src/core/plugin-installer.test.ts`
+
+Smoke test that a committed `bun.lock` survives the copy and is honored by `bun install`.
+
+- [ ] **Step 1: Write the test**
+
+Append to `src/core/plugin-installer.test.ts`:
+
+```typescript
+describe("installPlugin — lockfile honored", () => {
+  it("preserves bun.lock from source and uses it", async () => {
+    const pluginSrc = join(upstream, "plugins", "locked");
+    mkdirSync(pluginSrc, { recursive: true });
+    writeFileSync(
+      join(pluginSrc, "package.json"),
+      JSON.stringify({
+        name: "locked",
+        version: "1.0.0",
+        main: "index.js",
+        dependencies: { "is-odd": "3.0.1" },
+      }),
+    );
+    writeFileSync(join(pluginSrc, "index.js"), "export default { name: 'locked', apiVersion: '2', setup(){} };");
+    // A pre-existing bun.lock in the source — bun will use it.
+    // We can't easily fabricate a valid binary lockfile in a test, so we just
+    // verify that any lockfile present in source is copied into target.
+    writeFileSync(join(pluginSrc, "bun.lock"), "{}\n");
+
+    await installPlugin("m", "locked", "1.0.0", { type: "file", path: "plugins/locked" });
+
+    const target = pluginInstallDir("m", "locked", "1.0.0");
+    expect(existsSync(join(target, "bun.lock"))).toBe(true);
+  }, 30_000);
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `bun test src/core/plugin-installer.test.ts -t "preserves bun.lock"`
+Expected: PASS (cpSync copies all files, including lockfile).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/plugin-installer.test.ts
+git commit -m "test(installer): verify bun.lock is preserved through install"
+```
+
+---
+
+## Task 8: Add `ensure_bun` to `scripts/install.sh`
+
+**Files:**
+- Modify: `scripts/install.sh`
+
+Add an idempotent step that installs bun if missing. Best-effort: failure does not abort.
+
+- [ ] **Step 1: Add the function**
+
+In `scripts/install.sh`, insert this block immediately before the existing `bootstrap()` definition:
+
+```bash
+# Ensure bun is available so plugin runtime deps can be resolved at install
+# time. Idempotent and best-effort: a failure here warns and continues, never
+# aborts the kaizen installer.
+#
+# Opt out by setting KAIZEN_NO_BUN=1.
+ensure_bun() {
+  if [ "${KAIZEN_NO_BUN:-0}" = "1" ]; then
+    info "Skipping bun install (KAIZEN_NO_BUN=1)."
+    return 0
+  fi
+
+  if command -v bun >/dev/null 2>&1; then
+    info "bun already installed: $(command -v bun)"
+    return 0
+  fi
+  if [ -x "$HOME/.bun/bin/bun" ]; then
+    info "bun found at ~/.bun/bin/bun"
+    return 0
+  fi
+
+  info "Installing bun (required for plugin dependency resolution)..."
+  if curl -fsSL https://bun.sh/install | bash; then
+    green "  ✓ bun installed"
+  else
+    red "  ! bun install failed; install manually: curl -fsSL https://bun.sh/install | bash"
+    return 0
+  fi
+}
+```
+
+- [ ] **Step 2: Call `ensure_bun` before `bootstrap` in `main`**
+
+Find the existing line in `main()`:
+
+```bash
+  echo ""
+  bootstrap
+```
+
+Replace with:
+
+```bash
+  echo ""
+  ensure_bun
+
+  echo ""
+  bootstrap
+```
+
+- [ ] **Step 3: Sanity-check the script parses**
+
+Run: `bash -n scripts/install.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/install.sh
+git commit -m "feat(installer): ensure bun is installed for plugin dep resolution"
+```
+
+---
+
+## Task 9: Test `ensure_bun` no-op when bun is on PATH
+
+**Files:**
+- Modify: `tests/install-sh-test.sh`
+
+- [ ] **Step 1: Append the test**
+
+Add to the end of `tests/install-sh-test.sh`:
+
+```bash
+# --- Test: ensure_bun no-ops when bun on PATH ---------------------------------
+out="$(bash -c '
+  set -euo pipefail
+  # Stub PATH with a fake bun.
+  tmp="$(mktemp -d)"
+  cat > "$tmp/bun" <<EOF
+#!/bin/sh
+exit 0
+EOF
+  chmod +x "$tmp/bun"
+  PATH="$tmp:$PATH" HOME="$tmp" KAIZEN_NO_BUN=0
+  export PATH HOME KAIZEN_NO_BUN
+  # shellcheck source=/dev/null
+  source "$1"
+  ensure_bun
+  rm -rf "$tmp"
+' _ "$INSTALLER" 2>&1)" || fail "ensure_bun (PATH hit) errored: $out"
+
+echo "$out" | grep -q "bun already installed" || fail "ensure_bun (PATH hit) did not detect bun on PATH: $out"
+pass "ensure_bun no-ops when bun on PATH"
+```
+
+- [ ] **Step 2: Run the test script**
+
+Run: `bash tests/install-sh-test.sh`
+Expected: All existing tests PASS plus the new `ensure_bun no-ops when bun on PATH` PASSes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/install-sh-test.sh
+git commit -m "test(install.sh): ensure_bun no-ops when bun on PATH"
+```
+
+---
+
+## Task 10: Test `ensure_bun` no-op when `~/.bun/bin/bun` exists
+
+**Files:**
+- Modify: `tests/install-sh-test.sh`
+
+- [ ] **Step 1: Append the test**
+
+```bash
+# --- Test: ensure_bun no-ops when ~/.bun/bin/bun exists -----------------------
+out="$(bash -c '
+  set -euo pipefail
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/.bun/bin"
+  cat > "$tmp/.bun/bin/bun" <<EOF
+#!/bin/sh
+exit 0
+EOF
+  chmod +x "$tmp/.bun/bin/bun"
+  # Empty PATH so command -v bun fails.
+  PATH="/nonexistent-empty-path" HOME="$tmp"
+  export PATH HOME
+  # shellcheck source=/dev/null
+  source "$1"
+  ensure_bun
+  rm -rf "$tmp"
+' _ "$INSTALLER" 2>&1)" || fail "ensure_bun (~/.bun fallback) errored: $out"
+
+echo "$out" | grep -q "bun found at ~/.bun/bin/bun" || fail "ensure_bun did not detect ~/.bun/bin/bun: $out"
+pass "ensure_bun no-ops when ~/.bun/bin/bun exists"
+```
+
+- [ ] **Step 2: Run**
+
+Run: `bash tests/install-sh-test.sh`
+Expected: All PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/install-sh-test.sh
+git commit -m "test(install.sh): ensure_bun no-ops when ~/.bun/bin/bun exists"
+```
+
+---
+
+## Task 11: Test `ensure_bun` skipped via `KAIZEN_NO_BUN=1`
+
+**Files:**
+- Modify: `tests/install-sh-test.sh`
+
+- [ ] **Step 1: Append the test**
+
+```bash
+# --- Test: KAIZEN_NO_BUN=1 skips ensure_bun ----------------------------------
+out="$(bash -c '
+  set -euo pipefail
+  tmp="$(mktemp -d)"
+  PATH="/nonexistent-empty-path" HOME="$tmp" KAIZEN_NO_BUN=1
+  export PATH HOME KAIZEN_NO_BUN
+  # shellcheck source=/dev/null
+  source "$1"
+  ensure_bun
+  rm -rf "$tmp"
+' _ "$INSTALLER" 2>&1)" || fail "ensure_bun (NO_BUN) errored: $out"
+
+echo "$out" | grep -q "Skipping bun install (KAIZEN_NO_BUN=1)" || fail "KAIZEN_NO_BUN=1 was not respected: $out"
+pass "ensure_bun skipped via KAIZEN_NO_BUN=1"
+```
+
+- [ ] **Step 2: Run**
+
+Run: `bash tests/install-sh-test.sh`
+Expected: All PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/install-sh-test.sh
+git commit -m "test(install.sh): KAIZEN_NO_BUN=1 skips ensure_bun"
+```
+
+---
+
+## Task 12: Test `ensure_bun` failure does not abort
+
+**Files:**
+- Modify: `tests/install-sh-test.sh`
+
+Stub `curl` so the bun installer pipe fails; verify the script continues.
+
+- [ ] **Step 1: Append the test**
+
+```bash
+# --- Test: ensure_bun installer failure does not abort -----------------------
+out="$(bash -c '
+  set -euo pipefail
+  tmp="$(mktemp -d)"
+  # Stub: an empty PATH dir + a failing curl shadow.
+  stub="$tmp/stub"
+  mkdir -p "$stub"
+  cat > "$stub/curl" <<EOF
+#!/bin/sh
+exit 1
+EOF
+  chmod +x "$stub/curl"
+  PATH="$stub" HOME="$tmp"
+  export PATH HOME
+  # shellcheck source=/dev/null
+  source "$1"
+  # Should not abort despite curl failing.
+  ensure_bun
+  echo "AFTER_ENSURE_BUN"
+  rm -rf "$tmp"
+' _ "$INSTALLER" 2>&1)" || fail "ensure_bun (failure path) aborted the script: $out"
+
+echo "$out" | grep -q "AFTER_ENSURE_BUN" || fail "ensure_bun failure aborted execution: $out"
+echo "$out" | grep -q "bun install failed" || fail "ensure_bun did not warn on failure: $out"
+pass "ensure_bun installer failure does not abort"
+```
+
+- [ ] **Step 2: Run**
+
+Run: `bash tests/install-sh-test.sh`
+Expected: All PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/install-sh-test.sh
+git commit -m "test(install.sh): ensure_bun failure does not abort installer"
+```
+
+---
+
+## Task 13: Update plugin-authoring docs
+
+**Files:**
+- Modify: `docs/guides/plugin-authoring.md`
+
+Document the new behavior so plugin authors know what to expect.
+
+- [ ] **Step 1: Read the current docs to find the right insertion point**
+
+Read: `docs/guides/plugin-authoring.md`. Look for a section on `package.json` or distribution. If none exists, add a new section near the end titled `## Runtime dependencies`.
+
+- [ ] **Step 2: Add the new content**
+
+Append (or insert at the appropriate section) the following:
+
+```markdown
+## Runtime dependencies
+
+If your plugin imports any runtime npm package (e.g., `react`, `ink`, `zod`),
+declare it under `dependencies` in your `package.json`. Kaizen will resolve
+those dependencies automatically when the plugin is installed by running
+`bun install --production` in the install dir.
+
+**Best practices:**
+
+- **Commit your `bun.lock`** (or other lockfile) for reproducible installs.
+  Without a lockfile, two users installing "the same plugin version" can get
+  different transitive deps based on when they install.
+- **Keep build-only tools in `devDependencies`.** TypeScript, bundlers,
+  test runners, type packages — none of these need to land on user machines
+  at plugin install time.
+- **Postinstall lifecycle scripts are disabled by Bun by default.** If your
+  plugin (or one of its deps) needs to run a postinstall script — e.g., a
+  package with a native binding — declare the dep in `trustedDependencies`
+  in your `package.json`. See [Bun's lifecycle scripts docs](https://bun.com/docs/cli/install#trusted-dependencies).
+- **Prefer pure-JS or `optionalDependencies`-distributed native packages.**
+  Modern packages (`esbuild`, `lightningcss`, recent `sharp`) ship platform
+  binaries via `optionalDependencies` and install reliably without a build
+  step.
+
+If `package.json` has no `dependencies` field, no install step runs — your
+plugin is copied into place and that's it.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/guides/plugin-authoring.md
+git commit -m "docs(plugin-authoring): document runtime dep resolution"
+```
+
+---
+
+## Task 14: Update README installer section
+
+**Files:**
+- Modify: `README.md`
+
+Note that `install.sh` installs bun and the opt-out env var.
+
+- [ ] **Step 1: Find the install section in README**
+
+Read: `README.md`. Locate the `install.sh` / installation section.
+
+- [ ] **Step 2: Add a sentence noting bun installation**
+
+Near the install instructions, add:
+
+```markdown
+The installer also ensures [Bun](https://bun.sh) is present (used to resolve
+plugin runtime dependencies at install time). Set `KAIZEN_NO_BUN=1` to skip
+this step if you already manage bun yourself.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): note bun is installed for plugin dep resolution"
+```
+
+---
+
+## Task 15: Full verification
+
+**Files:** none
+
+- [ ] **Step 1: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `bun test`
+Expected: all tests PASS.
+
+- [ ] **Step 3: Run install.sh tests**
+
+Run: `bash tests/install-sh-test.sh`
+Expected: all PASS lines, no FAIL.
+
+- [ ] **Step 4: Manual smoke (optional but recommended)**
+
+```bash
+# In a temp dir, install kaizen from the dev binary, point it at the plugin
+# from the original issue (claude-tui@0.2.0 in kaizen-official-plugins), and
+# verify the plugin loads without "Cannot find module 'react/jsx-dev-runtime'".
+```
+
+If any test fails, fix and recommit before claiming done. Do not claim
+verification with failing tests.
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Task(s) |
+|---|---|
+| Plugin install flow change (the post-step) | 1, 2, 3, 4, 5, 6 |
+| All source types (`file`, `tarball`, `npm`) covered uniformly | 6 |
+| Lockfile honored when present | 7 |
+| `scripts/install.sh` `ensure_bun` step | 8 |
+| `ensure_bun` idempotent / opt-out / best-effort | 9, 10, 11, 12 |
+| Error message when bun missing | 5 |
+| Error message when `bun install` fails | 4 |
+| Wipe target on `bun install` failure | 4 |
+| Skip on no `package.json` / empty deps / malformed JSON | 2 |
+| Plugin-authoring docs (deps, lockfile, `trustedDependencies`) | 13 |
+| README/installer docs | 14 |
+| Final verification | 15 |
+
+All spec sections are covered. No placeholders. Type/method names are consistent across tasks (`installDeps`, `resolveBunExecutable`, `installDepsForTesting`).

--- a/docs/superpowers/plans/2026-04-30-sandbox-env-allowlist.md
+++ b/docs/superpowers/plans/2026-04-30-sandbox-env-allowlist.md
@@ -1,0 +1,1143 @@
+# Sandbox Env Allow-list Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carve an OS-infrastructure env-var allow-list around the permission enforcer's `env.get` check so trusted-tier plugins can read `process.env.PATH` (and friends) needed by Node/Bun stdlib calls like `child_process.spawn`, while preserving the proxy's secret-isolation guarantees for everything else.
+
+**Architecture:** Allow-list is data, not code. A `DEFAULT_ENV_ALLOWLIST` ships in `src/core/env-allowlist.ts` and supports exact names plus trailing-`*` prefixes. The permission enforcer takes an optional `envAllowList` constructor param; `evaluate()` short-circuits `env.get` checks when the name matches. Resolution at bootstrap: harness `env_allowlist` (if present) → user `defaults.env_allowlist` (if present) → built-in default.
+
+**Tech Stack:** TypeScript, Bun runtime, `bun:test`.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-sandbox-env-allowlist-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/core/env-allowlist.ts` — default list, `envAllowed()` matcher, `validateEnvAllowList()` schema check.
+- `src/core/env-allowlist.test.ts` — unit tests for matcher and validator.
+
+**Modified files:**
+- `src/types/plugin.ts` — add `env_allowlist?: string[]` to `KaizenDefaults` and to `KaizenConfig`.
+- `src/core/permission-enforcer.ts` — accept `envAllowList` option; consult allow-list in `evaluate()` for `env.get`.
+- `src/core/permission-enforcer.test.ts` — extend coverage for allow-list interactions across tiers.
+- `src/core/kaizen-config.ts` — validate `defaults.env_allowlist` on load; reject invalid entries.
+- `src/core/kaizen-config.test.ts` — config-load coverage.
+- `src/core/index.ts` — resolve allow-list from harness/user/default precedence; pass to enforcer.
+- `src/core/sandbox-bootstrap.test.ts` (or new test if absent) — proxy passthrough behavior under the allow-list.
+- `docs/guides/plugin-authoring.md` — replace incorrect "globals are not filtered" paragraph.
+- `docs/concepts/security.md` — extend env-proxy section; update troubleshooting note.
+- `docs/concepts/configuration.md` — document `defaults.env_allowlist` and per-harness `env_allowlist`.
+
+Each file owns one responsibility. The allow-list module is small and isolated; the enforcer change is one branch in `evaluate()`; the proxy itself does not change.
+
+---
+
+## Task 1: Create `env-allowlist.ts` matcher
+
+**Files:**
+- Create: `src/core/env-allowlist.ts`
+- Test: `src/core/env-allowlist.test.ts`
+
+The matcher takes an allow-list and a name, returns whether the name is allowed. Each entry is either an exact name or a trailing-`*` prefix.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/core/env-allowlist.test.ts`:
+
+```typescript
+import { describe, it, expect } from "bun:test";
+import { envAllowed, DEFAULT_ENV_ALLOWLIST } from "./env-allowlist.js";
+
+describe("envAllowed", () => {
+  it("matches exact names case-sensitively", () => {
+    expect(envAllowed(["PATH"], "PATH")).toBe(true);
+    expect(envAllowed(["PATH"], "PATHS")).toBe(false);
+    expect(envAllowed(["PATH"], "path")).toBe(false);
+    expect(envAllowed(["PATH"], "OTHER")).toBe(false);
+  });
+
+  it("matches prefix entries with trailing *", () => {
+    expect(envAllowed(["LC_*"], "LC_ALL")).toBe(true);
+    expect(envAllowed(["LC_*"], "LC_CTYPE")).toBe(true);
+    expect(envAllowed(["LC_*"], "LC")).toBe(false);          // prefix is "LC_"
+    expect(envAllowed(["LC_*"], "MYLC_FOO")).toBe(false);    // not a prefix match
+  });
+
+  it("supports mixed exact + prefix entries", () => {
+    expect(envAllowed(["PATH", "LC_*"], "PATH")).toBe(true);
+    expect(envAllowed(["PATH", "LC_*"], "LC_ALL")).toBe(true);
+    expect(envAllowed(["PATH", "LC_*"], "OTHER")).toBe(false);
+  });
+
+  it("empty list matches nothing", () => {
+    expect(envAllowed([], "PATH")).toBe(false);
+    expect(envAllowed([], "")).toBe(false);
+  });
+
+  it("default list contains expected entries", () => {
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("PATH");
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("HOME");
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("LC_*");
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("TMPDIR");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/env-allowlist.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement matcher and default list**
+
+Create `src/core/env-allowlist.ts`:
+
+```typescript
+/**
+ * OS-infrastructure env vars that bypass tier-based env.get gating.
+ * Plugins of any tier can read these. Override via:
+ *   ~/.kaizen/kaizen.json   defaults.env_allowlist
+ *   harness  kaizen.json    env_allowlist
+ *
+ * Each entry is either an exact name (e.g. "PATH") or a trailing-`*`
+ * prefix (e.g. "LC_*"). No other glob syntax is supported.
+ */
+export const DEFAULT_ENV_ALLOWLIST: string[] = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "TERM",
+  "COLUMNS",
+  "LINES",
+  "LANG",
+  "LANGUAGE",
+  "LC_*",
+  "TZ",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "PWD",
+  "OLDPWD",
+];
+
+/** Returns true iff `name` matches any entry in `allowList`. */
+export function envAllowed(allowList: string[], name: string): boolean {
+  for (const entry of allowList) {
+    if (entry.endsWith("*")) {
+      const prefix = entry.slice(0, -1);
+      if (prefix.length > 0 && name.startsWith(prefix)) return true;
+    } else if (entry === name) {
+      return true;
+    }
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/env-allowlist.test.ts`
+Expected: PASS for all five tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/env-allowlist.ts src/core/env-allowlist.test.ts
+git commit -m "feat(sandbox): add env allow-list module with default list"
+```
+
+---
+
+## Task 2: Add `validateEnvAllowList`
+
+**Files:**
+- Modify: `src/core/env-allowlist.ts`
+- Modify: `src/core/env-allowlist.test.ts`
+
+Schema validator used at config-load time. Returns the validated array; throws with the offending entry on invalid input.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/core/env-allowlist.test.ts`:
+
+```typescript
+import { validateEnvAllowList } from "./env-allowlist.js";
+
+describe("validateEnvAllowList", () => {
+  const src = "test.json: defaults.env_allowlist";
+
+  it("accepts an empty array", () => {
+    expect(validateEnvAllowList([], src)).toEqual([]);
+  });
+
+  it("accepts exact-name entries", () => {
+    expect(validateEnvAllowList(["PATH", "HOME"], src)).toEqual(["PATH", "HOME"]);
+  });
+
+  it("accepts trailing-* prefix entries", () => {
+    expect(validateEnvAllowList(["LC_*", "PATH"], src)).toEqual(["LC_*", "PATH"]);
+  });
+
+  it("rejects non-array input", () => {
+    expect(() => validateEnvAllowList("PATH", src)).toThrow(/must be an array/);
+    expect(() => validateEnvAllowList({}, src)).toThrow(/must be an array/);
+    expect(() => validateEnvAllowList(null, src)).toThrow(/must be an array/);
+  });
+
+  it("rejects non-string entries", () => {
+    expect(() => validateEnvAllowList([42], src)).toThrow(/test\.json: defaults\.env_allowlist/);
+    expect(() => validateEnvAllowList([null], src)).toThrow(/non-empty string/);
+  });
+
+  it("rejects empty-string entries", () => {
+    expect(() => validateEnvAllowList([""], src)).toThrow(/non-empty string/);
+  });
+
+  it("rejects entries containing whitespace", () => {
+    expect(() => validateEnvAllowList(["FOO BAR"], src)).toThrow(/whitespace/);
+    expect(() => validateEnvAllowList(["FOO\t"], src)).toThrow(/whitespace/);
+  });
+
+  it("rejects entries with * not at end", () => {
+    expect(() => validateEnvAllowList(["*FOO"], src)).toThrow(/\*FOO/);
+    expect(() => validateEnvAllowList(["FOO*BAR"], src)).toThrow(/FOO\*BAR/);
+  });
+
+  it("rejects entries with multiple *", () => {
+    expect(() => validateEnvAllowList(["FOO**"], src)).toThrow(/FOO\*\*/);
+    expect(() => validateEnvAllowList(["*FOO*"], src)).toThrow(/\*FOO\*/);
+  });
+
+  it("rejects bare * (would be empty prefix)", () => {
+    expect(() => validateEnvAllowList(["*"], src)).toThrow(/empty prefix/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/env-allowlist.test.ts`
+Expected: FAIL — `validateEnvAllowList` not exported.
+
+- [ ] **Step 3: Implement the validator**
+
+Append to `src/core/env-allowlist.ts`:
+
+```typescript
+/**
+ * Validate an env-allowlist value loaded from config. Returns the array
+ * unchanged on success; throws an Error with the offending entry on failure.
+ *
+ * `source` is included in error messages (e.g. "~/.kaizen/kaizen.json: defaults.env_allowlist").
+ */
+export function validateEnvAllowList(value: unknown, source: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${source}: must be an array of strings.`);
+  }
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry.length === 0) {
+      throw new Error(`${source}: each entry must be a non-empty string (got ${JSON.stringify(entry)}).`);
+    }
+    if (/\s/.test(entry)) {
+      throw new Error(`${source}: entry "${entry}" contains whitespace.`);
+    }
+    const stars = (entry.match(/\*/g) ?? []).length;
+    if (stars > 1) {
+      throw new Error(
+        `${source}: invalid entry "${entry}" — only one trailing '*' allowed (e.g. "LC_*").`,
+      );
+    }
+    if (stars === 1 && !entry.endsWith("*")) {
+      throw new Error(
+        `${source}: invalid entry "${entry}" — '*' may only appear as the trailing character (e.g. "LC_*").`,
+      );
+    }
+    if (entry === "*") {
+      throw new Error(`${source}: invalid entry "*" — empty prefix not allowed.`);
+    }
+  }
+  return value as string[];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/env-allowlist.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/env-allowlist.ts src/core/env-allowlist.test.ts
+git commit -m "feat(sandbox): add env allow-list validator"
+```
+
+---
+
+## Task 3: Add `env_allowlist` to type definitions
+
+**Files:**
+- Modify: `src/types/plugin.ts`
+
+Extend `KaizenDefaults` (user-level) and `KaizenConfig` (harness-level) with an optional `env_allowlist` field.
+
+- [ ] **Step 1: Modify `KaizenDefaults`**
+
+In `src/types/plugin.ts`, find:
+
+```typescript
+export interface KaizenDefaults {
+  /** Harness ref used when --harness is not passed on the CLI. */
+  harness?: string;
+  /** Per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects. */
+  plugin_config?: Record<string, Record<string, unknown>>;
+}
+```
+
+Replace with:
+
+```typescript
+export interface KaizenDefaults {
+  /** Harness ref used when --harness is not passed on the CLI. */
+  harness?: string;
+  /** Per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects. */
+  plugin_config?: Record<string, Record<string, unknown>>;
+  /**
+   * Env vars that bypass tier-based env.get gating, regardless of plugin tier.
+   * Entries are exact names ("PATH") or trailing-* prefixes ("LC_*").
+   * If absent, the built-in DEFAULT_ENV_ALLOWLIST is used. An explicit []
+   * means "no allow-list; gate everything."
+   */
+  env_allowlist?: string[];
+}
+```
+
+- [ ] **Step 2: Modify `KaizenConfig`**
+
+Find:
+
+```typescript
+export interface KaizenConfig {
+  /** Canonical refs (`<marketplace>/<name>[@<version>]`) or legacy bare npm names. */
+  plugins: string[];
+  /** ... */
+  extends?: string;
+  /** Informational marketplaces a harness expects; consumed by --harness bootstrap. */
+  marketplaces?: MarketplaceRef[];
+  [pluginName: string]: unknown;
+}
+```
+
+Add the field above the index signature:
+
+```typescript
+export interface KaizenConfig {
+  /** Canonical refs (`<marketplace>/<name>[@<version>]`) or legacy bare npm names. */
+  plugins: string[];
+  /** ... */
+  extends?: string;
+  /** Informational marketplaces a harness expects; consumed by --harness bootstrap. */
+  marketplaces?: MarketplaceRef[];
+  /**
+   * Per-harness env allow-list. Same syntax as KaizenDefaults.env_allowlist.
+   * If present, takes precedence over the user-level value at runtime.
+   */
+  env_allowlist?: string[];
+  [pluginName: string]: unknown;
+}
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/plugin.ts
+git commit -m "feat(types): add env_allowlist to KaizenDefaults and KaizenConfig"
+```
+
+---
+
+## Task 4: Wire allow-list into `PermissionEnforcer`
+
+**Files:**
+- Modify: `src/core/permission-enforcer.ts`
+- Modify: `src/core/permission-enforcer.test.ts`
+
+Constructor accepts `envAllowList: string[]` (default `DEFAULT_ENV_ALLOWLIST`). The `env.get` branch in `evaluate()` short-circuits on a match.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/permission-enforcer.test.ts`:
+
+```typescript
+import { DEFAULT_ENV_ALLOWLIST } from "./env-allowlist.js";
+
+describe("PermissionEnforcer — env allow-list", () => {
+  it("trusted plugin: allow-listed env permitted", () => {
+    const e = new PermissionEnforcer({ mode: "enforce" });
+    e.register("p", { tier: "trusted" });
+    expect(() =>
+      e.check("p", { kind: "env.get", name: "PATH" }),
+    ).not.toThrow();
+  });
+
+  it("trusted plugin: non-allow-listed env denied", () => {
+    const e = new PermissionEnforcer({ mode: "enforce" });
+    e.register("p", { tier: "trusted" });
+    expect(() =>
+      e.check("p", { kind: "env.get", name: "AWS_SECRET" }),
+    ).toThrow(/tier 'trusted' permits no external ops/);
+  });
+
+  it("trusted plugin + empty allow-list: PATH denied", () => {
+    const e = new PermissionEnforcer({ mode: "enforce", envAllowList: [] });
+    e.register("p", { tier: "trusted" });
+    expect(() =>
+      e.check("p", { kind: "env.get", name: "PATH" }),
+    ).toThrow(/tier 'trusted' permits no external ops/);
+  });
+
+  it("scoped plugin: declared env grants still permitted", () => {
+    const e = new PermissionEnforcer({ mode: "enforce" });
+    e.register("p", { tier: "scoped", env: ["DB_URL"] });
+    expect(() => e.check("p", { kind: "env.get", name: "DB_URL" })).not.toThrow();
+    expect(() => e.check("p", { kind: "env.get", name: "PATH" })).not.toThrow(); // allow-list
+    expect(() => e.check("p", { kind: "env.get", name: "OTHER" })).toThrow(/not in env grants/);
+  });
+
+  it("scoped plugin + custom allow-list replaces default", () => {
+    const e = new PermissionEnforcer({ mode: "enforce", envAllowList: ["MY_*"] });
+    e.register("p", { tier: "scoped" });
+    expect(() => e.check("p", { kind: "env.get", name: "MY_FOO" })).not.toThrow();
+    expect(() => e.check("p", { kind: "env.get", name: "PATH" })).toThrow(/not in env grants/);
+  });
+
+  it("unscoped plugin: all env permitted regardless of allow-list", () => {
+    const e = new PermissionEnforcer({ mode: "enforce", envAllowList: [] });
+    e.register("p", { tier: "unscoped" });
+    expect(() => e.check("p", { kind: "env.get", name: "PATH" })).not.toThrow();
+    expect(() => e.check("p", { kind: "env.get", name: "AWS_SECRET" })).not.toThrow();
+  });
+
+  it("default constructor uses DEFAULT_ENV_ALLOWLIST", () => {
+    const e = new PermissionEnforcer({ mode: "enforce" });
+    e.register("p", { tier: "trusted" });
+    for (const name of ["PATH", "HOME", "TMPDIR", "LANG"]) {
+      expect(() => e.check("p", { kind: "env.get", name })).not.toThrow();
+    }
+    // LC_* prefix
+    expect(() => e.check("p", { kind: "env.get", name: "LC_ALL" })).not.toThrow();
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("LC_*"); // sanity
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/permission-enforcer.test.ts -t "env allow-list"`
+Expected: FAIL — `envAllowList` is not a constructor option; checks against PATH on trusted tier currently throw.
+
+- [ ] **Step 3: Modify the enforcer**
+
+In `src/core/permission-enforcer.ts`:
+
+1. Add the import at the top:
+   ```typescript
+   import { DEFAULT_ENV_ALLOWLIST, envAllowed } from "./env-allowlist.js";
+   ```
+
+2. Add the field on the class:
+   ```typescript
+   export class PermissionEnforcer {
+     private mode: EnforcerMode;
+     private readonly envAllowList: string[];
+     private readonly manifests = new Map<string, PluginPermissions>();
+     // ... existing fields
+   ```
+
+3. Update the constructor:
+   ```typescript
+   constructor(opts: { mode: EnforcerMode; envAllowList?: string[] }) {
+     this.mode = opts.mode;
+     this.envAllowList = opts.envAllowList ?? DEFAULT_ENV_ALLOWLIST;
+   }
+   ```
+
+4. In `evaluate()`, find the `env.get` case:
+
+   Existing:
+   ```typescript
+   case "env.get":
+     return (m.env ?? []).includes(op.name) ? null : `env var '${op.name}' not in env grants`;
+   ```
+
+   The trusted-tier branch above this already returns a denial string before this case is reached. We need the allow-list to short-circuit *both* the trusted denial and the scoped grant check. Restructure:
+
+   At the top of `evaluate()`, after the `tier === "unscoped"` early-return and the `import` case but BEFORE the `if (tier === "trusted")` line, insert:
+
+   ```typescript
+   // Allow-listed env reads bypass tier checks entirely.
+   if (op.kind === "env.get" && envAllowed(this.envAllowList, op.name)) return null;
+   ```
+
+   The existing tier-trusted check and the `env.get` case in the scoped switch both stay as-is. Allow-listed names never reach them.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/permission-enforcer.test.ts`
+Expected: all tests PASS, including the new env-allow-list group and the existing tier tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/permission-enforcer.ts src/core/permission-enforcer.test.ts
+git commit -m "feat(enforcer): consult env allow-list before tier checks"
+```
+
+---
+
+## Task 5: Validate `defaults.env_allowlist` on global config load
+
+**Files:**
+- Modify: `src/core/kaizen-config.ts`
+- Modify: `src/core/kaizen-config.test.ts`
+
+Loader rejects invalid entries; accepts valid entries unchanged; treats absent and `[]` as distinct.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/core/kaizen-config.test.ts` (or wherever `loadKaizenGlobalConfig` is tested — locate it first):
+
+```typescript
+import { loadKaizenGlobalConfig } from "./kaizen-config.js";
+
+describe("loadKaizenGlobalConfig — env_allowlist", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kz-cfg-"));
+    process.env.KAIZEN_HOME_OVERRIDE = home;
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env.KAIZEN_HOME_OVERRIDE;
+  });
+
+  function writeCfg(obj: unknown) {
+    writeFileSync(join(home, "kaizen.json"), JSON.stringify(obj));
+  }
+
+  it("absent env_allowlist is left undefined", async () => {
+    writeCfg({ defaults: { harness: "official/x@1.0.0" } });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.defaults?.env_allowlist).toBeUndefined();
+  });
+
+  it("valid env_allowlist passes through", async () => {
+    writeCfg({ defaults: { env_allowlist: ["PATH", "LC_*"] } });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.defaults?.env_allowlist).toEqual(["PATH", "LC_*"]);
+  });
+
+  it("empty array is preserved (not normalized to undefined)", async () => {
+    writeCfg({ defaults: { env_allowlist: [] } });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.defaults?.env_allowlist).toEqual([]);
+  });
+
+  it("invalid entry rejected with offender named", async () => {
+    writeCfg({ defaults: { env_allowlist: ["FOO*BAR"] } });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/FOO\*BAR/);
+  });
+
+  it("non-array rejected", async () => {
+    writeCfg({ defaults: { env_allowlist: "PATH" } });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/must be an array/);
+  });
+});
+```
+
+(If the existing test file does not import `mkdtempSync`, `tmpdir`, etc., add them. Verify against the file's existing import block.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/core/kaizen-config.test.ts -t "env_allowlist"`
+Expected: FAIL — `env_allowlist` is currently rejected as an unknown key under `defaults`.
+
+- [ ] **Step 3: Update the loader**
+
+In `src/core/kaizen-config.ts`:
+
+1. Add import at the top:
+   ```typescript
+   import { validateEnvAllowList } from "./env-allowlist.js";
+   ```
+
+2. Update the allowed-keys set:
+   ```typescript
+   const ALLOWED_DEFAULTS_KEYS = new Set(["harness", "plugin_config", "env_allowlist"]);
+   ```
+
+3. After the existing `defaults.plugin_config` validation block (around line 115), add:
+
+   ```typescript
+   if (defaults.env_allowlist !== undefined) {
+     validateEnvAllowList(defaults.env_allowlist, `${path}: defaults.env_allowlist`);
+   }
+   ```
+
+   The validator throws on invalid input; the call has no return-value usage because the parsed object is returned as-is.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/core/kaizen-config.test.ts`
+Expected: all tests PASS, including new env_allowlist tests and existing config tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/kaizen-config.ts src/core/kaizen-config.test.ts
+git commit -m "feat(config): accept and validate defaults.env_allowlist"
+```
+
+---
+
+## Task 6: Validate harness-level `env_allowlist`
+
+**Files:**
+- Modify: wherever harness `kaizen.json` is loaded/validated. Locate via `grep -rn "resolveHarness\|kaizen.json" src --include="*.ts" | grep -iv test`. Likely candidates: `src/core/harness-marketplace.ts`, `src/core/config.ts`, or `src/core/kaizen-config.ts`. Read the resolver entry point referenced from `src/cli.ts:423` (`resolveHarnessOrFatal`) to find the right file.
+
+Apply the same `validateEnvAllowList` call when a harness `kaizen.json` is parsed.
+
+- [ ] **Step 1: Identify the harness loader**
+
+Run: `grep -n "resolveHarnessOrFatal\|loadHarnessConfig\|readFileSync.*kaizen.json" src --include="*.ts" -r | grep -v test | head`
+
+Read the resolver implementation. Find the point at which the harness JSON is parsed into a `KaizenConfig` (the function returning `{ kaizenJsonPath, config }` invoked from `src/cli.ts:423`).
+
+- [ ] **Step 2: Write the failing test**
+
+Add a test in the same file as that function's existing tests (or its sibling `*.test.ts`). The test should:
+
+```typescript
+// Pseudocode — adjust to match the actual loader's signature.
+it("rejects invalid env_allowlist in harness kaizen.json", () => {
+  const dir = mkdtempSync(join(tmpdir(), "kz-h-"));
+  writeFileSync(join(dir, "kaizen.json"), JSON.stringify({
+    plugins: [],
+    env_allowlist: ["BAD*ENTRY"],
+  }));
+  expect(() => loadHarnessConfig(join(dir, "kaizen.json"))).toThrow(/BAD\*ENTRY/);
+});
+
+it("accepts valid env_allowlist in harness kaizen.json", () => {
+  const dir = mkdtempSync(join(tmpdir(), "kz-h-"));
+  writeFileSync(join(dir, "kaizen.json"), JSON.stringify({
+    plugins: [],
+    env_allowlist: ["PATH", "LC_*"],
+  }));
+  const cfg = loadHarnessConfig(join(dir, "kaizen.json"));
+  expect(cfg.env_allowlist).toEqual(["PATH", "LC_*"]);
+});
+```
+
+Substitute the actual loader function name discovered in Step 1.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run the new tests with `bun test <path-to-test-file>`.
+Expected: FAIL — invalid entries are silently accepted today.
+
+- [ ] **Step 4: Add validation in the harness loader**
+
+In the file identified in Step 1, after `JSON.parse` of the harness `kaizen.json`, before returning the config object, insert:
+
+```typescript
+import { validateEnvAllowList } from "./env-allowlist.js";
+
+// ... inside the loader, after parsing JSON into `cfg`:
+if (cfg.env_allowlist !== undefined) {
+  validateEnvAllowList(cfg.env_allowlist, `${kaizenJsonPath}: env_allowlist`);
+}
+```
+
+(Adjust the import path and field-access syntax to match the loader.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run the new tests.
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add <modified files>
+git commit -m "feat(config): validate harness env_allowlist on load"
+```
+
+---
+
+## Task 7: Resolve allow-list at bootstrap
+
+**Files:**
+- Modify: `src/core/index.ts`
+- Modify: `src/core/index.test.ts` (or `bootstrap.test.ts` — locate the existing tests for `initializePluginSystem`)
+
+Compute the effective allow-list at the point `PermissionEnforcer` is constructed in `initializePluginSystem`. Precedence: harness `env_allowlist` (if present, including `[]`) → user `defaults.env_allowlist` (if present, including `[]`) → `DEFAULT_ENV_ALLOWLIST`.
+
+- [ ] **Step 1: Inspect existing wiring**
+
+Read `src/core/index.ts` lines 30-70 to confirm where the enforcer is constructed and what config objects are in scope.
+
+- [ ] **Step 2: Write the failing test**
+
+In `src/core/index.test.ts` (or wherever `initializePluginSystem` is exercised today; locate via `grep -rn "initializePluginSystem" src --include="*.test.ts"`), add:
+
+```typescript
+it("uses default env_allowlist when neither user nor harness specifies one", async () => {
+  // Set up a minimal harness config + global config with no env_allowlist.
+  // After init, e.check on a trusted plugin for PATH must not throw.
+  // (Detail filled per the existing test scaffolding in this file.)
+});
+
+it("user defaults.env_allowlist overrides default when harness has none", async () => {
+  // Configure user with ["MY_*"]; harness omits env_allowlist.
+  // env.get("MY_FOO") permitted; env.get("PATH") denied for trusted plugin.
+});
+
+it("harness env_allowlist beats user env_allowlist", async () => {
+  // Configure user ["A_*"]; harness ["B_*"]. Effective list is ["B_*"].
+});
+
+it("explicit empty harness env_allowlist disables passthrough", async () => {
+  // Harness env_allowlist: []. env.get("PATH") denied for trusted plugin.
+});
+```
+
+Use the existing test patterns in the file for setting up `KaizenConfig` and `KaizenGlobalConfig` fixtures. Each test calls `initializePluginSystem(...)` and then probes `enforcer.check(...)` from the returned system, or via an `injectedEnforcer` workaround if the API doesn't expose the enforcer directly. If the existing tests show how to assert on enforcer behavior, follow that pattern; otherwise inject a custom enforcer in the opts to assert resolution at the call site instead.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `bun test src/core/index.test.ts -t "env_allowlist"` (or the relevant file).
+Expected: FAIL — current code constructs `new PermissionEnforcer({ mode })` with no allow-list option.
+
+- [ ] **Step 4: Modify `initializePluginSystem`**
+
+In `src/core/index.ts`, locate the block:
+
+```typescript
+let enforcer: PermissionEnforcer;
+if (injectedEnforcer) {
+  enforcer = injectedEnforcer;
+} else {
+  const mode = (process.env["KAIZEN_SANDBOX_MODE"] as EnforcerMode | undefined) ?? "enforce";
+  enforcer = new PermissionEnforcer({ mode });
+  initializeSandbox(enforcer);
+}
+```
+
+Replace with:
+
+```typescript
+let enforcer: PermissionEnforcer;
+if (injectedEnforcer) {
+  enforcer = injectedEnforcer;
+} else {
+  const mode = (process.env["KAIZEN_SANDBOX_MODE"] as EnforcerMode | undefined) ?? "enforce";
+  const envAllowList = await resolveEnvAllowList(kaizenConfig);
+  enforcer = new PermissionEnforcer({ mode, envAllowList });
+  initializeSandbox(enforcer);
+}
+```
+
+Add a helper near the top of `src/core/index.ts` (or in a new file `src/core/resolve-env-allowlist.ts` if you prefer isolation; the spec allows either):
+
+```typescript
+import { DEFAULT_ENV_ALLOWLIST } from "./env-allowlist.js";
+import { loadKaizenGlobalConfig } from "./kaizen-config.js";
+
+async function resolveEnvAllowList(harnessConfig: KaizenConfig): Promise<string[]> {
+  // Harness wins if explicitly set (including []).
+  if (harnessConfig.env_allowlist !== undefined) return harnessConfig.env_allowlist;
+  // Otherwise, user defaults.
+  const global = await loadKaizenGlobalConfig();
+  if (global.defaults?.env_allowlist !== undefined) return global.defaults.env_allowlist;
+  // Otherwise, built-in default.
+  return DEFAULT_ENV_ALLOWLIST;
+}
+```
+
+Adjust the existing imports at the top of `index.ts` to include `KaizenConfig` if not already imported.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test src/core/index.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/index.ts src/core/index.test.ts
+git commit -m "feat(bootstrap): resolve env allow-list with harness>user>default precedence"
+```
+
+---
+
+## Task 8: End-to-end proxy behavior under allow-list
+
+**Files:**
+- Modify: `src/core/sandbox-bootstrap.test.ts` (or create if absent — check first via `ls src/core/sandbox-bootstrap.test.ts 2>/dev/null`)
+
+Verify the proxy's `get`, `has`, and `ownKeys` traps respect the allow-list end-to-end (no proxy code change is needed; this confirms the enforcer-level change reaches the proxy correctly).
+
+- [ ] **Step 1: Confirm or create the test file**
+
+Run: `ls src/core/sandbox-bootstrap.test.ts 2>/dev/null && echo EXISTS || echo MISSING`
+
+If MISSING, create it with the standard `bun:test` boilerplate. If EXISTS, append to it.
+
+- [ ] **Step 2: Write the test**
+
+Add (or create file with) the following:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { initializeSandbox, restoreSandboxForTesting } from "./sandbox-bootstrap.js";
+import { PermissionEnforcer } from "./permission-enforcer.js";
+import { setCurrentPluginForTesting, clearCurrentPluginForTesting } from "./plugin-scope.js";
+
+describe("sandbox proxy + env allow-list", () => {
+  let enforcer: PermissionEnforcer;
+
+  beforeEach(() => {
+    enforcer = new PermissionEnforcer({ mode: "enforce" }); // default allow-list
+    enforcer.register("p", { tier: "trusted" });
+    initializeSandbox(enforcer);
+    process.env.PATH ??= "/usr/bin";
+    process.env.AWS_TEST_SECRET = "shh";
+    setCurrentPluginForTesting("p");
+  });
+  afterEach(() => {
+    clearCurrentPluginForTesting();
+    delete process.env.AWS_TEST_SECRET;
+    restoreSandboxForTesting();
+  });
+
+  it("trusted plugin reads allow-listed PATH", () => {
+    expect(typeof process.env.PATH).toBe("string");
+    expect(process.env.PATH!.length).toBeGreaterThan(0);
+  });
+
+  it("trusted plugin sees undefined for non-allow-listed secret", () => {
+    expect(process.env.AWS_TEST_SECRET).toBeUndefined();
+  });
+
+  it("'in' check respects allow-list", () => {
+    expect("PATH" in process.env).toBe(true);
+    expect("AWS_TEST_SECRET" in process.env).toBe(false);
+  });
+
+  it("Object.keys excludes non-allow-listed secret", () => {
+    const keys = Object.keys(process.env);
+    expect(keys).toContain("PATH");
+    expect(keys).not.toContain("AWS_TEST_SECRET");
+  });
+});
+```
+
+If `setCurrentPluginForTesting` / `clearCurrentPluginForTesting` / `restoreSandboxForTesting` exports do not exist, locate the equivalent test helpers in `src/core/plugin-scope.ts` and `src/core/sandbox-bootstrap.ts` (the existing `restoreSandboxForTesting` is referenced in line 88 of `sandbox-bootstrap.ts`). Substitute the real names.
+
+- [ ] **Step 3: Run tests**
+
+Run: `bun test src/core/sandbox-bootstrap.test.ts`
+Expected: all four tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/sandbox-bootstrap.test.ts
+git commit -m "test(sandbox): proxy passthrough under env allow-list"
+```
+
+---
+
+## Task 9: Integration smoke — trusted plugin spawns a binary
+
+**Files:**
+- Locate an existing integration test under `tests/integration/` or write a focused one. Run `ls tests/integration/` and identify the closest existing test to extend.
+
+A trusted-tier plugin calls `child_process.spawn` for a binary that exists on PATH. With the allow-list active, `process.env.PATH` is visible and the spawn succeeds.
+
+- [ ] **Step 1: Locate the right test surface**
+
+Run: `ls tests/integration/ && grep -rln "trusted\|tier\|spawn" tests/ --include="*.ts" 2>/dev/null | head`
+
+Identify whether an existing trusted-tier plugin fixture or test already exists. If yes, extend it. If no, this task may be deferred to a follow-up; mark this task complete after the unit tests in Tasks 4 and 8 cover the behavior. The unit tests already exercise the allow-list end to end at the enforcer + proxy layer.
+
+- [ ] **Step 2: If an existing integration scaffold exists, add the spawn case**
+
+Use a portable binary always present on macOS and Linux runners: `/usr/bin/true` or `echo`. Confirm the test runner has access:
+
+```typescript
+import { spawnSync } from "child_process";
+
+// inside a trusted plugin's setup():
+const result = spawnSync("echo", ["ok"], { env: process.env });
+expect(result.status).toBe(0);
+expect(result.stdout.toString()).toContain("ok");
+```
+
+- [ ] **Step 3: If no scaffold exists, document the deferral**
+
+Add a one-line note in the plan's status (or in a follow-up issue): "Integration smoke deferred; unit coverage in tasks 4 and 8 exercises the bug end-to-end at the enforcer + proxy layer."
+
+- [ ] **Step 4: Commit (if a test was added)**
+
+```bash
+git add <changed files>
+git commit -m "test(integration): trusted plugin spawn succeeds under env allow-list"
+```
+
+---
+
+## Task 10: Update `docs/guides/plugin-authoring.md`
+
+**Files:**
+- Modify: `docs/guides/plugin-authoring.md` (lines 385-391)
+
+Replace the incorrect "globals are not filtered" paragraph.
+
+- [ ] **Step 1: Read the current paragraph**
+
+Read: `docs/guides/plugin-authoring.md` lines 380-395 to confirm exact wording.
+
+- [ ] **Step 2: Replace the blockquote**
+
+Find:
+
+```
+> **What the sandbox enforces today:** The enforcer gates module imports and
+> calls made through `ctx.fs` / `ctx.net` / `ctx.exec`. It does **not** filter
+> Node.js globals. `process.cwd()`, `process.env`, `process.platform`,
+> `os.homedir()`, and similar ambient values are accessible to plugins of any
+> tier. `tier` currently signals intent and controls which `ctx.*` grants are
+> available — it is not a hard runtime cap on globals. A future release may
+> tighten this; for now, treat global access as unrestricted.
+```
+
+Replace with:
+
+```
+> **What the sandbox enforces today:** The enforcer gates module imports,
+> calls through `ctx.fs` / `ctx.net` / `ctx.exec`, and reads from
+> `process.env`. A built-in allow-list of OS-infrastructure variables —
+> `PATH`, `HOME`, `USER`, locale (`LC_*`, `LANG`), tmpdirs (`TMPDIR`,
+> `TEMP`, `TMP`), and similar — passes through under any tier so that
+> stdlib calls such as `child_process.spawn`, `os.homedir()`, and
+> `os.tmpdir()` work without elevating tiers. Variables outside the
+> allow-list follow tier rules: `unscoped` reads anything, `scoped` reads
+> names declared in `env: [...]`, `trusted` reads only allow-listed
+> names.
+>
+> Override the allow-list via `defaults.env_allowlist` in
+> `~/.kaizen/kaizen.json` (user-level) or `env_allowlist` in a harness's
+> `kaizen.json` (harness-level; takes precedence). An explicit `[]` means
+> "gate everything; no passthrough." Entries are exact names (`"PATH"`)
+> or trailing-`*` prefixes (`"LC_*"`).
+>
+> `process.cwd()`, `process.platform`, `os.platform()`, and similar
+> non-env globals are not filtered.
+```
+
+- [ ] **Step 3: Verify rendering**
+
+Skim the diff for stray formatting issues. No code execution needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guides/plugin-authoring.md
+git commit -m "docs(plugin-authoring): correct sandbox-enforcement description"
+```
+
+---
+
+## Task 11: Update `docs/concepts/security.md`
+
+**Files:**
+- Modify: `docs/concepts/security.md`
+
+Extend the env-proxy section and the troubleshooting note.
+
+- [ ] **Step 1: Locate the env-proxy section and the troubleshooting note**
+
+Read: `docs/concepts/security.md`. Find the line `process.env.X | Declare env: ["X"]...` (around line 70) and the troubleshooting block around line 111 (`process.env.X returns undefined unexpectedly`).
+
+- [ ] **Step 2: Update the env row**
+
+Find a line like:
+
+```
+| `process.env.X` | Declare `env: ["X"]` and read `process.env.X` normally (proxy enforces the grant) |
+```
+
+Update to:
+
+```
+| `process.env.X` | OS-infrastructure vars (PATH, HOME, locale, tmpdirs, …) pass through under any tier via a built-in allow-list. For other vars, declare `env: ["X"]` (scoped tier) and read `process.env.X` normally (proxy enforces the grant). Override the allow-list with `defaults.env_allowlist` (user) or `env_allowlist` (harness). |
+```
+
+- [ ] **Step 3: Update the troubleshooting note**
+
+Find the paragraph beginning `**"process.env.X returns undefined unexpectedly."**` and update it to:
+
+```
+**"`process.env.X` returns `undefined` unexpectedly."** The env proxy hides
+variables you have not declared and that are not in the active allow-list.
+For OS-infrastructure variables (`PATH`, `HOME`, locale, tmpdirs, …) this
+is unexpected and means your active allow-list does not include the name —
+check `defaults.env_allowlist` in `~/.kaizen/kaizen.json` and the harness's
+`env_allowlist`. For application/secret variables, add the name to your
+plugin's `env: [...]` grants and re-load.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/concepts/security.md
+git commit -m "docs(security): describe env allow-list and overrides"
+```
+
+---
+
+## Task 12: Document config keys
+
+**Files:**
+- Modify: `docs/concepts/configuration.md`
+
+Document `defaults.env_allowlist` (user-level) and per-harness `env_allowlist`.
+
+- [ ] **Step 1: Locate the configuration reference**
+
+Read: `docs/concepts/configuration.md`. Find the section that documents `defaults.harness` and `defaults.plugin_config` (the existing user-level `defaults.*` documentation).
+
+- [ ] **Step 2: Add an `env_allowlist` subsection**
+
+Insert under the `defaults` section:
+
+```markdown
+### `defaults.env_allowlist` (optional)
+
+Array of env-var names that bypass tier-based env.get gating, regardless
+of plugin tier. Each entry is an exact name (`"PATH"`) or a trailing-`*`
+prefix (`"LC_*"`). If absent, kaizen ships a sensible default covering
+PATH, HOME, USER, locale, tmpdirs, and similar OS-infrastructure
+variables — see `src/core/env-allowlist.ts`.
+
+An explicit empty array `[]` is a valid override meaning "no
+passthrough; gate everything per tier rules." Distinguishable from
+absent.
+
+A harness's `kaizen.json` may also set `env_allowlist` at top level. The
+harness value takes precedence over this user-level value when both are
+set. Resolution order:
+
+1. Harness `env_allowlist` (if present, including `[]`)
+2. User `defaults.env_allowlist` (if present, including `[]`)
+3. Built-in `DEFAULT_ENV_ALLOWLIST`
+
+Invalid entries (multiple `*`, `*` not at end, whitespace, empty
+strings) cause kaizen to fail at config load with the offending entry
+named.
+
+Example (user config):
+
+​```json
+{
+  "defaults": {
+    "harness": "official/claude-wrapper",
+    "env_allowlist": ["PATH", "HOME", "LC_*", "MY_TOOL_*"]
+  }
+}
+​```
+
+Example (harness `kaizen.json`, strict mode):
+
+​```json
+{
+  "plugins": ["official/example@1.0.0"],
+  "env_allowlist": []
+}
+​```
+```
+
+(Replace the `​```` characters above with backticks; they are zero-width-space-separated to keep the JSON code blocks intact in this plan file. When inserting into the actual docs, use plain triple backticks.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/concepts/configuration.md
+git commit -m "docs(configuration): document env_allowlist user and harness keys"
+```
+
+---
+
+## Task 13: Full verification
+
+**Files:** none
+
+- [ ] **Step 1: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `bun test`
+Expected: all tests PASS.
+
+- [ ] **Step 3: Manual smoke (optional)**
+
+Build and try the original repro from issue #64: a trusted-tier plugin that spawns a binary on PATH. Confirm `Executable not found in $PATH` no longer fires under default config.
+
+If any test fails, fix and recommit before claiming done. Do not claim verification with failing tests.
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section / requirement | Task(s) |
+|---|---|
+| Allow-list module + default list | 1 |
+| Allow-list validator (exact/prefix syntax, error on invalid) | 2 |
+| Type changes for `KaizenDefaults` and `KaizenConfig` | 3 |
+| Enforcer consults allow-list in `evaluate()` for `env.get` | 4 |
+| User config validates `defaults.env_allowlist` on load | 5 |
+| Harness config validates `env_allowlist` on load | 6 |
+| Resolution precedence harness > user > default | 7 |
+| Distinguish absent from explicit `[]` | 5, 7 |
+| Proxy `get` / `has` / `ownKeys` reflect allow-list | 8 |
+| Trusted-tier behavior change covered (PATH passes, AWS_* denied) | 4, 8 |
+| Scoped-tier explicit grants still work | 4 |
+| Unscoped tier unaffected | 4 |
+| Doc: plugin-authoring correction | 10 |
+| Doc: security.md proxy explanation + troubleshooting | 11 |
+| Doc: configuration.md key reference | 12 |
+| Final verification | 13 |
+| Integration smoke (deferred-OK if scaffold absent) | 9 |
+
+All spec sections covered. No placeholders. Type/method names consistent: `envAllowed`, `validateEnvAllowList`, `DEFAULT_ENV_ALLOWLIST`, `envAllowList` (constructor option), `env_allowlist` (config key in JSON, snake_case for consistency with existing `plugin_config`).

--- a/docs/superpowers/specs/2026-04-30-plugin-runtime-deps-design.md
+++ b/docs/superpowers/specs/2026-04-30-plugin-runtime-deps-design.md
@@ -1,0 +1,163 @@
+# Plugin runtime dependency resolution
+
+**Issue:** [#65 — Marketplace install does not resolve plugin runtime dependencies](https://github.com/CraightonH/kaizen/issues/65)
+**Date:** 2026-04-30
+**Status:** Approved (brainstorm complete, ready for implementation plan)
+
+## Problem
+
+When a plugin declares runtime `dependencies` in its `package.json`, the kaizen
+marketplace install copies the plugin source into
+`~/.kaizen/marketplaces/<m>/plugins/<name>@<version>/` but does not resolve
+those deps. At plugin load time Bun fails to resolve the imports because there
+is no `node_modules` at or above the install path.
+
+Repro: `claude-tui@0.2.0` declares `ink`, `ink-spinner`, and `react` as runtime
+deps. Loading the plugin fails with:
+
+```
+ResolveMessage: Cannot find module 'react/jsx-dev-runtime'
+```
+
+…which cascades into a misleading `Plugin(s) [claude-driver] consumes undefined
+service 'claude-tui:channel'` error four steps removed from the real cause.
+
+All existing official plugins ship only `devDependencies`, so the gap was
+hidden until the first plugin with real runtime deps tried to load.
+
+## Goal
+
+When kaizen installs a plugin from any source (`file`, `tarball`, `npm`), if
+the plugin declares runtime npm dependencies, kaizen resolves them via
+`bun install --production` so the plugin's imports load successfully. The
+installer (`scripts/install.sh`) ensures `bun` is present so this is reliable
+end-to-end on a fresh machine.
+
+## Non-goals
+
+- Hoisting deps into a marketplace-shared `node_modules`.
+- Pre-bundled plugin artifacts as a contract (plugins remain unbundled source).
+- Lockfile policy enforcement (we honor whatever the author committed).
+- A dep cache strategy beyond Bun's existing global cache.
+- A `--skip-deps` escape hatch (YAGNI; revisit if airgapped install becomes a real ask).
+- Dev-time plugin workflows (e.g., `kaizen plugin link`) — unaffected.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Approach | Per-plugin `bun install --production` at install time | Smallest change; matches Bun's per-plugin model; works uniformly across source types; no kaizen-owned resolution layer. |
+| Package manager | `bun` only | kaizen already requires Bun; one assumed runtime end-to-end; no detection branching. |
+| When to install | Only when `package.json` exists *and* has a non-empty `dependencies` object | Avoids no-op `bun install` calls on the existing zero-dep official plugins. |
+| Failure mode | Hard fail; wipe target; surface bun's stderr | A plugin with unresolved deps is broken on arrival; failing at install gives an actionable error instead of a misleading load-time cascade. |
+| Reinstall behavior | Wipe and re-resolve every install | Matches the existing "every install is fresh" contract; bun's global cache makes the second run cheap. |
+| Lockfile handling | Honor whatever the author committed (`bun.lock`, `package-lock.json`, etc.) | Standard Bun behavior; documents "commit your lockfile" as best practice without enforcing it. |
+| Bun availability — installer | `scripts/install.sh` runs bun's official installer if bun is missing | Single point of responsibility for bootstrap; idempotent. |
+| Bun availability — runtime | At `kaizen install` time: prefer `bun` on PATH, fall back to `~/.bun/bin/bun`, else error with install instructions | Handles the common "first shell after install.sh, PATH not refreshed" case without making kaizen a package-manager installer. |
+
+## Design
+
+### Plugin install flow (`src/core/plugin-installer.ts`)
+
+After the source-specific copy/extract step in `installPlugin` (the three
+existing `case` branches), add a single post-step that runs uniformly for all
+source types:
+
+```
+1. Source materialized at `target` (existing logic — unchanged).
+2. If `target/package.json` exists, parses, and has a non-empty `dependencies` object:
+   a. Resolve a bun executable: `bun` on PATH → fallback `~/.bun/bin/bun`.
+      If neither resolves, throw with install instructions.
+   b. Run `bun install --production` with cwd=target, capturing stdout/stderr.
+   c. On non-zero exit: rmSync(target, { recursive: true, force: true }), throw
+      with bun's stderr included.
+3. Otherwise (no package.json, malformed JSON, or empty/absent `dependencies`),
+   no-op.
+```
+
+A small internal helper resolves the bun executable. Not exported.
+
+### `scripts/install.sh` change
+
+Add an `ensure_bun` step that runs *before* `bootstrap` (the existing step that
+adds the official marketplace and installs the default harness — which now may
+pull plugins with runtime deps).
+
+```
+ensure_bun:
+  if KAIZEN_NO_BUN=1: info "Skipping bun install (KAIZEN_NO_BUN=1)"; return 0
+  if `bun` on PATH: info "bun already installed"; return 0
+  if `~/.bun/bin/bun` exists: info "bun found at ~/.bun/bin/bun"; return 0
+  info "Installing bun (required for plugin dependency resolution)..."
+  if curl -fsSL https://bun.sh/install | bash:
+    green "  ✓ bun installed"
+  else:
+    red "  ! bun install failed; install manually: curl -fsSL https://bun.sh/install | bash"
+    return 0  # best-effort; do not abort
+```
+
+- Idempotent.
+- Best-effort, matching the existing `bootstrap()` convention. A bun-install
+  failure does not abort the kaizen installer.
+- `KAIZEN_NO_BUN=1` opt-out (mirroring `KAIZEN_NO_BOOTSTRAP`).
+- Bun's installer modifies the user's shell profile to add `~/.bun/bin` to
+  PATH. kaizen does not touch shell profiles itself.
+
+### Error messages
+
+**Bun missing at `kaizen install` time:**
+```
+error: plugin '<name>@<version>' declares runtime dependencies but bun is not
+on PATH or at ~/.bun/bin/bun.
+Install bun: curl -fsSL https://bun.sh/install | bash
+```
+
+**`bun install` non-zero exit:**
+```
+error: bun install failed for plugin '<name>@<version>' at <target>
+<bun's stderr, indented>
+```
+Target dir is removed so the half-installed plugin doesn't linger.
+
+**Malformed `package.json`:** treat as "no deps" — debug log and skip. A
+plugin with broken JSON is the author's bug; the plugin will fail at load
+with a clearer error than kaizen could produce.
+
+## Testing
+
+### Unit tests (`src/core/plugin-installer.test.ts`, extending existing)
+
+1. `file` source with `package.json` containing real `dependencies` → after install, `target/node_modules/<dep>` exists.
+2. `file` source with `package.json` and empty/missing `dependencies` → no `node_modules` created, no bun call (assert via spy).
+3. `file` source with no `package.json` → no `node_modules`, no bun call.
+4. `bun install` failure path (use a deliberately bad dep name to avoid network) → `target` is removed, error includes bun's stderr.
+5. Bun missing path → stub the resolver to return null; assert error message includes the install command.
+6. `tarball` and `npm` source variants → one test each confirming the post-step runs uniformly.
+
+Tests that actually exercise `bun install` against the registry use a tiny pure-JS dep to keep network/cache footprint minimal. Failure-path tests do not hit the network.
+
+### Installer tests (`scripts/install.test.sh` or sourced helpers)
+
+- `ensure_bun` no-ops when `bun` is on a stubbed PATH.
+- `ensure_bun` no-ops when `~/.bun/bin/bun` exists (set `HOME` to a temp dir with a stub binary).
+- `KAIZEN_NO_BUN=1` skips the step.
+- Failure of the bun installer (simulate via stubbed `curl` that exits non-zero) does not abort the script.
+
+## Documentation
+
+To be landed alongside the code via `kaizen:update-docs`:
+
+- Plugin-authoring page:
+  - "Runtime deps in `package.json` are resolved automatically at install time via `bun install --production`."
+  - "Commit your `bun.lock` (or other lockfile) for reproducible installs."
+  - "Postinstall lifecycle scripts are disabled by Bun by default. If your plugin needs one (e.g., a native binding), declare the dep in `trustedDependencies` in your `package.json`."
+  - Recommend keeping build-only tools in `devDependencies` so they're not pulled at install time.
+- Installer/README docs:
+  - `install.sh` installs bun as part of setup; `KAIZEN_NO_BUN=1` opts out.
+  - `kaizen install` requires bun on PATH or at `~/.bun/bin/bun`.
+
+## Risks & open questions
+
+- **Postinstall trust gotcha.** Bun disables lifecycle scripts by default. Plugin authors hitting this will get a non-obvious failure mode. Mitigation: documented in the authoring page; bun's own error output usually points to `trustedDependencies`.
+- **Network requirement at install time.** Plugins with deps require network access to the npm registry on first install (cached thereafter via Bun's global cache). Acceptable; airgapped install is out of scope.
+- **Per-plugin disk duplication.** Each plugin gets its own `node_modules`. Acceptable for now; hoisting is a layered optimization if it becomes a real cost.

--- a/docs/superpowers/specs/2026-04-30-sandbox-env-allowlist-design.md
+++ b/docs/superpowers/specs/2026-04-30-sandbox-env-allowlist-design.md
@@ -1,0 +1,272 @@
+# Sandbox env allow-list
+
+**Issue:** [#64 — sandbox-bootstrap process.env Proxy hides PATH from spawn() under trusted tier](https://github.com/CraightonH/kaizen/issues/64)
+**Date:** 2026-04-30
+**Status:** Approved (brainstorm complete, ready for implementation plan)
+
+## Problem
+
+`src/core/sandbox-bootstrap.ts` installs a `Proxy` over `process.env` that
+delegates each get/has/ownKeys to the permission enforcer's
+`env.get` check. Under the **trusted** tier the enforcer denies all external
+ops, so every `process.env.X` read from a trusted-tier plugin returns
+`undefined` — including `PATH`.
+
+This breaks any stdlib call that depends on PATH:
+`child_process.spawn("<binary>", args, { env: process.env })` invokes Bun's
+resolver, which reads PATH through the proxy, gets `undefined`, and fails
+with `Executable not found in $PATH: "<binary>"`. The same code works fine
+in `unscoped`, in `scoped` with `env: ["PATH"]`, or outside any plugin
+context.
+
+The docs compound the confusion. `docs/guides/plugin-authoring.md:385-391`
+claims that globals (`process.env`, `process.cwd()`, etc.) are *not*
+filtered. `docs/concepts/security.md:70` correctly states env reads are
+gated. The implementation matches `security.md`; `plugin-authoring.md` is
+wrong.
+
+## Goal
+
+Preserve the proxy's value (static auditability of declared env grants;
+secret isolation across plugins) while removing the stdlib-spawn footgun.
+Do this without baking permanent opinions into kaizen core: the platform
+ships a sensible default allow-list and lets users and harnesses override
+it via config.
+
+## Non-goals
+
+- Changing tier semantics for `fs` / `net` / `exec` / `events`.
+- Glob/regex support beyond a trailing `*` prefix in allow-list entries.
+- Per-plugin allow-list overrides (plugins still declare `env: [...]` for
+  anything outside the allow-list).
+- Filtering of non-env globals (`process.cwd()`, `process.platform`,
+  `os.platform()`, etc.) — out of scope; remains unfiltered.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Resolution path | Infrastructure allow-list bypasses tier check; doc fix lands alongside | Preserves goals 1+2 of the proxy (auditability, secret isolation) while removing the implicit-PATH trap. |
+| Where the check lives | `permission-enforcer.ts:evaluate()` for `op.kind === "env.get"` | Single source of truth; any future caller of `env.get` inherits the same behavior. |
+| Allow-list shape | List of strings; entries are exact names or `PREFIX_*` (trailing wildcard only) | Tiny implementation; covers the realistic POSIX case (`LC_*`); no regex foot-guns. |
+| Config plumbing | `DEFAULT_ENV_ALLOWLIST` in code; user `defaults.env_allowlist` in `~/.kaizen/kaizen.json`; harness `env_allowlist` in harness `kaizen.json` | Kaizen ships a working default; users and harnesses override without forking. |
+| Precedence | harness > user > default | Mirrors the existing harness-overrides-user pattern in kaizen config. |
+| Explicit `[]` semantics | Valid override meaning "no allow-list; gate everything" | Distinguishable from absent. Strict-mode escape hatch for users who want the original behavior. |
+| Invalid entries | Reject at config load with offending entry in error | Fail fast; never boot with unenforceable policy. |
+
+## Default allow-list
+
+```
+PATH
+HOME
+USER
+LOGNAME
+SHELL
+TERM
+COLUMNS
+LINES
+LANG
+LANGUAGE
+LC_*
+TZ
+TMPDIR
+TEMP
+TMP
+PWD
+OLDPWD
+```
+
+Every entry is read by either the OS process resolver, Node/Bun stdlib
+(`os.homedir`, `os.tmpdir`, child-process resolution), or terminal/locale
+code. None are conventional secret-bearing variables.
+
+Deliberately **excluded** from the default — plugins that need these declare
+`env: [...]`:
+
+- `BUN_*`, `NODE_*` — runtime tuning.
+- `KAIZEN_*` — kaizen-internal.
+- `SSH_*`, `GPG_*`, `AWS_*`, etc. — credential adjacent.
+- `XDG_*` — used by some apps but not Node/Bun stdlib.
+
+## Design
+
+### Allow-list module (`src/core/env-allowlist.ts`)
+
+New file. Exports:
+
+```ts
+export const DEFAULT_ENV_ALLOWLIST: string[] = [
+  "PATH", "HOME", "USER", "LOGNAME",
+  "SHELL", "TERM", "COLUMNS", "LINES",
+  "LANG", "LANGUAGE", "LC_*", "TZ",
+  "TMPDIR", "TEMP", "TMP",
+  "PWD", "OLDPWD",
+];
+
+/** Returns true iff `name` matches any entry in `allowList`. */
+export function envAllowed(allowList: string[], name: string): boolean;
+
+/** Validates allow-list entries. Throws with the offending entry on invalid input. */
+export function validateEnvAllowList(entries: unknown, source: string): string[];
+```
+
+`envAllowed`: each entry is either an exact name or ends with a single `*`.
+For prefix entries, match if `name.startsWith(entry.slice(0, -1))` and the
+prefix is non-empty. Exact match is case-sensitive (env var names are
+case-sensitive on POSIX; on Windows we still match exactly — kaizen's
+runtime is Bun, which is POSIX-leaning).
+
+`validateEnvAllowList`: confirms input is `string[]`, each entry is a
+non-empty string, contains no whitespace, contains at most one `*` and
+only as a trailing character. `source` is used in the error message
+(e.g., `"~/.kaizen/kaizen.json"`).
+
+### Permission enforcer change (`src/core/permission-enforcer.ts`)
+
+Constructor gains a new option `envAllowList: string[]` (default
+`DEFAULT_ENV_ALLOWLIST`). Add to the existing options bag.
+
+In `evaluate()` for `op.kind === "env.get"`, before tier-specific logic:
+
+```ts
+case "env.get": {
+  if (envAllowed(this.envAllowList, op.name)) return null;
+  if (tier === "trusted") return `tier 'trusted' permits no external ops (attempted env.get)`;
+  return (m.env ?? []).includes(op.name) ? null : `env var '${op.name}' not in env grants`;
+}
+```
+
+The existing `if (tier === "unscoped") return null;` early-return at the
+top of `evaluate()` stays in place, so unscoped is unaffected.
+
+### Proxy (`src/core/sandbox-bootstrap.ts`)
+
+No code change. The proxy already calls `enforcer.check({kind: "env.get",
+name})` for `get`, `has`, and `ownKeys`. The new allow-list logic in the
+enforcer takes effect transparently for all three traps.
+
+### Config plumbing
+
+**Type changes:**
+
+- `KaizenConfig` (user-level): `defaults.env_allowlist?: string[]` (optional).
+- Harness manifest type: `env_allowlist?: string[]` (optional).
+
+**Loader behavior:**
+
+- On config load, if `env_allowlist` is present at either level, run
+  `validateEnvAllowList(entries, source)`. Invalid entries → load error
+  (kaizen does not boot).
+- Resolution at the point where `PermissionEnforcer` is constructed
+  (currently in the bootstrap flow):
+
+  ```ts
+  const envAllowList =
+    harnessConfig.env_allowlist ??     // present? use it (incl. empty [])
+    userConfig.defaults?.env_allowlist ??
+    DEFAULT_ENV_ALLOWLIST;
+  ```
+
+  `??` (not `||`) preserves explicit `[]` overrides.
+
+### Error messages
+
+- **Invalid allow-list entry at load:**
+  ```
+  invalid env_allowlist entry "<entry>" in <source>:
+  entries must be a non-empty string, optionally ending with a single trailing '*' (e.g. "LC_*")
+  ```
+- **Trusted-tier env denial (after fix):** unchanged from today —
+  `tier 'trusted' permits no external ops (attempted env.get)`. Now only
+  fires for non-allow-listed names; PATH/HOME/etc. silently pass.
+
+## Testing
+
+### `src/core/env-allowlist.test.ts` (new)
+
+- Exact match: `["PATH"]` matches `"PATH"`, not `"PATHS"`, not `"path"`.
+- Prefix match: `["LC_*"]` matches `"LC_ALL"`, `"LC_CTYPE"`; not `"LC"`,
+  not `"MYLC_FOO"`.
+- Mixed list works: `["PATH", "LC_*"]`.
+- Empty list: nothing matches.
+- Validator rejects: non-array, non-string entry, empty string, entry
+  containing whitespace, entry with `*` not at end (e.g., `"*FOO"`,
+  `"FOO*BAR"`), entry with multiple `*`.
+- Validator passes: empty array, `["PATH"]`, `["LC_*"]`, `["PATH", "LC_*"]`.
+
+### `src/core/permission-enforcer.test.ts` (extend)
+
+- Trusted + default allow-list → `env.get("PATH")` permitted.
+- Trusted + default allow-list → `env.get("AWS_SECRET")` denied with the
+  existing trusted-tier message.
+- Trusted + `[]` → `env.get("PATH")` denied.
+- Scoped + `env: ["DB_URL"]` + default → both `PATH` and `DB_URL`
+  permitted; `OTHER` denied.
+- Scoped + custom allow-list `["MY_*"]` (default replaced) → `MY_FOO`
+  permitted; `PATH` denied. Confirms override replaces default.
+- Unscoped → all permitted regardless of allow-list.
+
+### `src/core/sandbox-bootstrap.test.ts` (extend, or add focused file)
+
+Run inside a stubbed `getCurrentPlugin()` returning a trusted plugin
+manifest, with the enforcer constructed using the default allow-list:
+
+- `process.env.PATH` returns the real value.
+- `process.env.AWS_SECRET` (real value set in the test process) returns `undefined`.
+- `"PATH" in process.env` is `true`.
+- `"AWS_SECRET" in process.env` is `false`.
+- `Object.keys(process.env)` includes `PATH`, excludes `AWS_SECRET`.
+
+### Config-load tests (extend the existing `kaizen-config.test.ts` and
+harness loader test)
+
+- Absent at both levels → resolved list is `DEFAULT_ENV_ALLOWLIST`.
+- User-only `defaults.env_allowlist: ["FOO"]` → resolved is `["FOO"]`.
+- Harness-only `env_allowlist: ["BAR"]` → resolved is `["BAR"]`.
+- Both present → harness wins.
+- Explicit `[]` at user level → resolved is `[]` (not the default).
+- Invalid entry at either level → config-load error names the offending entry and source.
+
+### Integration smoke
+
+Add (or extend) an integration test that runs a trusted-tier plugin
+calling `child_process.spawn` for a binary on PATH (use `echo` for
+portability, or another binary kaizen tests already rely on). Confirms
+the spawn succeeds end-to-end.
+
+## Documentation updates
+
+To land alongside the code:
+
+1. **`docs/guides/plugin-authoring.md` (lines 385-391):** replace the
+   incorrect "globals are not filtered" paragraph with an accurate one
+   describing the env proxy, the allow-list, and the override knobs.
+
+2. **`docs/concepts/security.md`:** extend the existing env-proxy
+   explanation to describe the allow-list, the precedence (harness >
+   user > default), and the override mechanisms. Update the
+   `process.env.X returns undefined unexpectedly` troubleshooting note
+   to point at the allow-list first.
+
+3. **Configuration reference** (existing `docs/concepts/configuration.md`
+   or `docs/reference/host-api.md` — pick whichever already documents
+   `KaizenConfig.defaults.*` and harness fields): document
+   `defaults.env_allowlist` and `env_allowlist` (per-harness), the
+   syntax (exact name or `PREFIX_*`), the precedence rule, and the
+   explicit-empty semantics.
+
+## Risks & open questions
+
+- **Default allow-list ages.** New "infrastructure" vars may emerge (rare,
+  but possible). Mitigation: users/harnesses can extend without forking.
+  The default is data-shaped, easy to update.
+- **Plugins relying on the trusted-tier-blocks-everything behavior.** A
+  plugin author who somehow depended on `process.env.PATH === undefined`
+  (unlikely) would see a behavior change. Acceptable; the previous
+  behavior was a bug.
+- **Windows env-var case-insensitivity.** Bun is POSIX-leaning and kaizen
+  doesn't claim Windows support today. Match remains case-sensitive.
+- **Harness override of an unrelated user policy.** If a user sets a
+  strict `[]` and a harness sets a permissive list, the harness wins.
+  This is consistent with the existing model: harnesses curate plugin
+  behavior. Documented in the config reference.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,6 +83,35 @@ verify_checksum() {
   [ "$expected" = "$actual" ] || die "checksum mismatch for ${name} (expected ${expected}, got ${actual})"
 }
 
+# Ensure bun is available so plugin runtime deps can be resolved at install
+# time. Idempotent and best-effort: a failure here warns and continues, never
+# aborts the kaizen installer.
+#
+# Opt out by setting KAIZEN_NO_BUN=1.
+ensure_bun() {
+  if [ "${KAIZEN_NO_BUN:-0}" = "1" ]; then
+    info "Skipping bun install (KAIZEN_NO_BUN=1)."
+    return 0
+  fi
+
+  if command -v bun >/dev/null 2>&1; then
+    info "bun already installed: $(command -v bun)"
+    return 0
+  fi
+  if [ -x "$HOME/.bun/bin/bun" ]; then
+    info "bun found at ~/.bun/bin/bun"
+    return 0
+  fi
+
+  info "Installing bun (required for plugin dependency resolution)..."
+  if curl -fsSL https://bun.sh/install | bash; then
+    green "  ✓ bun installed"
+  else
+    red "  ! bun install failed; install manually: curl -fsSL https://bun.sh/install | bash"
+    return 0
+  fi
+}
+
 # Register the official marketplace and install the default harness. Plugin
 # resolution is deferred to the binary — kaizen auto-installs a harness's
 # plugins on first run via src/core/bootstrap.ts. Each step is best-effort:
@@ -199,6 +228,9 @@ main() {
   else
     info "~/.kaizen/kaizen.json already exists, skipping init."
   fi
+
+  echo ""
+  ensure_bun
 
   echo ""
   bootstrap

--- a/src/core/plugin-installer.test.ts
+++ b/src/core/plugin-installer.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync } from "fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { installPlugin, installHarness } from "./plugin-installer.js";
+import { installPlugin, installHarness, resolveBunExecutable, installDepsForTesting } from "./plugin-installer.js";
 import { pluginInstallDir, harnessInstallDir, marketplaceRepoDir } from "./kaizen-config.js";
 
 let home: string;
@@ -35,6 +35,206 @@ describe("installPlugin — file source", () => {
     const target = pluginInstallDir("m", "demo", "1.0.0");
     expect(existsSync(join(target, "package.json"))).toBe(true);
     expect(existsSync(join(target, "index.js"))).toBe(true);
+  });
+
+  it("resolves runtime deps after copying file source", async () => {
+    const pluginSrc = join(upstream, "plugins", "with-deps");
+    mkdirSync(pluginSrc, { recursive: true });
+    writeFileSync(
+      join(pluginSrc, "package.json"),
+      JSON.stringify({
+        name: "with-deps",
+        version: "1.0.0",
+        main: "index.js",
+        dependencies: { "is-odd": "3.0.1" },
+      }),
+    );
+    writeFileSync(join(pluginSrc, "index.js"), "export default { name: 'with-deps', apiVersion: '2', setup(){} };");
+
+    await installPlugin("m", "with-deps", "1.0.0", { type: "file", path: "plugins/with-deps" });
+
+    const target = pluginInstallDir("m", "with-deps", "1.0.0");
+    expect(existsSync(join(target, "node_modules", "is-odd"))).toBe(true);
+  }, 30_000);
+});
+
+describe("installPlugin — lockfile honored", () => {
+  it("preserves bun.lock from source through install", async () => {
+    const pluginSrc = join(upstream, "plugins", "locked");
+    mkdirSync(pluginSrc, { recursive: true });
+    // No dependencies so installDeps no-ops; we only need to verify cpSync
+    // carries the committed lockfile through to the install dir.
+    writeFileSync(
+      join(pluginSrc, "package.json"),
+      JSON.stringify({
+        name: "locked",
+        version: "1.0.0",
+        main: "index.js",
+      }),
+    );
+    writeFileSync(join(pluginSrc, "index.js"), "export default { name: 'locked', apiVersion: '2', setup(){} };");
+    // A pre-existing bun.lock in the source — bun will use it.
+    // We can't easily fabricate a valid binary lockfile in a test, so we just
+    // verify that any lockfile present in source is copied into target.
+    writeFileSync(join(pluginSrc, "bun.lock"), "{}\n");
+
+    await installPlugin("m", "locked", "1.0.0", { type: "file", path: "plugins/locked" });
+
+    const target = pluginInstallDir("m", "locked", "1.0.0");
+    expect(existsSync(join(target, "bun.lock"))).toBe(true);
+  }, 30_000);
+});
+
+describe("resolveBunExecutable", () => {
+  it("returns 'bun' when bun is on PATH", () => {
+    // The test runner is bun itself, so `bun` resolves on PATH.
+    const got = resolveBunExecutable();
+    expect(got).not.toBeNull();
+    // Either "bun" (PATH hit) or an absolute path ending with /bin/bun.
+    expect(got === "bun" || got!.endsWith("/bin/bun")).toBe(true);
+  });
+
+  it("falls back to ~/.bun/bin/bun when not on PATH", () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "kz-bun-home-"));
+    const fakeBunDir = join(fakeHome, ".bun", "bin");
+    mkdirSync(fakeBunDir, { recursive: true });
+    const fakeBun = join(fakeBunDir, "bun");
+    writeFileSync(fakeBun, "#!/bin/sh\nexit 0\n");
+    chmodSync(fakeBun, 0o755);
+
+    const origPath = process.env.PATH;
+    const origHome = process.env.HOME;
+    process.env.PATH = "/nonexistent-empty-path";
+    process.env.HOME = fakeHome;
+    try {
+      expect(resolveBunExecutable()).toBe(fakeBun);
+    } finally {
+      process.env.PATH = origPath;
+      process.env.HOME = origHome;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when bun is nowhere", () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "kz-bun-home-"));
+    const origPath = process.env.PATH;
+    const origHome = process.env.HOME;
+    process.env.PATH = "/nonexistent-empty-path";
+    process.env.HOME = fakeHome;
+    try {
+      expect(resolveBunExecutable()).toBeNull();
+    } finally {
+      process.env.PATH = origPath;
+      process.env.HOME = origHome;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("installDeps — no-op cases", () => {
+  let target: string;
+  beforeEach(() => { target = mkdtempSync(join(tmpdir(), "kz-deps-")); });
+  afterEach(() => { rmSync(target, { recursive: true, force: true }); });
+
+  it("no-ops when package.json missing", async () => {
+    await installDepsForTesting(target, "demo", "1.0.0");
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  });
+
+  it("no-ops when package.json has no dependencies field", async () => {
+    writeFileSync(join(target, "package.json"), JSON.stringify({ name: "demo", version: "1.0.0" }));
+    await installDepsForTesting(target, "demo", "1.0.0");
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  });
+
+  it("no-ops when dependencies is an empty object", async () => {
+    writeFileSync(join(target, "package.json"), JSON.stringify({ name: "demo", version: "1.0.0", dependencies: {} }));
+    await installDepsForTesting(target, "demo", "1.0.0");
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  });
+
+  it("no-ops when package.json is malformed", async () => {
+    writeFileSync(join(target, "package.json"), "{ not valid json");
+    await installDepsForTesting(target, "demo", "1.0.0");
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  });
+});
+
+describe("installDeps — runs bun install", () => {
+  it("creates node_modules/<dep> for a declared runtime dep", async () => {
+    const target = mkdtempSync(join(tmpdir(), "kz-deps-real-"));
+    try {
+      writeFileSync(
+        join(target, "package.json"),
+        JSON.stringify({
+          name: "demo",
+          version: "1.0.0",
+          dependencies: { "is-odd": "3.0.1" },
+        }),
+      );
+
+      await installDepsForTesting(target, "demo", "1.0.0");
+
+      expect(existsSync(join(target, "node_modules", "is-odd"))).toBe(true);
+    } finally {
+      rmSync(target, { recursive: true, force: true });
+    }
+  }, 30_000); // network + cache pull on first run
+});
+
+describe("installDeps — failure path", () => {
+  it("wipes target and throws with bun stderr when bun install fails", async () => {
+    const target = mkdtempSync(join(tmpdir(), "kz-deps-fail-"));
+    try {
+      writeFileSync(
+        join(target, "package.json"),
+        JSON.stringify({
+          name: "demo",
+          version: "1.0.0",
+          // Scoped name in a kaizen-reserved scope guaranteed not to exist.
+          dependencies: { "@kaizen-test-does-not-exist/nope": "1.0.0" },
+        }),
+      );
+      writeFileSync(join(target, "marker.txt"), "x");
+
+      let err: Error | null = null;
+      try {
+        await installDepsForTesting(target, "demo", "1.0.0");
+      } catch (e) {
+        err = e as Error;
+      }
+
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain("bun install failed for plugin 'demo@1.0.0'");
+      expect(existsSync(target)).toBe(false); // wiped
+    } finally {
+      rmSync(target, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+describe("installDeps — bun missing", () => {
+  it("throws with install instructions when no bun is resolvable", async () => {
+    const target = mkdtempSync(join(tmpdir(), "kz-deps-nobun-"));
+    try {
+      writeFileSync(
+        join(target, "package.json"),
+        JSON.stringify({ name: "demo", version: "1.0.0", dependencies: { "is-odd": "3.0.1" } }),
+      );
+
+      let err: Error | null = null;
+      try {
+        await installDepsForTesting(target, "demo", "1.0.0", () => null);
+      } catch (e) {
+        err = e as Error;
+      }
+
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain("bun is not on PATH or at ~/.bun/bin/bun");
+      expect(err!.message).toContain("curl -fsSL https://bun.sh/install | bash");
+    } finally {
+      rmSync(target, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/core/plugin-installer.ts
+++ b/src/core/plugin-installer.ts
@@ -1,5 +1,6 @@
 import { cpSync, mkdirSync, existsSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { createHash } from "crypto";
+import { homedir } from "os";
 import { join } from "path";
 import { $ } from "bun";
 import type { PluginSource } from "../types/plugin.js";
@@ -17,17 +18,19 @@ export async function installPlugin(
       const src = join(marketplaceRepoDir(marketplaceId), source.path);
       if (!existsSync(src)) throw new Error(`file source not found in marketplace: ${source.path}`);
       cpSync(src, target, { recursive: true });
-      return;
+      break;
     }
     case "tarball": {
       await installTarball(source.url, target, source.sha256);
-      return;
+      break;
     }
     case "npm": {
       await installNpm(source.name, source.version, target);
-      return;
+      break;
     }
   }
+
+  await installDeps(target, name, version);
 }
 
 /**
@@ -75,3 +78,77 @@ async function installNpm(pkgName: string, pkgVersion: string, target: string): 
   await $`tar -xzf ${join(scratch, tgz)} -C ${target} --strip-components=1`.quiet();
   rmSync(scratch, { recursive: true, force: true });
 }
+
+/**
+ * Resolve a usable `bun` executable path.
+ * Preference: `bun` on PATH → `~/.bun/bin/bun` → null.
+ *
+ * Exported for testing. Internal callers use it via installDeps.
+ */
+export function resolveBunExecutable(): string | null {
+  // PATH lookup: probe with `which` semantics via Bun.which. Pass PATH
+  // explicitly so changes to process.env.PATH at runtime are honored
+  // (Bun.which() otherwise uses the cached startup PATH).
+  const onPath = Bun.which("bun", { PATH: process.env.PATH ?? "" });
+  if (onPath) return "bun";
+  // Honor process.env.HOME at runtime; fall back to homedir() if HOME is unset.
+  const home = process.env.HOME ?? homedir();
+  const fallback = join(home, ".bun", "bin", "bun");
+  if (existsSync(fallback)) return fallback;
+  return null;
+}
+
+/**
+ * If `target` contains a package.json with non-empty runtime dependencies,
+ * run `bun install --production` in it. Otherwise no-op.
+ *
+ * On bun-install failure: rmSync(target) and throw with bun's stderr.
+ * On missing bun: throw with install instructions.
+ */
+async function installDeps(
+  target: string,
+  name: string,
+  version: string,
+  bunResolver: () => string | null = resolveBunExecutable,
+): Promise<void> {
+  const pkgPath = join(target, "package.json");
+  if (!existsSync(pkgPath)) return;
+
+  let pkg: { dependencies?: Record<string, string> };
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch {
+    // Malformed package.json — let plugin load surface the real error.
+    return;
+  }
+
+  const deps = pkg.dependencies;
+  if (!deps || Object.keys(deps).length === 0) return;
+
+  const bun = bunResolver();
+  if (!bun) {
+    throw new Error(
+      `plugin '${name}@${version}' declares runtime dependencies but bun is not on PATH or at ~/.bun/bin/bun.\n` +
+      `Install bun: curl -fsSL https://bun.sh/install | bash`,
+    );
+  }
+
+  const proc = Bun.spawnSync({
+    cmd: [bun, "install", "--production"],
+    cwd: target,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (proc.exitCode !== 0) {
+    const stderr = proc.stderr ? new TextDecoder().decode(proc.stderr) : "";
+    rmSync(target, { recursive: true, force: true });
+    throw new Error(
+      `bun install failed for plugin '${name}@${version}' at ${target}\n` +
+      stderr.split("\n").map((l) => `  ${l}`).join("\n"),
+    );
+  }
+}
+
+// Test-only export. Not part of the public API.
+export const installDepsForTesting = installDeps;

--- a/tests/install-sh-test.sh
+++ b/tests/install-sh-test.sh
@@ -72,7 +72,7 @@ KAIZEN_FAKE_LOG="$btmp/log" PATH="$btmp/bin:$PATH" bash -c '
 ' _ "$INSTALLER" || fail "bootstrap errored"
 
 expected_market="kaizen marketplace add https://github.com/CraightonH/kaizen-official-plugins.git --id official"
-expected_install="kaizen install official/minimum-shell"
+expected_install="kaizen install official/claude-wrapper"
 
 grep -Fxq "$expected_market" "$btmp/log" || fail "bootstrap did not run: $expected_market"
 grep -Fxq "$expected_install" "$btmp/log" || fail "bootstrap did not run: $expected_install"
@@ -88,5 +88,89 @@ KAIZEN_NO_BOOTSTRAP=1 KAIZEN_FAKE_LOG="$btmp/log" PATH="$btmp/bin:$PATH" bash -c
 ' _ "$INSTALLER" || fail "bootstrap with KAIZEN_NO_BOOTSTRAP errored"
 [ ! -s "$btmp/log" ] || fail "bootstrap ran commands when KAIZEN_NO_BOOTSTRAP=1"
 pass "KAIZEN_NO_BOOTSTRAP=1 skips bootstrap"
+
+# --- Test: ensure_bun no-ops when bun on PATH ---------------------------------
+out="$(bash -c '
+  set -euo pipefail
+  # Stub PATH with a fake bun.
+  tmp="$(mktemp -d)"
+  cat > "$tmp/bun" <<EOF
+#!/bin/sh
+exit 0
+EOF
+  chmod +x "$tmp/bun"
+  PATH="$tmp:$PATH" HOME="$tmp" KAIZEN_NO_BUN=0
+  export PATH HOME KAIZEN_NO_BUN
+  # shellcheck source=/dev/null
+  source "$1"
+  ensure_bun
+  rm -rf "$tmp"
+' _ "$INSTALLER" 2>&1)" || fail "ensure_bun (PATH hit) errored: $out"
+
+echo "$out" | grep -q "bun already installed" || fail "ensure_bun (PATH hit) did not detect bun on PATH: $out"
+pass "ensure_bun no-ops when bun on PATH"
+
+# --- Test: ensure_bun no-ops when ~/.bun/bin/bun exists -----------------------
+out="$(bash -c '
+  set -euo pipefail
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/.bun/bin"
+  cat > "$tmp/.bun/bin/bun" <<EOF
+#!/bin/sh
+exit 0
+EOF
+  chmod +x "$tmp/.bun/bin/bun"
+  # Empty PATH so command -v bun fails.
+  PATH="/nonexistent-empty-path" HOME="$tmp"
+  export PATH HOME
+  # shellcheck source=/dev/null
+  source "$1"
+  ensure_bun
+  /bin/rm -rf "$tmp"
+' _ "$INSTALLER" 2>&1)" || fail "ensure_bun (~/.bun fallback) errored: $out"
+
+echo "$out" | grep -q "bun found at ~/.bun/bin/bun" || fail "ensure_bun did not detect ~/.bun/bin/bun: $out"
+pass "ensure_bun no-ops when ~/.bun/bin/bun exists"
+
+# --- Test: KAIZEN_NO_BUN=1 skips ensure_bun ----------------------------------
+out="$(bash -c '
+  set -euo pipefail
+  tmp="$(mktemp -d)"
+  PATH="/nonexistent-empty-path" HOME="$tmp" KAIZEN_NO_BUN=1
+  export PATH HOME KAIZEN_NO_BUN
+  # shellcheck source=/dev/null
+  source "$1"
+  ensure_bun
+  /bin/rm -rf "$tmp"
+' _ "$INSTALLER" 2>&1)" || fail "ensure_bun (NO_BUN) errored: $out"
+
+echo "$out" | grep -q "Skipping bun install (KAIZEN_NO_BUN=1)" || fail "KAIZEN_NO_BUN=1 was not respected: $out"
+pass "ensure_bun skipped via KAIZEN_NO_BUN=1"
+
+# --- Test: ensure_bun installer failure does not abort -----------------------
+out="$(bash -c '
+  set -euo pipefail
+  tmp="$(mktemp -d)"
+  # Stub: an empty PATH dir + a failing curl shadow.
+  stub="$tmp/stub"
+  mkdir -p "$stub"
+  cat > "$stub/curl" <<EOF
+#!/bin/sh
+exit 1
+EOF
+  chmod +x "$stub/curl"
+  PATH="$stub" HOME="$tmp"
+  export PATH HOME
+  # shellcheck source=/dev/null
+  source "$1"
+  # Should not abort despite curl failing.
+  ensure_bun
+  echo "AFTER_ENSURE_BUN"
+  /bin/rm -rf "$tmp"
+' _ "$INSTALLER" 2>&1)" || fail "ensure_bun (failure path) aborted the script: $out"
+
+echo "$out" | grep -q "AFTER_ENSURE_BUN" || fail "ensure_bun failure aborted execution: $out"
+echo "$out" | grep -q "bun install failed" || fail "ensure_bun did not warn on failure: $out"
+pass "ensure_bun installer failure does not abort"
 
 echo "OK"


### PR DESCRIPTION
## Summary

- Run `bun install --production` after every plugin install when `package.json` declares runtime `dependencies`. Applies uniformly to `file`, `tarball`, and `npm` sources.
- Add `ensure_bun` step to `scripts/install.sh` (idempotent, best-effort, opt out via `KAIZEN_NO_BUN=1`).
- Hard-fail with bun's stderr and clean up the target dir when `bun install` fails.

Spec: `docs/superpowers/specs/2026-04-30-plugin-runtime-deps-design.md`
Plan: `docs/superpowers/plans/2026-04-30-plugin-runtime-deps.md`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 409 pass / 1 skip / 0 fail (incl. 14 new installer tests)
- [x] `bash tests/install-sh-test.sh` — all PASS (5 existing + 4 new ensure_bun cases)