### PR TITLE
feat(sandbox): env allow-list for OS-infrastructure vars

### DIFF
--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -24,10 +24,55 @@ Kaizen has exactly one user-editable config file: `~/.kaizen/kaizen.json`.
 - **`defaults`** *(optional, object)* — what this user defaults to.
   - **`defaults.harness`** *(optional, string)* — harness ref used when `--harness` is not passed on the CLI.
   - **`defaults.plugin_config`** *(optional, object)* — per-plugin config overrides, keyed by plugin name.
+  - **`defaults.env_allowlist`** *(optional, array of strings)* — env-var allow-list; see [`defaults.env_allowlist`](#defaultsenv_allowlist-optional) below.
 - **`marketplaces`** *(optional, array)* — registered marketplaces. Managed by `kaizen marketplace add/remove`.
 - **`marketplaceUpdateTTL`** *(optional, number)* — background marketplace refresh interval in seconds.
 
 Any other top-level key is a validation error.
+
+### `defaults.env_allowlist` (optional)
+
+Array of env-var names that bypass tier-based env.get gating, regardless
+of plugin tier. Each entry is an exact name (`"PATH"`) or a trailing-`*`
+prefix (`"LC_*"`). If absent, kaizen ships a sensible default covering
+PATH, HOME, USER, locale, tmpdirs, and similar OS-infrastructure
+variables — see `src/core/env-allowlist.ts`.
+
+An explicit empty array `[]` is a valid override meaning "no
+passthrough; gate everything per tier rules." Distinguishable from
+absent.
+
+A harness's `kaizen.json` may also set `env_allowlist` at top level. The
+harness value takes precedence over this user-level value when both are
+set. Resolution order:
+
+1. Harness `env_allowlist` (if present, including `[]`)
+2. User `defaults.env_allowlist` (if present, including `[]`)
+3. Built-in `DEFAULT_ENV_ALLOWLIST`
+
+Invalid entries (multiple `*`, `*` not at end, whitespace, empty
+strings) cause kaizen to fail at config load with the offending entry
+named.
+
+Example (user config):
+
+```json
+{
+  "defaults": {
+    "harness": "official/claude-wrapper",
+    "env_allowlist": ["PATH", "HOME", "LC_*", "MY_TOOL_*"]
+  }
+}
+```
+
+Example (harness `kaizen.json`, strict mode):
+
+```json
+{
+  "plugins": ["official/example@1.0.0"],
+  "env_allowlist": []
+}
+```
 
 ## Effective plugin config
 

--- a/docs/concepts/plugin-model.md
+++ b/docs/concepts/plugin-model.md
@@ -164,7 +164,7 @@ declare what they need. Every plugin picks a tier.
 
 | Tier | What it can touch | Install UX |
 |------|-------------------|------------|
-| **trusted** | Only `ctx.*`. No filesystem, network, env, exec, or cross-plugin event subscription. | Silent |
+| **trusted** | Only `ctx.*`, plus an OS-infrastructure env-var allow-list (`PATH`, `HOME`, locale, tmpdirs, …) for stdlib calls. No filesystem, network, app/secret env, exec, or cross-plugin event subscription. | Silent |
 | **scoped** | External resources you enumerate: fs paths, hosts, env vars, binaries, event subscriptions. | UAC shows grant list |
 | **unscoped** | Raw Node access. Runs the user shell, dynamic spawn, native modules. | Typed confirmation required |
 

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -67,7 +67,7 @@ etc. — the require patch refuses. Use the context surface instead:
 | `fs.readFileSync(path)` | `await ctx.fs.readText(path)` |
 | `fs.writeFileSync(path, data)` | `await ctx.fs.writeText(path, data)` |
 | `fetch(url)` | `await ctx.net.fetch(url)` (global `fetch` also intercepted) |
-| `process.env.X` | Declare `env: ["X"]` and read `process.env.X` normally (proxy enforces the grant) |
+| `process.env.X` | OS-infrastructure vars (PATH, HOME, locale, tmpdirs, …) pass through under any tier via a built-in allow-list. For other vars, declare `env: ["X"]` (scoped tier) and read `process.env.X` normally (proxy enforces the grant). Override the allow-list with `defaults.env_allowlist` (user) or `env_allowlist` (harness). |
 | `execSync(cmd)` / `spawn(...)` | `await ctx.exec.run(binary, args, opts)` — returns `{exitCode, stdout, stderr}`, never throws on non-zero |
 | `eventBus.on(...)` | `ctx.on(event, handler)` — checks `events.subscribe` grant |
 
@@ -109,9 +109,14 @@ Workflow:
 `events: { subscribe: ["other-plugin:*"] }` or the specific event name.
 
 **"`process.env.X` returns `undefined` unexpectedly."** The env proxy hides
-vars not in your grant. Add `X` to `env: [...]`. For application secrets like
-API keys, declare them under `config.secrets` and fetch via `ctx.secrets.get(...)`
-instead of relying on environment variables at all.
+variables you have not declared and that are not in the active allow-list.
+For OS-infrastructure variables (`PATH`, `HOME`, locale, tmpdirs, …) this
+is unexpected and means your active allow-list does not include the name —
+check `defaults.env_allowlist` in `~/.kaizen/kaizen.json` and the harness's
+`env_allowlist`. For application/secret variables, add the name to your
+plugin's `env: [...]` grants and re-load. For application secrets like
+API keys, declare them under `config.secrets` and fetch via
+`ctx.secrets.get(...)` instead of relying on environment variables at all.
 
 **"SDK throws `net.connect` denial for a host I don't recognize."** The SDK
 fetched somewhere you didn't declare. Look at the denial record

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -431,13 +431,25 @@ Checks (see `src/commands/plugin-validate.ts` for the full list):
   enforcement).
 - `*.test.ts` file present; `README.md` present.
 
-> **What the sandbox enforces today:** The enforcer gates module imports and
-> calls made through `ctx.fs` / `ctx.net` / `ctx.exec`. It does **not** filter
-> Node.js globals. `process.cwd()`, `process.env`, `process.platform`,
-> `os.homedir()`, and similar ambient values are accessible to plugins of any
-> tier. `tier` currently signals intent and controls which `ctx.*` grants are
-> available — it is not a hard runtime cap on globals. A future release may
-> tighten this; for now, treat global access as unrestricted.
+> **What the sandbox enforces today:** The enforcer gates module imports,
+> calls through `ctx.fs` / `ctx.net` / `ctx.exec`, and reads from
+> `process.env`. A built-in allow-list of OS-infrastructure variables —
+> `PATH`, `HOME`, `USER`, locale (`LC_*`, `LANG`), tmpdirs (`TMPDIR`,
+> `TEMP`, `TMP`), and similar — passes through under any tier so that
+> stdlib calls such as `child_process.spawn`, `os.homedir()`, and
+> `os.tmpdir()` work without elevating tiers. Variables outside the
+> allow-list follow tier rules: `unscoped` reads anything, `scoped` reads
+> names declared in `env: [...]`, `trusted` reads only allow-listed
+> names.
+>
+> Override the allow-list via `defaults.env_allowlist` in
+> `~/.kaizen/kaizen.json` (user-level) or `env_allowlist` in a harness's
+> `kaizen.json` (harness-level; takes precedence). An explicit `[]` means
+> "gate everything; no passthrough." Entries are exact names (`"PATH"`)
+> or trailing-`*` prefixes (`"LC_*"`).
+>
+> `process.cwd()`, `process.platform`, `os.platform()`, and similar
+> non-env globals are not filtered.
 
 Exit code is `0` on pass (possibly with warnings), `1` on any failure. Common
 fixes:

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -295,6 +295,7 @@ export interface KaizenConfig {
   plugins: string[];           // marketplace refs "<marketplace-id>/<name>[@<version>]" or local paths ("./", "../", "/")
   extends?: string;            // harness to extend: marketplace ref or local path
   marketplaces?: MarketplaceRef[];
+  env_allowlist?: string[];    // per-harness env-var allow-list; takes precedence over user defaults.env_allowlist
   [pluginName: string]: unknown;  // per-plugin config slices
 }
 ```
@@ -305,6 +306,7 @@ export interface KaizenConfig {
 export interface KaizenDefaults {
   harness?: string;                                    // default harness ref
   plugin_config?: Record<string, Record<string, unknown>>;  // per-plugin overrides
+  env_allowlist?: string[];                            // env-var allow-list; entries are exact names ("PATH") or trailing-* prefixes ("LC_*")
 }
 
 export interface KaizenGlobalConfig {

--- a/src/core/config-harness.test.ts
+++ b/src/core/config-harness.test.ts
@@ -75,6 +75,37 @@ describe("resolveHarnessOrFatal", () => {
     expect(config.plugins).toEqual(["x"]);
   });
 
+  test("rejects invalid env_allowlist in harness kaizen.json", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "bad");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "kaizen.json"),
+      JSON.stringify({ plugins: [], env_allowlist: ["BAD*ENTRY"] }),
+    );
+    expect(() => resolveHarnessOrFatal({ harness: "bad" })).toThrow(/BAD\*ENTRY/);
+  });
+
+  test("accepts valid env_allowlist in harness kaizen.json", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "good");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "kaizen.json"),
+      JSON.stringify({ plugins: [], env_allowlist: ["PATH", "LC_*"] }),
+    );
+    const { config } = resolveHarnessOrFatal({ harness: "good" });
+    expect(config.env_allowlist).toEqual(["PATH", "LC_*"]);
+  });
+
+  test("rejects non-array env_allowlist in harness kaizen.json", () => {
+    const dir = join(tmp, ".kaizen", "harnesses", "bad2");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "kaizen.json"),
+      JSON.stringify({ plugins: [], env_allowlist: "PATH" }),
+    );
+    expect(() => resolveHarnessOrFatal({ harness: "bad2" })).toThrow(/must be an array/);
+  });
+
   test("harness plugins are returned unchanged (no project-config overlay)", () => {
     const dir = join(tmp, ".kaizen", "harnesses", "official");
     mkdirSync(dir, { recursive: true });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { homedir } from "os";
 import type { KaizenConfig } from "../types/plugin.js";
 import { fatal } from "./errors.js";
+import { validateEnvAllowList } from "./env-allowlist.js";
 
 // ---------------------------------------------------------------------------
 // Well-known paths
@@ -105,6 +106,13 @@ function parseAndValidateHarness(path: string, label: string): KaizenConfig {
   validateHarnessConfig(config, path);
   if (!config["plugins"]) fatal(`Harness '${label}' kaizen.json is missing 'plugins'.`);
   if (!Array.isArray(config["plugins"])) fatal(`Harness '${label}' kaizen.json 'plugins' must be an array.`);
+  if (config["env_allowlist"] !== undefined) {
+    try {
+      validateEnvAllowList(config["env_allowlist"], `${path}: env_allowlist`);
+    } catch (e) {
+      fatal(e instanceof Error ? e.message : String(e));
+    }
+  }
   return config as KaizenConfig;
 }
 

--- a/src/core/env-allowlist.test.ts
+++ b/src/core/env-allowlist.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "bun:test";
+import { envAllowed, DEFAULT_ENV_ALLOWLIST, validateEnvAllowList } from "./env-allowlist.js";
+
+describe("envAllowed", () => {
+  it("matches exact names case-sensitively", () => {
+    expect(envAllowed(["PATH"], "PATH")).toBe(true);
+    expect(envAllowed(["PATH"], "PATHS")).toBe(false);
+    expect(envAllowed(["PATH"], "path")).toBe(false);
+    expect(envAllowed(["PATH"], "OTHER")).toBe(false);
+  });
+
+  it("matches prefix entries with trailing *", () => {
+    expect(envAllowed(["LC_*"], "LC_ALL")).toBe(true);
+    expect(envAllowed(["LC_*"], "LC_CTYPE")).toBe(true);
+    expect(envAllowed(["LC_*"], "LC")).toBe(false);
+    expect(envAllowed(["LC_*"], "MYLC_FOO")).toBe(false);
+  });
+
+  it("supports mixed exact + prefix entries", () => {
+    expect(envAllowed(["PATH", "LC_*"], "PATH")).toBe(true);
+    expect(envAllowed(["PATH", "LC_*"], "LC_ALL")).toBe(true);
+    expect(envAllowed(["PATH", "LC_*"], "OTHER")).toBe(false);
+  });
+
+  it("empty list matches nothing", () => {
+    expect(envAllowed([], "PATH")).toBe(false);
+    expect(envAllowed([], "")).toBe(false);
+  });
+
+  it("default list contains expected entries", () => {
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("PATH");
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("HOME");
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("LC_*");
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("TMPDIR");
+  });
+});
+
+describe("validateEnvAllowList", () => {
+  const src = "test.json: defaults.env_allowlist";
+
+  it("accepts an empty array", () => {
+    expect(validateEnvAllowList([], src)).toEqual([]);
+  });
+
+  it("accepts exact-name entries", () => {
+    expect(validateEnvAllowList(["PATH", "HOME"], src)).toEqual(["PATH", "HOME"]);
+  });
+
+  it("accepts trailing-* prefix entries", () => {
+    expect(validateEnvAllowList(["LC_*", "PATH"], src)).toEqual(["LC_*", "PATH"]);
+  });
+
+  it("rejects non-array input", () => {
+    expect(() => validateEnvAllowList("PATH", src)).toThrow(/must be an array/);
+    expect(() => validateEnvAllowList({}, src)).toThrow(/must be an array/);
+    expect(() => validateEnvAllowList(null, src)).toThrow(/must be an array/);
+  });
+
+  it("rejects non-string entries", () => {
+    expect(() => validateEnvAllowList([42], src)).toThrow(/test\.json: defaults\.env_allowlist/);
+    expect(() => validateEnvAllowList([null], src)).toThrow(/non-empty string/);
+  });
+
+  it("rejects empty-string entries", () => {
+    expect(() => validateEnvAllowList([""], src)).toThrow(/non-empty string/);
+  });
+
+  it("rejects entries containing whitespace", () => {
+    expect(() => validateEnvAllowList(["FOO BAR"], src)).toThrow(/whitespace/);
+    expect(() => validateEnvAllowList(["FOO\t"], src)).toThrow(/whitespace/);
+  });
+
+  it("rejects entries with * not at end", () => {
+    expect(() => validateEnvAllowList(["*FOO"], src)).toThrow(/\*FOO/);
+    expect(() => validateEnvAllowList(["FOO*BAR"], src)).toThrow(/FOO\*BAR/);
+  });
+
+  it("rejects entries with multiple *", () => {
+    expect(() => validateEnvAllowList(["FOO**"], src)).toThrow(/FOO\*\*/);
+    expect(() => validateEnvAllowList(["*FOO*"], src)).toThrow(/\*FOO\*/);
+  });
+
+  it("rejects bare * (would be empty prefix)", () => {
+    expect(() => validateEnvAllowList(["*"], src)).toThrow(/empty prefix/);
+  });
+});

--- a/src/core/env-allowlist.ts
+++ b/src/core/env-allowlist.ts
@@ -1,0 +1,78 @@
+/**
+ * OS-infrastructure env vars that bypass tier-based env.get gating.
+ * Plugins of any tier can read these. Override via:
+ *   ~/.kaizen/kaizen.json   defaults.env_allowlist
+ *   harness  kaizen.json    env_allowlist
+ *
+ * Each entry is either an exact name (e.g. "PATH") or a trailing-`*`
+ * prefix (e.g. "LC_*"). No other glob syntax is supported.
+ */
+export const DEFAULT_ENV_ALLOWLIST: string[] = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "TERM",
+  "COLUMNS",
+  "LINES",
+  "LANG",
+  "LANGUAGE",
+  "LC_*",
+  "TZ",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "PWD",
+  "OLDPWD",
+];
+
+/** Returns true iff `name` matches any entry in `allowList`. */
+export function envAllowed(allowList: string[], name: string): boolean {
+  for (const entry of allowList) {
+    if (entry.endsWith("*")) {
+      const prefix = entry.slice(0, -1);
+      if (prefix.length > 0 && name.startsWith(prefix)) return true;
+    } else if (entry === name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Validate an env-allowlist value loaded from config. Returns the array
+ * unchanged on success; throws an Error with the offending entry on failure.
+ *
+ * `source` is included in error messages (e.g. "~/.kaizen/kaizen.json: defaults.env_allowlist").
+ */
+export function validateEnvAllowList(value: unknown, source: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${source}: must be an array of strings.`);
+  }
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry.length === 0) {
+      throw new Error(
+        `${source}: each entry must be a non-empty string (got ${JSON.stringify(entry)}).`,
+      );
+    }
+    if (/\s/.test(entry)) {
+      throw new Error(`${source}: entry "${entry}" contains whitespace.`);
+    }
+    const stars = (entry.match(/\*/g) ?? []).length;
+    if (stars > 1) {
+      throw new Error(
+        `${source}: invalid entry "${entry}" — only one trailing '*' allowed (e.g. "LC_*").`,
+      );
+    }
+    if (stars === 1 && !entry.endsWith("*")) {
+      throw new Error(
+        `${source}: invalid entry "${entry}" — '*' may only appear as the trailing character (e.g. "LC_*").`,
+      );
+    }
+    if (entry === "*") {
+      throw new Error(`${source}: invalid entry "*" — empty prefix not allowed.`);
+    }
+  }
+  return value as string[];
+}

--- a/src/core/index.test.ts
+++ b/src/core/index.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolveEnvAllowList } from "./index.js";
+import { DEFAULT_ENV_ALLOWLIST } from "./env-allowlist.js";
+
+let home: string;
+let origHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kz-init-"));
+  origHome = process.env.KAIZEN_HOME_OVERRIDE;
+  process.env.KAIZEN_HOME_OVERRIDE = home;
+});
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.KAIZEN_HOME_OVERRIDE;
+  else process.env.KAIZEN_HOME_OVERRIDE = origHome;
+  try { rmSync(home, { recursive: true, force: true }); } catch {}
+});
+
+function writeUserCfg(obj: unknown) {
+  const path = join(home, "kaizen.json");
+  mkdirSync(home, { recursive: true });
+  writeFileSync(path, JSON.stringify(obj), "utf8");
+}
+
+describe("resolveEnvAllowList — precedence", () => {
+  it("uses default env_allowlist when neither user nor harness specifies one", async () => {
+    const result = await resolveEnvAllowList({ plugins: [] });
+    expect(result).toBe(DEFAULT_ENV_ALLOWLIST);
+  });
+
+  it("user defaults.env_allowlist overrides default when harness has none", async () => {
+    writeUserCfg({ defaults: { env_allowlist: ["MY_*"] } });
+    const result = await resolveEnvAllowList({ plugins: [] });
+    expect(result).toEqual(["MY_*"]);
+  });
+
+  it("harness env_allowlist beats user env_allowlist", async () => {
+    writeUserCfg({ defaults: { env_allowlist: ["A_*"] } });
+    const result = await resolveEnvAllowList({ plugins: [], env_allowlist: ["B_*"] });
+    expect(result).toEqual(["B_*"]);
+  });
+
+  it("explicit empty harness env_allowlist disables passthrough", async () => {
+    writeUserCfg({ defaults: { env_allowlist: ["A_*"] } });
+    const result = await resolveEnvAllowList({ plugins: [], env_allowlist: [] });
+    expect(result).toEqual([]);
+  });
+
+  it("explicit empty user env_allowlist disables passthrough (no harness override)", async () => {
+    writeUserCfg({ defaults: { env_allowlist: [] } });
+    const result = await resolveEnvAllowList({ plugins: [] });
+    expect(result).toEqual([]);
+  });
+
+  it("falls back to default when global config load fails", async () => {
+    // Write malformed JSON to force load failure
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, "kaizen.json"), "{ not json", "utf8");
+    const result = await resolveEnvAllowList({ plugins: [] });
+    expect(result).toBe(DEFAULT_ENV_ALLOWLIST);
+  });
+});

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,6 +11,8 @@ import type { EnforcerMode } from "./permission-enforcer.js";
 import { AuditLog } from "./audit-log.js";
 import { initializeSandbox } from "./sandbox-bootstrap.js";
 import { runInPluginScope } from "./plugin-scope.js";
+import { DEFAULT_ENV_ALLOWLIST } from "./env-allowlist.js";
+import { loadKaizenGlobalConfig } from "./kaizen-config.js";
 
 export { PluginManager } from "./plugin-manager.js";
 export { ServiceRegistry } from "./service-registry.js";
@@ -46,7 +48,8 @@ export async function initializePluginSystem(
     enforcer = injectedEnforcer;
   } else {
     const mode = (process.env["KAIZEN_SANDBOX_MODE"] as EnforcerMode | undefined) ?? "enforce";
-    enforcer = new PermissionEnforcer({ mode });
+    const envAllowList = await resolveEnvAllowList(kaizenConfig);
+    enforcer = new PermissionEnforcer({ mode, envAllowList });
     initializeSandbox(enforcer);
   }
 
@@ -108,4 +111,22 @@ export async function runHarness(opts: RunHarnessOpts): Promise<void> {
 
 export async function bootstrap(kaizenConfig: KaizenConfig, lockfilePath: string): Promise<void> {
   return runHarness({ kaizenConfig, lockfilePath });
+}
+
+/**
+ * Resolve the effective env allow-list using precedence:
+ *   1. Harness `env_allowlist` (if present, including [])
+ *   2. User `defaults.env_allowlist` (if present, including [])
+ *   3. Built-in DEFAULT_ENV_ALLOWLIST
+ */
+export async function resolveEnvAllowList(harnessConfig: KaizenConfig): Promise<string[]> {
+  if (harnessConfig.env_allowlist !== undefined) return harnessConfig.env_allowlist;
+  try {
+    const global = await loadKaizenGlobalConfig();
+    if (global.defaults?.env_allowlist !== undefined) return global.defaults.env_allowlist;
+  } catch {
+    // If global config fails to load, fall back to default. The CLI should
+    // surface load errors before reaching here, but be defensive.
+  }
+  return DEFAULT_ENV_ALLOWLIST;
 }

--- a/src/core/kaizen-config.test.ts
+++ b/src/core/kaizen-config.test.ts
@@ -171,4 +171,32 @@ describe("loadKaizenGlobalConfig validation", () => {
     const cfg = await loadKaizenGlobalConfig();
     expect(cfg).toEqual({});
   });
+
+  it("env_allowlist: absent is left undefined", async () => {
+    writeCfg({ defaults: { harness: "official/x@1.0.0" } });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.defaults?.env_allowlist).toBeUndefined();
+  });
+
+  it("env_allowlist: valid array passes through", async () => {
+    writeCfg({ defaults: { env_allowlist: ["PATH", "LC_*"] } });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.defaults?.env_allowlist).toEqual(["PATH", "LC_*"]);
+  });
+
+  it("env_allowlist: empty array preserved (not normalized)", async () => {
+    writeCfg({ defaults: { env_allowlist: [] } });
+    const cfg = await loadKaizenGlobalConfig();
+    expect(cfg.defaults?.env_allowlist).toEqual([]);
+  });
+
+  it("env_allowlist: invalid entry rejected with offender named", async () => {
+    writeCfg({ defaults: { env_allowlist: ["FOO*BAR"] } });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/FOO\*BAR/);
+  });
+
+  it("env_allowlist: non-array rejected", async () => {
+    writeCfg({ defaults: { env_allowlist: "PATH" } });
+    await expect(loadKaizenGlobalConfig()).rejects.toThrow(/must be an array/);
+  });
 });

--- a/src/core/kaizen-config.ts
+++ b/src/core/kaizen-config.ts
@@ -6,6 +6,7 @@ import { parseRef, resolveRef } from "./ref-resolver.js";
 import { readCatalog } from "./marketplace.js";
 import { installHarness } from "./plugin-installer.js";
 import { fatal } from "./errors.js";
+import { validateEnvAllowList } from "./env-allowlist.js";
 
 /** Test hook: KAIZEN_HOME_OVERRIDE redirects `~/.kaizen` for a single process. */
 export function kaizenHome(): string {
@@ -45,7 +46,7 @@ const ALLOWED_TOP_LEVEL_KEYS = new Set([
   "marketplaces",
   "marketplaceUpdateTTL",
 ]);
-const ALLOWED_DEFAULTS_KEYS = new Set(["harness", "plugin_config"]);
+const ALLOWED_DEFAULTS_KEYS = new Set(["harness", "plugin_config", "env_allowlist"]);
 
 export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
   const path = kaizenHomeConfigPath();
@@ -112,6 +113,9 @@ export async function loadKaizenGlobalConfig(): Promise<KaizenGlobalConfig> {
           throw new Error(`${path}: 'defaults.plugin_config.${name}' must be an object.`);
         }
       }
+    }
+    if (defaults.env_allowlist !== undefined) {
+      validateEnvAllowList(defaults.env_allowlist, `${path}: defaults.env_allowlist`);
     }
   }
 

--- a/src/core/permission-enforcer.test.ts
+++ b/src/core/permission-enforcer.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { PermissionEnforcer } from "./permission-enforcer.js";
 import { PermissionError } from "./errors.js";
+import { DEFAULT_ENV_ALLOWLIST } from "./env-allowlist.js";
 
 describe("PermissionEnforcer", () => {
   test("unregistered plugin denied", () => {
@@ -137,5 +138,63 @@ describe("PermissionEnforcer", () => {
     const e = new PermissionEnforcer({ mode: "observe" });
     e.register("p1", { tier: "trusted" });
     expect(() => e.check("p1", { kind: "fs.read", path: "x" })).not.toThrow();
+  });
+});
+
+describe("PermissionEnforcer — env allow-list", () => {
+  test("trusted plugin: allow-listed env permitted", () => {
+    const e = new PermissionEnforcer({ mode: "enforce" });
+    e.register("p", { tier: "trusted" });
+    expect(() =>
+      e.check("p", { kind: "env.get", name: "PATH" }),
+    ).not.toThrow();
+  });
+
+  test("trusted plugin: non-allow-listed env denied", () => {
+    const e = new PermissionEnforcer({ mode: "enforce" });
+    e.register("p", { tier: "trusted" });
+    expect(() =>
+      e.check("p", { kind: "env.get", name: "AWS_SECRET" }),
+    ).toThrow(/tier 'trusted' permits no external ops/);
+  });
+
+  test("trusted plugin + empty allow-list: PATH denied", () => {
+    const e = new PermissionEnforcer({ mode: "enforce", envAllowList: [] });
+    e.register("p", { tier: "trusted" });
+    expect(() =>
+      e.check("p", { kind: "env.get", name: "PATH" }),
+    ).toThrow(/tier 'trusted' permits no external ops/);
+  });
+
+  test("scoped plugin: declared env grants still permitted", () => {
+    const e = new PermissionEnforcer({ mode: "enforce" });
+    e.register("p", { tier: "scoped", env: ["DB_URL"] });
+    expect(() => e.check("p", { kind: "env.get", name: "DB_URL" })).not.toThrow();
+    expect(() => e.check("p", { kind: "env.get", name: "PATH" })).not.toThrow();
+    expect(() => e.check("p", { kind: "env.get", name: "OTHER" })).toThrow(/not in env grants/);
+  });
+
+  test("scoped plugin + custom allow-list replaces default", () => {
+    const e = new PermissionEnforcer({ mode: "enforce", envAllowList: ["MY_*"] });
+    e.register("p", { tier: "scoped" });
+    expect(() => e.check("p", { kind: "env.get", name: "MY_FOO" })).not.toThrow();
+    expect(() => e.check("p", { kind: "env.get", name: "PATH" })).toThrow(/not in env grants/);
+  });
+
+  test("unscoped plugin: all env permitted regardless of allow-list", () => {
+    const e = new PermissionEnforcer({ mode: "enforce", envAllowList: [] });
+    e.register("p", { tier: "unscoped" });
+    expect(() => e.check("p", { kind: "env.get", name: "PATH" })).not.toThrow();
+    expect(() => e.check("p", { kind: "env.get", name: "AWS_SECRET" })).not.toThrow();
+  });
+
+  test("default constructor uses DEFAULT_ENV_ALLOWLIST", () => {
+    const e = new PermissionEnforcer({ mode: "enforce" });
+    e.register("p", { tier: "trusted" });
+    for (const name of ["PATH", "HOME", "TMPDIR", "LANG"]) {
+      expect(() => e.check("p", { kind: "env.get", name })).not.toThrow();
+    }
+    expect(() => e.check("p", { kind: "env.get", name: "LC_ALL" })).not.toThrow();
+    expect(DEFAULT_ENV_ALLOWLIST).toContain("LC_*");
   });
 });

--- a/src/core/permission-enforcer.ts
+++ b/src/core/permission-enforcer.ts
@@ -1,5 +1,6 @@
 import type { PluginPermissions, PermissionOp } from "../types/plugin.js";
 import { PermissionError } from "./errors.js";
+import { DEFAULT_ENV_ALLOWLIST, envAllowed } from "./env-allowlist.js";
 
 export type EnforcerMode = "enforce" | "log-only" | "observe";
 
@@ -36,12 +37,14 @@ const FORBIDDEN_IMPORTS_NON_UNSCOPED = new Set<string>([
 
 export class PermissionEnforcer {
   private mode: EnforcerMode;
+  private readonly envAllowList: string[];
   private readonly manifests = new Map<string, PluginPermissions>();
   private readonly listeners: DenialListener[] = [];
   private readonly checkListeners: CheckListener[] = [];
 
-  constructor(opts: { mode: EnforcerMode }) {
+  constructor(opts: { mode: EnforcerMode; envAllowList?: string[] }) {
     this.mode = opts.mode;
+    this.envAllowList = opts.envAllowList ?? DEFAULT_ENV_ALLOWLIST;
   }
 
   setMode(mode: EnforcerMode): void { this.mode = mode; }
@@ -84,6 +87,9 @@ export class PermissionEnforcer {
         ? `module '${op.module}' is forbidden in tier '${tier}'`
         : null;
     }
+
+    // Allow-listed env reads bypass tier checks entirely.
+    if (op.kind === "env.get" && envAllowed(this.envAllowList, op.name)) return null;
 
     if (tier === "trusted") return `tier 'trusted' permits no external ops (attempted ${op.kind})`;
 

--- a/src/core/sandbox-bootstrap.test.ts
+++ b/src/core/sandbox-bootstrap.test.ts
@@ -71,4 +71,57 @@ describe("sandbox-bootstrap", () => {
     });
     resetSandboxForTesting();
   });
+
+  test("trusted plugin reads allow-listed PATH via proxy", async () => {
+    const enforcer = new PermissionEnforcer({ mode: "enforce" }); // default allow-list
+    initializeSandbox(enforcer);
+    enforcer.register("p_allow", { tier: "trusted" });
+    process.env.PATH ??= "/usr/bin";
+    await runInPluginScope("p_allow", async () => {
+      expect(typeof process.env.PATH).toBe("string");
+      expect(process.env.PATH!.length).toBeGreaterThan(0);
+    });
+    resetSandboxForTesting();
+  });
+
+  test("trusted plugin sees undefined for non-allow-listed secret", async () => {
+    const enforcer = new PermissionEnforcer({ mode: "enforce" });
+    initializeSandbox(enforcer);
+    enforcer.register("p_secret", { tier: "trusted" });
+    process.env.AWS_TEST_SECRET = "shh";
+    await runInPluginScope("p_secret", async () => {
+      expect(process.env.AWS_TEST_SECRET).toBeUndefined();
+    });
+    delete process.env.AWS_TEST_SECRET;
+    resetSandboxForTesting();
+  });
+
+  test("'in' check respects allow-list", async () => {
+    const enforcer = new PermissionEnforcer({ mode: "enforce" });
+    initializeSandbox(enforcer);
+    enforcer.register("p_in", { tier: "trusted" });
+    process.env.PATH ??= "/usr/bin";
+    process.env.AWS_TEST_SECRET = "shh";
+    await runInPluginScope("p_in", async () => {
+      expect("PATH" in process.env).toBe(true);
+      expect("AWS_TEST_SECRET" in process.env).toBe(false);
+    });
+    delete process.env.AWS_TEST_SECRET;
+    resetSandboxForTesting();
+  });
+
+  test("Object.keys excludes non-allow-listed secret", async () => {
+    const enforcer = new PermissionEnforcer({ mode: "enforce" });
+    initializeSandbox(enforcer);
+    enforcer.register("p_keys", { tier: "trusted" });
+    process.env.PATH ??= "/usr/bin";
+    process.env.AWS_TEST_SECRET = "shh";
+    await runInPluginScope("p_keys", async () => {
+      const keys = Object.keys(process.env);
+      expect(keys).toContain("PATH");
+      expect(keys).not.toContain("AWS_TEST_SECRET");
+    });
+    delete process.env.AWS_TEST_SECRET;
+    resetSandboxForTesting();
+  });
 });

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -252,6 +252,11 @@ export interface KaizenConfig {
   extends?: string;
   /** Informational marketplaces a harness expects; consumed by --harness bootstrap. */
   marketplaces?: MarketplaceRef[];
+  /**
+   * Per-harness env allow-list. Same syntax as KaizenDefaults.env_allowlist.
+   * If present, takes precedence over the user-level value at runtime.
+   */
+  env_allowlist?: string[];
   [pluginName: string]: unknown;
 }
 
@@ -341,6 +346,13 @@ export interface KaizenDefaults {
   harness?: string;
   /** Per-plugin config overrides. Keyed by plugin name. Values are plugin-specific objects. */
   plugin_config?: Record<string, Record<string, unknown>>;
+  /**
+   * Env vars that bypass tier-based env.get gating, regardless of plugin tier.
+   * Entries are exact names ("PATH") or trailing-* prefixes ("LC_*").
+   * If absent, the built-in DEFAULT_ENV_ALLOWLIST is used. An explicit []
+   * means "no allow-list; gate everything."
+   */
+  env_allowlist?: string[];
 }
 
 export interface KaizenGlobalConfig {


### PR DESCRIPTION
## Summary

- Add a built-in env allow-list (`PATH`, `HOME`, `USER`, `LC_*`, `TMPDIR`, …) that bypasses tier-based `env.get` gating so trusted plugins can read OS infra vars needed by stdlib calls like `child_process.spawn`.
- Override via user `defaults.env_allowlist` (`~/.kaizen/kaizen.json`) or per-harness `env_allowlist`. Precedence: harness > user > built-in default. Explicit `[]` disables passthrough.
- Validates entries on config load (rejects multi-`*`, mid-string `*`, whitespace, empty strings).

Spec: `docs/superpowers/specs/2026-04-30-sandbox-env-allowlist-design.md`
Plan: `docs/superpowers/plans/2026-04-30-sandbox-env-allowlist.md`

**Default-policy change:** trusted-tier plugins gain visibility to ~17 OS-infrastructure env vars by default (the bug this fixes). Restore strict-old behavior with `env_allowlist: []`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 437 pass / 1 skip / 0 fail
- [ ] Task 9 integration smoke deferred per plan (no trusted-tier spawn scaffold under `tests/integration/`); unit coverage exercises enforcer + proxy end-to-end.