### PR TITLE
feat(plugins): add onReady() lifecycle hook

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -60,7 +60,10 @@ kaizen run
   │   │   └─ defineService / provideService / consumeService / defineEvent / on
   │   └─ service validation (exactly-one-provider check, exactly-one-driver check)
   │
-  ├─ READY → core calls driver.start(ctx)
+  ├─ READY → core calls onReady(ctx) on each plugin in topo order (optional hook)
+  │   │  state flips to RUNNING for each plugin before its onReady runs;
+  │   │  useService() is legal here, setup-only APIs still throw.
+  │   └─ then core calls driver.start(ctx)
   │
   ├─ RUNNING (driven by the session-driver plugin)
   │   │  Everything in this phase — reading user input, calling an LLM,
@@ -92,6 +95,12 @@ INITIALIZING → READY → RUNNING → CLOSED
 `defineService`, `provideService`, `consumeService`, `defineEvent`, and `on`
 are only valid during `INITIALIZING` (inside `setup()`). `useService` is only
 valid during `RUNNING`. Calling them outside their allowed state throws.
+
+After all `setup()` calls resolve, core invokes the optional `onReady(ctx)`
+hook on every loaded plugin in topological order. `onReady` runs with core
+state `RUNNING` — `useService()` is legal — and is the canonical place for
+non-driver `RUNNING`-phase wiring. The driver's `start()` runs after every
+`onReady` returns.
 
 ## Plugin initialization order
 

--- a/docs/concepts/plugin-model.md
+++ b/docs/concepts/plugin-model.md
@@ -71,8 +71,14 @@ The high-level sequence when you run `kaizen --harness <something>`:
    persist in the harness's `permissions.lock` (see `docs/concepts/harnesses.md`).
 4. **Setup.** Plugins are topologically sorted by their declared dependencies
    and each `setup(ctx)` runs in order. After all `setup()` calls complete,
-   core validates that every consumed service has a provider, then calls
-   `start(ctx)` on the single session driver.
+   core validates that every consumed service has a provider.
+5. **Ready.** After every plugin's `setup()` resolves, core calls
+   `onReady(ctx)` on each plugin in topological order. Core state is
+   `RUNNING`, so `useService()` is legal. Setup-only APIs (`on`,
+   `defineService`, `provideService`, `consumeService`, `defineEvent`)
+   are not. Errors are fatal. Optional — plugins that do not need
+   `RUNNING`-phase wiring may omit it.
+6. **Start.** Core calls `start(ctx)` on the single session driver.
 
 Exact loader mechanics — the compiled-binary `createRequire` anchor, package
 shape requirements, the dep-resolution walk for plugin-internal imports —

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -215,6 +215,55 @@ The same pattern applies to any state the handler needs from `start()`:
 allocate a mutable container in module scope, populate it at the start of
 `start()`, and clear it in a `finally` block.
 
+### Non-driver `RUNNING`-phase wiring with `onReady` {#on-ready}
+
+`useService()` is `RUNNING`-only — it throws if called from `setup()`. This is
+straightforward for the driver (do it in `start()`) but used to be awkward for
+non-driver plugins, since core only invokes `start()` on the driver. The
+`onReady(ctx)` hook closes that gap.
+
+`onReady` is an optional plugin method. Core invokes it once per loaded plugin,
+in topological order (same edges as `setup()`), after every `setup()` resolves
+and before `driver.start()` is invoked. Inside `onReady`, `useService()` is
+legal; the same setup-only APIs that are forbidden in `start()` (`ctx.on`,
+`provideService`, `consumeService`, `defineService`, `defineEvent`) are
+forbidden here.
+
+```ts
+const plugin: KaizenPlugin = {
+  name: "my-consumer",
+  services: { consumes: ["peer:thing"] },
+
+  async setup(ctx) {
+    // setup-only wiring goes here
+  },
+
+  async onReady(ctx) {
+    // RUNNING-phase wiring: legal to call useService now.
+    const peer = ctx.useService<PeerThing>("peer:thing");
+    peer.onSomething(() => {
+      // …
+    });
+  },
+};
+```
+
+A throw from `onReady` is fatal — the harness aborts with the same shape as a
+`setup()` failure. `onReady` runs exactly once during the initial harness boot;
+hot-reload (`PluginManager.reload`) does not re-invoke it.
+
+The driver may also define `onReady` for the same purpose. `start()` retains
+its "session loop" meaning and is unaffected.
+
+#### When to still use the events pattern
+
+`onReady` solves the "I need `useService()` legality" problem. Cross-plugin
+coordination that depends on another plugin's *runtime* state — e.g. waiting
+until the driver's session loop has actually started — still belongs in an
+event handshake. Define a vocabulary event in a shared events plugin, have
+the driver emit it during `start()`, and subscribe to it in `setup()` of any
+plugin that needs to react.
+
 ## Publishing types {#publishing-types}
 
 When your plugin provides a service, consumers need your types at compile time

--- a/docs/reference/host-api.md
+++ b/docs/reference/host-api.md
@@ -156,6 +156,55 @@ composite. Note that `ctx.secrets` and `ctx.log` are **not** part of
 
 ---
 
+## Plugin lifecycle methods
+
+Defined on `KaizenPlugin` (the default export of a plugin). See
+[`plugin-model.md`](../concepts/plugin-model.md#lifecycle) for phase semantics.
+
+#### `setup(ctx: PluginContext): Promise<void>`
+
+Required. Called once during `INITIALIZING` in topological order. Use for
+`defineService`, `provideService`, `consumeService`, `defineEvent`, `on`.
+`useService()` is **not** legal here — it throws.
+
+#### `start?(ctx: PluginContext): Promise<void>`
+
+Driver-only. Called once on the single plugin with `driver: true` after every
+`onReady` returns. Owns the session loop. `useService()` is legal; setup-only
+APIs throw.
+
+#### `onReady?(ctx: PluginContext): Promise<void> | void`
+
+Optional `RUNNING`-phase wiring hook. Core invokes it once per loaded plugin
+in topological order (same edges as `setup()`), after every `setup()` resolves
+and before `driver.start()` is invoked.
+
+**Phase legality during `onReady`:**
+
+| API | Legal? |
+| --- | --- |
+| `ctx.useService` | yes |
+| `ctx.emit` | yes |
+| `ctx.fs` / `ctx.net` / `ctx.exec` / `ctx.secrets` | yes |
+| `ctx.on` | no (setup-only) |
+| `ctx.defineService` | no (setup-only) |
+| `ctx.provideService` | no (setup-only) |
+| `ctx.consumeService` | no (setup-only) |
+| `ctx.defineEvent` | no (setup-only) |
+
+A throw from `onReady` is fatal. Plugins that do not need `RUNNING`-phase
+wiring may omit it. See the [authoring guide][on-ready] for usage.
+
+[on-ready]: ../guides/plugin-authoring.md#on-ready
+
+#### `stop?(ctx: PluginContext): Promise<void>`
+
+Optional. Called during unload, before events/services/permissions are
+deregistered. Use to close resources opened in `setup()` or `start()`. Errors
+are logged but do not prevent deregistration.
+
+---
+
 ## Type-only exports
 
 The following are TypeScript types only (stripped at runtime). Import them

--- a/docs/superpowers/specs/2026-04-29-plugin-onready-hook-design.md
+++ b/docs/superpowers/specs/2026-04-29-plugin-onready-hook-design.md
@@ -1,7 +1,7 @@
 # Design: `onReady` plugin lifecycle hook
 
 **Date:** 2026-04-29
-**Status:** Proposed
+**Status:** Implemented
 **Issue:** [#63](https://github.com/CraightonH/kaizen/issues/63)
 
 ## Problem

--- a/src/core/plugin-manager-onready.test.ts
+++ b/src/core/plugin-manager-onready.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { PluginManager } from "./plugin-manager.js";
+import { EventBus } from "./event-bus.js";
+import { ServiceRegistry } from "./service-registry.js";
+import { PermissionEnforcer } from "./permission-enforcer.js";
+import { AuditLog } from "./audit-log.js";
+
+function makeRegistries() {
+  return {
+    eventBus: new EventBus(),
+    serviceRegistry: new ServiceRegistry(),
+  };
+}
+
+function makeSandboxStubs() {
+  const enforcer = new PermissionEnforcer({ mode: "log-only" });
+  const auditLog = new AuditLog({
+    rootDir: mkdtempSync(join(tmpdir(), "kaizen-test-audit-")),
+    sessionId: "test",
+    enabled: false,
+  });
+  const lockfilePath = join(mkdtempSync(join(tmpdir(), "kaizen-test-lock-")), "permissions.lock");
+  const options = { trustLockfile: false, allowUnscoped: false, nonInteractive: true };
+  return { enforcer, auditLog, lockfilePath, options };
+}
+
+const createdDirs: string[] = [];
+afterEach(() => {
+  for (const d of createdDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+interface PluginSpec {
+  name: string;
+  driver?: boolean;
+  setupBody?: string;
+  onReadyBody?: string;
+  hasOnReady?: boolean;
+  startBody?: string;
+  hasStart?: boolean;
+  consumes?: string[];
+  provides?: string[];
+}
+
+function writePlugin(spec: PluginSpec): string {
+  const dir = mkdtempSync(join(tmpdir(), `kz-pm-onready-${spec.name}-`));
+  createdDirs.push(dir);
+  writeFileSync(join(dir, "package.json"), JSON.stringify({
+    name: spec.name, version: "1.0.0", type: "module", main: "index.mjs",
+  }));
+  const parts: string[] = [];
+  parts.push(`export default {`);
+  parts.push(`  name: ${JSON.stringify(spec.name)},`);
+  parts.push(`  apiVersion: "3",`);
+  if (spec.driver) parts.push(`  driver: true,`);
+  if (spec.consumes || spec.provides) {
+    parts.push(`  services: ${JSON.stringify({
+      ...(spec.consumes ? { consumes: spec.consumes } : {}),
+      ...(spec.provides ? { provides: spec.provides } : {}),
+    })},`);
+  }
+  parts.push(`  async setup(ctx) {`);
+  if (spec.setupBody) parts.push(spec.setupBody);
+  parts.push(`  },`);
+  if (spec.hasOnReady) {
+    parts.push(`  async onReady(ctx) {`);
+    if (spec.onReadyBody) parts.push(spec.onReadyBody);
+    parts.push(`  },`);
+  }
+  if (spec.hasStart) {
+    parts.push(`  async start(ctx) {`);
+    if (spec.startBody) parts.push(spec.startBody);
+    parts.push(`  },`);
+  }
+  parts.push(`};`);
+  writeFileSync(join(dir, "index.mjs"), parts.join("\n"));
+  return dir;
+}
+
+describe("PluginManager.initialize calls onReady()", () => {
+  test("onReady is invoked on every loaded plugin", async () => {
+    const bridgeKey = `__kz_onready_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = { calls: [] as string[] };
+
+    const driverDir = writePlugin({
+      name: "driver",
+      driver: true,
+      hasStart: true,
+      startBody: `/* no-op driver */`,
+      hasOnReady: true,
+      onReadyBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("driver");`,
+    });
+    const consumerDir = writePlugin({
+      name: "consumer",
+      hasOnReady: true,
+      onReadyBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("consumer");`,
+    });
+
+    const { eventBus, serviceRegistry } = makeRegistries();
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: [driverDir, consumerDir] },
+      eventBus, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+
+    await manager.initialize();
+
+    const bridge = (globalThis as Record<string, { calls: string[] }>)[bridgeKey]!;
+    expect(bridge.calls.sort()).toEqual(["consumer", "driver"]);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
+});

--- a/src/core/plugin-manager-onready.test.ts
+++ b/src/core/plugin-manager-onready.test.ts
@@ -113,4 +113,46 @@ describe("PluginManager.initialize calls onReady()", () => {
     expect(bridge.calls.sort()).toEqual(["consumer", "driver"]);
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
+
+  test("onReady runs in topological order (provider before consumer)", async () => {
+    const bridgeKey = `__kz_onready_topo_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = { calls: [] as string[] };
+
+    const driverDir = writePlugin({
+      name: "driver",
+      driver: true,
+      hasStart: true,
+      startBody: `/* no-op */`,
+    });
+    const providerDir = writePlugin({
+      name: "provider",
+      provides: ["provider:thing"],
+      setupBody: `ctx.defineService("provider:thing", { schema: {} }); ctx.provideService("provider:thing", { ok: true });`,
+      hasOnReady: true,
+      onReadyBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("provider");`,
+    });
+    const consumerDir = writePlugin({
+      name: "consumer",
+      consumes: ["provider:thing"],
+      hasOnReady: true,
+      onReadyBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("consumer");`,
+    });
+
+    const { eventBus, serviceRegistry } = makeRegistries();
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: [consumerDir, providerDir, driverDir] },
+      eventBus, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+    await manager.initialize();
+
+    const bridge = (globalThis as Record<string, { calls: string[] }>)[bridgeKey]!;
+    const providerIdx = bridge.calls.indexOf("provider");
+    const consumerIdx = bridge.calls.indexOf("consumer");
+    expect(providerIdx).toBeGreaterThanOrEqual(0);
+    expect(consumerIdx).toBeGreaterThan(providerIdx);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
 });

--- a/src/core/plugin-manager-onready.test.ts
+++ b/src/core/plugin-manager-onready.test.ts
@@ -110,7 +110,7 @@ describe("PluginManager.initialize calls onReady()", () => {
 
     await manager.initialize();
 
-    const bridge = (globalThis as Record<string, { calls: string[] }>)[bridgeKey]!;
+    const bridge = (globalThis as unknown as Record<string, { calls: string[] }>)[bridgeKey]!;
     expect(bridge.calls.sort()).toEqual(["consumer", "driver"]);
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
@@ -149,7 +149,7 @@ describe("PluginManager.initialize calls onReady()", () => {
     );
     await manager.initialize();
 
-    const bridge = (globalThis as Record<string, { calls: string[] }>)[bridgeKey]!;
+    const bridge = (globalThis as unknown as Record<string, { calls: string[] }>)[bridgeKey]!;
     const providerIdx = bridge.calls.indexOf("provider");
     const consumerIdx = bridge.calls.indexOf("consumer");
     expect(providerIdx).toBeGreaterThanOrEqual(0);
@@ -196,7 +196,7 @@ describe("PluginManager.initialize calls onReady()", () => {
     );
     await manager.initialize();
 
-    const bridge = (globalThis as Record<string, { ok: boolean; error: string | null }>)[bridgeKey]!;
+    const bridge = (globalThis as unknown as Record<string, { ok: boolean; error: string | null }>)[bridgeKey]!;
     expect(bridge.error).toBeNull();
     expect(bridge.ok).toBe(true);
     delete (globalThis as Record<string, unknown>)[bridgeKey];
@@ -241,7 +241,7 @@ describe("PluginManager.initialize calls onReady()", () => {
     );
     await manager.initialize();
 
-    const bridge = (globalThis as Record<string, {
+    const bridge = (globalThis as unknown as Record<string, {
       provideErr: string | null; onErr: string | null; consumeErr: string | null;
       defineSvcErr: string | null; defineEvtErr: string | null;
     }>)[bridgeKey]!;
@@ -302,7 +302,7 @@ describe("PluginManager.initialize calls onReady()", () => {
       lockfilePath,
     });
 
-    const bridge = (globalThis as Record<string, { calls: string[] }>)[bridgeKey]!;
+    const bridge = (globalThis as unknown as Record<string, { calls: string[] }>)[bridgeKey]!;
     const startIdx = bridge.calls.indexOf("driver:start");
     const peerOnReadyIdx = bridge.calls.indexOf("peer:onReady");
     const driverOnReadyIdx = bridge.calls.indexOf("driver:onReady");

--- a/src/core/plugin-manager-onready.test.ts
+++ b/src/core/plugin-manager-onready.test.ts
@@ -251,4 +251,29 @@ describe("PluginManager.initialize calls onReady()", () => {
     expect(bridge.defineEvtErr).toMatch(/after initialization/i);
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
+
+  test("a throw from onReady is fatal", async () => {
+    const driverDir = writePlugin({
+      name: "driver",
+      driver: true,
+      hasStart: true,
+      startBody: `/* no-op */`,
+    });
+    const badDir = writePlugin({
+      name: "bad",
+      hasOnReady: true,
+      onReadyBody: `throw new Error("onReady kaboom");`,
+    });
+
+    const { eventBus, serviceRegistry } = makeRegistries();
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: [badDir, driverDir] },
+      eventBus, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+
+    await expect(manager.initialize()).rejects.toThrow(/onReady\(\) failed.*onReady kaboom/);
+  });
 });

--- a/src/core/plugin-manager-onready.test.ts
+++ b/src/core/plugin-manager-onready.test.ts
@@ -310,4 +310,26 @@ describe("PluginManager.initialize calls onReady()", () => {
     expect(startIdx).toBeGreaterThan(driverOnReadyIdx);
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
+
+  test("plugins without onReady() initialize without error", async () => {
+    const driverDir = writePlugin({
+      name: "driver",
+      driver: true,
+      hasStart: true,
+      startBody: `/* no-op */`,
+    });
+    const plainDir = writePlugin({ name: "plain" });
+
+    const { eventBus, serviceRegistry } = makeRegistries();
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: [plainDir, driverDir] },
+      eventBus, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+
+    await expect(manager.initialize()).resolves.toBeDefined();
+    expect(manager.list().map((e) => e.name).sort()).toEqual(["driver", "plain"]);
+  });
 });

--- a/src/core/plugin-manager-onready.test.ts
+++ b/src/core/plugin-manager-onready.test.ts
@@ -200,4 +200,55 @@ describe("PluginManager.initialize calls onReady()", () => {
     expect(bridge.ok).toBe(true);
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
+
+  test("setup-only APIs throw inside onReady", async () => {
+    const bridgeKey = `__kz_onready_gating_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = {
+      provideErr: null as string | null,
+      onErr: null as string | null,
+      consumeErr: null as string | null,
+      defineSvcErr: null as string | null,
+      defineEvtErr: null as string | null,
+    };
+
+    const driverDir = writePlugin({
+      name: "driver",
+      driver: true,
+      hasStart: true,
+      startBody: `/* no-op */`,
+    });
+    const pluginDir = writePlugin({
+      name: "p",
+      hasOnReady: true,
+      onReadyBody: `
+        const b = globalThis[${JSON.stringify(bridgeKey)}];
+        try { ctx.provideService("p:x", {}); } catch (e) { b.provideErr = e.message; }
+        try { ctx.on("evt", () => {}); } catch (e) { b.onErr = e.message; }
+        try { ctx.consumeService("other:thing"); } catch (e) { b.consumeErr = e.message; }
+        try { ctx.defineService("p:y", { schema: {} }); } catch (e) { b.defineSvcErr = e.message; }
+        try { ctx.defineEvent("p:evt"); } catch (e) { b.defineEvtErr = e.message; }
+      `,
+    });
+
+    const { eventBus, serviceRegistry } = makeRegistries();
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: [pluginDir, driverDir] },
+      eventBus, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+    await manager.initialize();
+
+    const bridge = (globalThis as Record<string, {
+      provideErr: string | null; onErr: string | null; consumeErr: string | null;
+      defineSvcErr: string | null; defineEvtErr: string | null;
+    }>)[bridgeKey]!;
+    expect(bridge.provideErr).toMatch(/after initialization/i);
+    expect(bridge.onErr).toMatch(/after initialization/i);
+    expect(bridge.consumeErr).toMatch(/after initialization/i);
+    expect(bridge.defineSvcErr).toMatch(/after initialization/i);
+    expect(bridge.defineEvtErr).toMatch(/after initialization/i);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
 });

--- a/src/core/plugin-manager-onready.test.ts
+++ b/src/core/plugin-manager-onready.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { PluginManager } from "./plugin-manager.js";
+import { runHarness } from "./index.js";
 import { EventBus } from "./event-bus.js";
 import { ServiceRegistry } from "./service-registry.js";
 import { PermissionEnforcer } from "./permission-enforcer.js";
@@ -275,5 +276,38 @@ describe("PluginManager.initialize calls onReady()", () => {
     );
 
     await expect(manager.initialize()).rejects.toThrow(/onReady\(\) failed.*onReady kaboom/);
+  });
+
+  test("driver.start() runs after every plugin's onReady", async () => {
+    const bridgeKey = `__kz_onready_before_start_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = { calls: [] as string[] };
+
+    const driverDir = writePlugin({
+      name: "driver",
+      driver: true,
+      hasOnReady: true,
+      onReadyBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("driver:onReady");`,
+      hasStart: true,
+      startBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("driver:start");`,
+    });
+    const peerDir = writePlugin({
+      name: "peer",
+      hasOnReady: true,
+      onReadyBody: `globalThis[${JSON.stringify(bridgeKey)}].calls.push("peer:onReady");`,
+    });
+
+    const lockfilePath = join(mkdtempSync(join(tmpdir(), "kaizen-test-lock-")), "permissions.lock");
+    await runHarness({
+      kaizenConfig: { plugins: [peerDir, driverDir] },
+      lockfilePath,
+    });
+
+    const bridge = (globalThis as Record<string, { calls: string[] }>)[bridgeKey]!;
+    const startIdx = bridge.calls.indexOf("driver:start");
+    const peerOnReadyIdx = bridge.calls.indexOf("peer:onReady");
+    const driverOnReadyIdx = bridge.calls.indexOf("driver:onReady");
+    expect(startIdx).toBeGreaterThan(peerOnReadyIdx);
+    expect(startIdx).toBeGreaterThan(driverOnReadyIdx);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 });

--- a/src/core/plugin-manager-onready.test.ts
+++ b/src/core/plugin-manager-onready.test.ts
@@ -155,4 +155,49 @@ describe("PluginManager.initialize calls onReady()", () => {
     expect(consumerIdx).toBeGreaterThan(providerIdx);
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
+
+  test("useService() is legal inside onReady", async () => {
+    const bridgeKey = `__kz_onready_useservice_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = { ok: false, error: null as string | null };
+
+    const driverDir = writePlugin({
+      name: "driver",
+      driver: true,
+      hasStart: true,
+      startBody: `/* no-op */`,
+    });
+    const providerDir = writePlugin({
+      name: "provider",
+      provides: ["provider:thing"],
+      setupBody: `ctx.defineService("provider:thing", { schema: {} }); ctx.provideService("provider:thing", { value: 42 });`,
+    });
+    const consumerDir = writePlugin({
+      name: "consumer",
+      consumes: ["provider:thing"],
+      hasOnReady: true,
+      onReadyBody: `
+        try {
+          const svc = ctx.useService("provider:thing");
+          globalThis[${JSON.stringify(bridgeKey)}].ok = svc.value === 42;
+        } catch (e) {
+          globalThis[${JSON.stringify(bridgeKey)}].error = e.message;
+        }
+      `,
+    });
+
+    const { eventBus, serviceRegistry } = makeRegistries();
+    const { enforcer, auditLog, lockfilePath, options } = makeSandboxStubs();
+    const manager = new PluginManager(
+      { plugins: [providerDir, consumerDir, driverDir] },
+      eventBus, serviceRegistry,
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+    await manager.initialize();
+
+    const bridge = (globalThis as Record<string, { ok: boolean; error: string | null }>)[bridgeKey]!;
+    expect(bridge.error).toBeNull();
+    expect(bridge.ok).toBe(true);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
 });

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -457,6 +457,26 @@ export class PluginManager {
       if (!claimedKeys.has(key)) warn(`Unknown config key '${key}'. No plugin claimed it.`);
     }
 
+    // PASS 4: invoke onReady() on every loaded plugin in topo order.
+    // Flips each plugin's state to RUNNING so useService() is legal.
+    // Setup-only APIs (on/defineService/provideService/consumeService/defineEvent)
+    // remain forbidden — same gating as start().
+    for (const plugin of sorted) {
+      const record = this.plugins.get(plugin.name);
+      if (!record || record.entry.status !== "loaded") continue;
+      if (!record.stateRef || !record.ctx) continue;
+      record.stateRef.current = "RUNNING";
+      if (typeof plugin.onReady !== "function") continue;
+      try {
+        await runInPluginScope(plugin.name, async () => {
+          await plugin.onReady!(record.ctx!);
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        fatal(`Plugin '${plugin.name}' onReady() failed: ${msg}`);
+      }
+    }
+
     // Resolve driver — the one plugin with `driver: true`.
     // Core's single cross-plugin contract: call start() on the session driver.
     const driverNames: string[] = [];

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -281,10 +281,15 @@ function topoSort(plugins: KaizenPlugin[]): KaizenPlugin[] {
 // PluginManager
 // ---------------------------------------------------------------------------
 
+interface StateRef {
+  current: CoreState;
+}
+
 interface PluginRecord {
   plugin: KaizenPlugin;
   entry: PluginEntry;
   ctx?: PluginContext;
+  stateRef?: StateRef;
 }
 
 export class PluginManager {
@@ -407,7 +412,7 @@ export class PluginManager {
       const critical = isCritical(plugin, this.serviceRegistry);
       const rPath = resolvedPathMap.get(plugin.name) ?? null;
       try {
-        const ctx = await this.setupPlugin(plugin, rPath);
+        const { ctx, stateRef } = await this.setupPlugin(plugin, rPath);
         loadedNames.add(plugin.name);
         this.plugins.set(plugin.name, {
           plugin,
@@ -418,6 +423,7 @@ export class PluginManager {
             status: "loaded",
           },
           ctx,
+          stateRef,
         });
         debug(`Plugin '${plugin.name}' initialized.`);
       } catch (err) {
@@ -512,7 +518,7 @@ export class PluginManager {
       this.serviceRegistry.consume(resolveCapName(raw, aliases), plugin.name);
     }
     try {
-      const ctx = await this.setupPlugin(plugin, resolvedPath);
+      const { ctx, stateRef } = await this.setupPlugin(plugin, resolvedPath);
       this.plugins.set(name, {
         plugin,
         entry: {
@@ -522,6 +528,7 @@ export class PluginManager {
           status: "loaded",
         },
         ctx,
+        stateRef,
       });
       try {
         this.serviceRegistry.validateAll();
@@ -627,7 +634,7 @@ export class PluginManager {
   // Internal setup
   // --------------------------------------------------------------------------
 
-  private async setupPlugin(plugin: KaizenPlugin, resolvedPath: string | null = null): Promise<PluginContext> {
+  private async setupPlugin(plugin: KaizenPlugin, resolvedPath: string | null = null): Promise<{ ctx: PluginContext; stateRef: StateRef }> {
     // Register the plugin's permission manifest (defaults to trusted).
     this.enforcer.register(plugin.name, plugin.permissions ?? { tier: "trusted" });
     // Scan imports after registration so check() has the manifest.
@@ -673,7 +680,7 @@ export class PluginManager {
     // Build secrets context for this plugin
     const secretsCtx = createSecretsContext(this.secretsRegistry, plugin.name, secretRefs);
 
-    let pluginState: CoreState = "INITIALIZING";
+    const stateRef: StateRef = { current: "INITIALIZING" };
     const ctx = createPluginContext(
       plugin.name,
       pluginConfig,
@@ -681,12 +688,12 @@ export class PluginManager {
       this.eventBus,
       this.serviceRegistry,
       this.enforcer,
-      () => pluginState,
+      () => stateRef.current,
       this.getPublicApi(),
       this.getLifecycleApi(),
     );
     await runInPluginScope(plugin.name, async () => { await plugin.setup(ctx); });
-    pluginState = "READY";
+    stateRef.current = "READY";
 
     // After setup, check if this plugin provided a secret provider
     // (core-secrets calls ctx.provideService(SECRETS_PROVIDER_SERVICE, provider))
@@ -697,7 +704,7 @@ export class PluginManager {
       // Plugin didn't register a secret provider — that's fine
     }
 
-    return ctx;
+    return { ctx, stateRef };
   }
 
   private scanAndCheckImports(pluginName: string, resolvedPath: string): void {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -217,6 +217,18 @@ export interface KaizenPlugin {
   setup(ctx: PluginContext): Promise<void>;
   start?(ctx: PluginContext): Promise<void>;
   /**
+   * Optional `RUNNING`-phase wiring hook. Called once per loaded plugin in
+   * topological order after every `setup()` resolves and before
+   * `driver.start()` is invoked. `useService()` is legal here; setup-only
+   * APIs (`on`, `defineService`, `provideService`, `consumeService`,
+   * `defineEvent`) are not. Throwing is fatal.
+   *
+   * Use this for non-driver plugins that need to call `useService()` against
+   * a peer's service. The driver's `start()` retains its "session loop"
+   * meaning and is unaffected.
+   */
+  onReady?(ctx: PluginContext): Promise<void> | void;
+  /**
    * Called during unload, before events/services/permissions are deregistered.
    * Use to close resources opened in setup() or start() (readline interfaces,
    * network listeners, timers, file watchers). Errors are logged but do not


### PR DESCRIPTION
## Summary

- Add optional `onReady(ctx)` lifecycle hook on `KaizenPlugin`.
- Core invokes it once per loaded plugin in topo order after every `setup()` resolves and before `driver.start()`. State is `RUNNING` so `useService()` is legal; setup-only APIs (`on`, `defineService`, `provideService`, `consumeService`, `defineEvent`) remain forbidden.
- Throws are fatal. Hot-reload (`load()`) does NOT re-invoke `onReady` — out of scope.

Spec: `docs/superpowers/specs/2026-04-29-plugin-onready-hook-design.md`
Plan: `docs/superpowers/plans/2026-04-29-plugin-onready-hook.md`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 404 pass / 1 skip / 0 fail (incl. 7 new onReady tests covering invocation, topo order, useService legality, setup-only API gating, fatal-on-throw, ordering vs driver.start, no-op when absent)