### PR TITLE
feat(installer): bundle plugins at marketplace install time

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,9 @@ If you're building a plugin or marketplace, work through these in order:
 4. [How do I use the host API (secrets, config, events)?](reference/host-api.md)
 5. [How do I declare services and dependencies?](concepts/plugin-model.md#services)
 6. [How do I test my plugin locally?](guides/plugin-authoring.md#testing)
-7. [How do I validate it?](guides/plugin-authoring.md#validate)
-8. [How do I publish to a marketplace?](guides/marketplace-authoring.md)
+7. [How do I handle runtime deps, JSX, and bundling?](guides/plugin-authoring.md#bundling)
+8. [How do I validate it?](guides/plugin-authoring.md#validate)
+9. [How do I publish to a marketplace?](guides/marketplace-authoring.md)
 
 A link that leads to a missing or incomplete section is a known documentation
 gap. Open an issue or check `docs/superpowers/specs/` for in-progress work.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -197,7 +197,9 @@ All marketplace data lives under `~/.kaizen/` (or `$KAIZEN_HOME_OVERRIDE` in tes
       plugins/
         <name>@<version>/                  # installed plugin bits
           package.json
-          index.mjs
+          index.tsx                        # source kept for inspection
+          dist/
+            index.js                       # bundle; loader prefers this
       harnesses/
         <name>/
           kaizen.json                      # installed harness config
@@ -217,7 +219,7 @@ All paths are computed by `src/core/kaizen-config.ts` — never hardcode `~/.kai
 
 ### Third-party plugin loading
 
-Marketplace plugins are imported by **absolute path** from their install directory — there is no `node_modules` involvement. `src/core/plugin-loader.ts` reads `package.json` for the entry point and calls dynamic `import(absolutePath)`.
+Marketplace plugins are imported by **absolute path** from their install directory — there is no `node_modules` involvement. At install time `installPlugin` runs `bun build --target=bun` to produce `<install-dir>/dist/index.js`; `node_modules/` is removed after a successful build. The loader (`loadPluginFromMarketplaceInstall` in `plugin-manager.ts`) prefers `dist/index.js` when present and falls back to `pkg.module ?? pkg.main ?? "index.js"` otherwise. See [Bundling](../guides/plugin-authoring.md#bundling) for authoring details.
 
 ### Key modules
 

--- a/docs/concepts/plugin-model.md
+++ b/docs/concepts/plugin-model.md
@@ -63,8 +63,11 @@ The high-level sequence when you run `kaizen --harness <something>`:
    `~/.kaizen/marketplaces/<id>/plugins/<name>@<version>/`; legacy names fall
    back through authored-plugin and npm directories.
 2. **Install.** If a referenced plugin version isn't on disk yet, the
-   installer materializes it from its source (file, tarball, or npm) into
-   the marketplace install tree.
+   installer materializes it from its source (file, tarball, or npm),
+   installs runtime dependencies via `bun install --production` if declared,
+   then bundles the plugin to `dist/index.js` with `bun build --target=bun`.
+   `node_modules/` is removed after a successful bundle; source files stay on
+   disk. See [Bundling](../guides/plugin-authoring.md#bundling).
 3. **Consent.** Before a new plugin runs, kaizen reads its declared
    permissions and either accepts silently (TRUSTED), prompts with a grant
    list (SCOPED), or requires typed confirmation (UNSCOPED). Decisions

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -520,6 +520,70 @@ those dependencies automatically when the plugin is installed by running
 If `package.json` has no `dependencies` field, no install step runs — your
 plugin is copied into place and that's it.
 
+## Bundling {#bundling}
+
+After `bun install --production` completes, kaizen runs `bun build --target=bun`
+to produce `<install-dir>/dist/index.js`. The plugin loader prefers this bundle
+over the raw entry point. Once the build succeeds, `node_modules/` and any bun
+lockfile are removed from the install directory — source files (`package.json`,
+`README.md`, `index.tsx`, etc.) stay on disk for inspection.
+
+**Why bundling is required.** The compiled `kaizen` binary cannot resolve
+`node_modules/` at runtime or transform JSX/TypeScript at import time. A bundle
+produces a self-contained ESM module that loads from the binary without further
+resolution.
+
+### Declaring externals (`kaizen.bundleExternals`) {#bundle-externals}
+
+Some transitive dependencies conditionally import packages you don't want
+bundled — for example, `ink`'s `devtools.js` pulls in `react-devtools-core`.
+When bun encounters such an import it will try to bundle it, which fails if the
+package is absent or incompatible.
+
+Declare these externals in your `package.json` under a top-level `kaizen` key:
+
+```json
+{
+  "name": "claude-tui",
+  "version": "0.2.0",
+  "type": "module",
+  "main": "index.tsx",
+  "dependencies": { "ink": "^7.0.1", "react": "^19.2.0" },
+  "kaizen": {
+    "bundleExternals": ["react-devtools-core"]
+  }
+}
+```
+
+`bundleExternals` is a `string[]`. Each entry is passed verbatim to
+`bun build --external <entry>`. Kaizen does not curate or validate the list —
+it is your responsibility to declare only what you need.
+
+### Dynamic imports {#dynamic-imports}
+
+Avoid eval'd or string-concatenated dynamic imports of bare specifiers.
+`import("./foo.js")` and `import(varHoldingAbsolutePath)` survive bundling;
+`` import(`some-pkg-${version}`) `` will not.
+
+### Local-path plugins {#local-path-bundling}
+
+Local-path plugins (`./path/to/plugin`) are **not** bundled. They load via the
+raw entry, which only works under uncompiled `bun src/cli.ts`. Use local-path
+plugins for development; publish to a marketplace for any other use.
+
+### The `kaizen.*` namespace {#kaizen-namespace}
+
+The `kaizen` key in `package.json` is reserved for plugin-side static metadata
+that kaizen needs to read before importing the plugin entry. `bundleExternals`
+is the first field in this namespace; additional fields may be added in future
+releases.
+
+### Upgrading from ≤ 0.3.2 {#upgrading}
+
+Plugins installed under kaizen ≤ 0.3.2 do not have a `dist/index.js`. Run
+`kaizen install <ref>` again to regenerate the bundle layout. `installPlugin`
+is idempotent, so re-installing is safe.
+
 ## Next steps
 
 Once your plugin validates, publish it:

--- a/docs/reference/plugin-standards.md
+++ b/docs/reference/plugin-standards.md
@@ -18,6 +18,24 @@ This document is the canonical reference for kaizen plugin authors. Every rule i
 - [required] **`README.md`** at the package root documenting install, configuration, and permissions
 - [guideline] **`CHANGELOG.md`** tracking version history and breaking changes
 
+### `kaizen` namespace in package.json
+
+The top-level `kaizen` key in `package.json` is reserved for kaizen-specific static metadata. Currently one field is defined:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `kaizen.bundleExternals` | `string[]` | Packages passed verbatim to `bun build --external` at install time. Use when a transitive dependency conditionally imports a package you don't want bundled. Missing or empty means no externals. Kaizen does not validate or curate the list. |
+
+```json
+{
+  "kaizen": {
+    "bundleExternals": ["react-devtools-core"]
+  }
+}
+```
+
+See [Declaring externals](../guides/plugin-authoring.md#bundle-externals) in the plugin-authoring guide.
+
 ### Example package.json
 
 ```json

--- a/src/core/plugin-installer.test.ts
+++ b/src/core/plugin-installer.test.ts
@@ -285,6 +285,54 @@ describe("readBundleExternals", () => {
   });
 });
 
+describe("installPlugin — bundling", () => {
+  it("produces dist/index.js and removes node_modules after a deps-free file install", async () => {
+    const pluginSrc = join(upstream, "plugins", "trivial");
+    mkdirSync(pluginSrc, { recursive: true });
+    writeFileSync(
+      join(pluginSrc, "package.json"),
+      JSON.stringify({ name: "trivial", version: "1.0.0", type: "module", main: "index.js" }),
+    );
+    writeFileSync(
+      join(pluginSrc, "index.js"),
+      "export default { name: 'trivial', apiVersion: '2', setup(){} };",
+    );
+
+    await installPlugin("m", "trivial", "1.0.0", { type: "file", path: "plugins/trivial" });
+
+    const target = pluginInstallDir("m", "trivial", "1.0.0");
+    expect(existsSync(join(target, "dist", "index.js"))).toBe(true);
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+    expect(existsSync(join(target, "index.js"))).toBe(true);
+    expect(existsSync(join(target, "package.json"))).toBe(true);
+  }, 30_000);
+
+  it("produces dist/index.js and removes node_modules after a with-deps file install", async () => {
+    const pluginSrc = join(upstream, "plugins", "with-deps");
+    mkdirSync(pluginSrc, { recursive: true });
+    writeFileSync(
+      join(pluginSrc, "package.json"),
+      JSON.stringify({
+        name: "with-deps",
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        dependencies: { "is-odd": "3.0.1" },
+      }),
+    );
+    writeFileSync(
+      join(pluginSrc, "index.js"),
+      "import isOdd from 'is-odd'; export default { name: 'with-deps', apiVersion: '2', setup(){ isOdd(1); } };",
+    );
+
+    await installPlugin("m", "with-deps", "1.0.0", { type: "file", path: "plugins/with-deps" });
+
+    const target = pluginInstallDir("m", "with-deps", "1.0.0");
+    expect(existsSync(join(target, "dist", "index.js"))).toBe(true);
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+  }, 60_000);
+});
+
 describe("bundlePlugin", () => {
   let target: string;
   beforeEach(() => {

--- a/src/core/plugin-installer.test.ts
+++ b/src/core/plugin-installer.test.ts
@@ -317,4 +317,16 @@ describe("bundlePlugin", () => {
     expect(existsSync(join(target, "index.js"))).toBe(true);
     expect(existsSync(join(target, "package.json"))).toBe(true);
   }, 30_000);
+
+  it("rolls back target and includes stderr when bun build fails", async () => {
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ name: "broken", version: "1.0.0", type: "module", main: "index.js" }),
+    );
+    // Syntax error: unterminated string.
+    writeFileSync(join(target, "index.js"), "export default { broken: 'oops");
+
+    await expect(bundlePluginForTesting(target, "broken", "1.0.0")).rejects.toThrow(/bun build failed/);
+    expect(existsSync(target)).toBe(false);
+  }, 30_000);
 });

--- a/src/core/plugin-installer.test.ts
+++ b/src/core/plugin-installer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { installPlugin, installHarness, resolveBunExecutable, installDepsForTesting } from "./plugin-installer.js";
+import { installPlugin, installHarness, resolveBunExecutable, installDepsForTesting, readBundleExternalsForTesting } from "./plugin-installer.js";
 import { pluginInstallDir, harnessInstallDir, marketplaceRepoDir } from "./kaizen-config.js";
 
 let home: string;
@@ -249,5 +249,38 @@ describe("installHarness", () => {
 
     const target = join(harnessInstallDir("m", "anthropic-default"), "kaizen.json");
     expect(JSON.parse(readFileSync(target, "utf8"))).toEqual(doc);
+  });
+});
+
+describe("readBundleExternals", () => {
+  it("returns [] when kaizen field is missing", () => {
+    expect(readBundleExternalsForTesting({ name: "x", version: "1" })).toEqual([]);
+  });
+
+  it("returns [] when kaizen.bundleExternals is missing", () => {
+    expect(readBundleExternalsForTesting({ kaizen: {} })).toEqual([]);
+  });
+
+  it("returns the array verbatim when well-formed", () => {
+    expect(readBundleExternalsForTesting({
+      kaizen: { bundleExternals: ["react-devtools-core", "fsevents"] },
+    })).toEqual(["react-devtools-core", "fsevents"]);
+  });
+
+  it("returns [] when kaizen is not an object", () => {
+    expect(readBundleExternalsForTesting({ kaizen: "nope" })).toEqual([]);
+    expect(readBundleExternalsForTesting({ kaizen: null })).toEqual([]);
+    expect(readBundleExternalsForTesting({ kaizen: ["a"] })).toEqual([]);
+  });
+
+  it("returns [] when bundleExternals is not an array", () => {
+    expect(readBundleExternalsForTesting({ kaizen: { bundleExternals: "react" } })).toEqual([]);
+    expect(readBundleExternalsForTesting({ kaizen: { bundleExternals: { a: 1 } } })).toEqual([]);
+  });
+
+  it("filters non-string entries", () => {
+    expect(readBundleExternalsForTesting({
+      kaizen: { bundleExternals: ["ok", 42, null, "also-ok"] },
+    })).toEqual(["ok", "also-ok"]);
   });
 });

--- a/src/core/plugin-installer.test.ts
+++ b/src/core/plugin-installer.test.ts
@@ -329,4 +329,49 @@ describe("bundlePlugin", () => {
     await expect(bundlePluginForTesting(target, "broken", "1.0.0")).rejects.toThrow(/bun build failed/);
     expect(existsSync(target)).toBe(false);
   }, 30_000);
+
+  it("passes kaizen.bundleExternals as --external flags to bun build", async () => {
+    // Fake bun executable that records argv and writes a stub bundle.
+    const fakeBun = join(target, "fake-bun.sh");
+    const argLog = join(target, "args.log");
+    writeFileSync(
+      fakeBun,
+      `#!/bin/sh
+echo "$@" > ${JSON.stringify(argLog)}
+# argv: build --target=bun --outfile=<...> [--external X]... <entry>
+# Find --outfile=<path> and create the file.
+for a in "$@"; do
+  case "$a" in
+    --outfile=*)
+      out="\${a#--outfile=}"
+      mkdir -p "$(dirname "$out")"
+      echo "// stub" > "$out"
+      ;;
+  esac
+done
+exit 0
+`,
+    );
+    chmodSync(fakeBun, 0o755);
+
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({
+        name: "with-ext",
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        kaizen: { bundleExternals: ["react-devtools-core", "fsevents"] },
+      }),
+    );
+    writeFileSync(join(target, "index.js"), "export default { name: 'x', apiVersion: '2', setup(){} };");
+
+    await bundlePluginForTesting(target, "with-ext", "1.0.0", () => fakeBun);
+
+    const argv = readFileSync(argLog, "utf8");
+    expect(argv).toContain("--external react-devtools-core");
+    expect(argv).toContain("--external fsevents");
+    expect(argv).toContain("--target=bun");
+    expect(existsSync(join(target, "dist", "index.js"))).toBe(true);
+  });
 });

--- a/src/core/plugin-installer.test.ts
+++ b/src/core/plugin-installer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { installPlugin, installHarness, resolveBunExecutable, installDepsForTesting, readBundleExternalsForTesting } from "./plugin-installer.js";
+import { installPlugin, installHarness, resolveBunExecutable, installDepsForTesting, readBundleExternalsForTesting, bundlePluginForTesting } from "./plugin-installer.js";
 import { pluginInstallDir, harnessInstallDir, marketplaceRepoDir } from "./kaizen-config.js";
 
 let home: string;
@@ -283,4 +283,38 @@ describe("readBundleExternals", () => {
       kaizen: { bundleExternals: ["ok", 42, null, "also-ok"] },
     })).toEqual(["ok", "also-ok"]);
   });
+});
+
+describe("bundlePlugin", () => {
+  let target: string;
+  beforeEach(() => {
+    target = mkdtempSync(join(tmpdir(), "kz-bundle-"));
+  });
+  afterEach(() => {
+    rmSync(target, { recursive: true, force: true });
+  });
+
+  it("produces dist/index.js for a deps-free plugin and removes node_modules/lockfiles", async () => {
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ name: "trivial", version: "1.0.0", type: "module", main: "index.js" }),
+    );
+    writeFileSync(
+      join(target, "index.js"),
+      "export default { name: 'trivial', apiVersion: '2', setup(){} };",
+    );
+    // Pretend a previous installDeps left these behind.
+    mkdirSync(join(target, "node_modules"), { recursive: true });
+    writeFileSync(join(target, "node_modules", "marker"), "");
+    writeFileSync(join(target, "bun.lock"), "{}\n");
+
+    await bundlePluginForTesting(target, "trivial", "1.0.0");
+
+    expect(existsSync(join(target, "dist", "index.js"))).toBe(true);
+    expect(existsSync(join(target, "node_modules"))).toBe(false);
+    expect(existsSync(join(target, "bun.lock"))).toBe(false);
+    // Source survives.
+    expect(existsSync(join(target, "index.js"))).toBe(true);
+    expect(existsSync(join(target, "package.json"))).toBe(true);
+  }, 30_000);
 });

--- a/src/core/plugin-installer.test.ts
+++ b/src/core/plugin-installer.test.ts
@@ -37,52 +37,6 @@ describe("installPlugin — file source", () => {
     expect(existsSync(join(target, "index.js"))).toBe(true);
   });
 
-  it("resolves runtime deps after copying file source", async () => {
-    const pluginSrc = join(upstream, "plugins", "with-deps");
-    mkdirSync(pluginSrc, { recursive: true });
-    writeFileSync(
-      join(pluginSrc, "package.json"),
-      JSON.stringify({
-        name: "with-deps",
-        version: "1.0.0",
-        main: "index.js",
-        dependencies: { "is-odd": "3.0.1" },
-      }),
-    );
-    writeFileSync(join(pluginSrc, "index.js"), "export default { name: 'with-deps', apiVersion: '2', setup(){} };");
-
-    await installPlugin("m", "with-deps", "1.0.0", { type: "file", path: "plugins/with-deps" });
-
-    const target = pluginInstallDir("m", "with-deps", "1.0.0");
-    expect(existsSync(join(target, "node_modules", "is-odd"))).toBe(true);
-  }, 30_000);
-});
-
-describe("installPlugin — lockfile honored", () => {
-  it("preserves bun.lock from source through install", async () => {
-    const pluginSrc = join(upstream, "plugins", "locked");
-    mkdirSync(pluginSrc, { recursive: true });
-    // No dependencies so installDeps no-ops; we only need to verify cpSync
-    // carries the committed lockfile through to the install dir.
-    writeFileSync(
-      join(pluginSrc, "package.json"),
-      JSON.stringify({
-        name: "locked",
-        version: "1.0.0",
-        main: "index.js",
-      }),
-    );
-    writeFileSync(join(pluginSrc, "index.js"), "export default { name: 'locked', apiVersion: '2', setup(){} };");
-    // A pre-existing bun.lock in the source — bun will use it.
-    // We can't easily fabricate a valid binary lockfile in a test, so we just
-    // verify that any lockfile present in source is copied into target.
-    writeFileSync(join(pluginSrc, "bun.lock"), "{}\n");
-
-    await installPlugin("m", "locked", "1.0.0", { type: "file", path: "plugins/locked" });
-
-    const target = pluginInstallDir("m", "locked", "1.0.0");
-    expect(existsSync(join(target, "bun.lock"))).toBe(true);
-  }, 30_000);
 });
 
 describe("resolveBunExecutable", () => {

--- a/src/core/plugin-installer.ts
+++ b/src/core/plugin-installer.ts
@@ -164,3 +164,55 @@ async function installDeps(
 
 // Test-only export. Not part of the public API.
 export const installDepsForTesting = installDeps;
+
+async function bundlePlugin(
+  target: string,
+  name: string,
+  version: string,
+  bunResolver: () => string | null = resolveBunExecutable,
+): Promise<void> {
+  const pkgPath = join(target, "package.json");
+  if (!existsSync(pkgPath)) return;
+
+  let pkg: { main?: string; module?: string };
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch {
+    return;
+  }
+
+  const entry = pkg.module ?? pkg.main ?? "index.js";
+  const entryPath = join(target, entry);
+  const outFile = join(target, "dist", "index.js");
+  const externals = readBundleExternals(pkg);
+
+  const bun = bunResolver();
+  if (!bun) {
+    throw new Error(
+      `plugin '${name}@${version}' could not be bundled: bun is not on PATH or at ~/.bun/bin/bun.\n` +
+      `Install bun: curl -fsSL https://bun.sh/install | bash`,
+    );
+  }
+
+  const cmd = [bun, "build", "--target=bun", `--outfile=${outFile}`];
+  for (const ext of externals) cmd.push("--external", ext);
+  cmd.push(entryPath);
+
+  const proc = Bun.spawnSync({ cmd, cwd: target, stdout: "pipe", stderr: "pipe" });
+
+  if (proc.exitCode !== 0) {
+    const stderr = proc.stderr ? new TextDecoder().decode(proc.stderr) : "";
+    rmSync(target, { recursive: true, force: true });
+    throw new Error(
+      `bun build failed for plugin '${name}@${version}' at ${target}\n` +
+      stderr.split("\n").map((l) => `  ${l}`).join("\n"),
+    );
+  }
+
+  rmSync(join(target, "node_modules"), { recursive: true, force: true });
+  rmSync(join(target, "bun.lockb"), { force: true });
+  rmSync(join(target, "bun.lock"), { force: true });
+}
+
+// Test-only export. Not part of the public API.
+export const bundlePluginForTesting = bundlePlugin;

--- a/src/core/plugin-installer.ts
+++ b/src/core/plugin-installer.ts
@@ -98,6 +98,18 @@ export function resolveBunExecutable(): string | null {
   return null;
 }
 
+function readBundleExternals(pkg: unknown): string[] {
+  if (typeof pkg !== "object" || pkg === null) return [];
+  const kz = (pkg as Record<string, unknown>)["kaizen"];
+  if (typeof kz !== "object" || kz === null || Array.isArray(kz)) return [];
+  const list = (kz as Record<string, unknown>)["bundleExternals"];
+  if (!Array.isArray(list)) return [];
+  return list.filter((x): x is string => typeof x === "string");
+}
+
+// Test-only export. Not part of the public API.
+export const readBundleExternalsForTesting = readBundleExternals;
+
 /**
  * If `target` contains a package.json with non-empty runtime dependencies,
  * run `bun install --production` in it. Otherwise no-op.

--- a/src/core/plugin-installer.ts
+++ b/src/core/plugin-installer.ts
@@ -31,6 +31,7 @@ export async function installPlugin(
   }
 
   await installDeps(target, name, version);
+  await bundlePlugin(target, name, version);
 }
 
 /**

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -482,3 +482,60 @@ describe("isInstalled(marketplaceId, name, version)", () => {
     expect(await isInstalled("m", "demo", "1.0.0")).toBe(true);
   });
 });
+
+describe("loadPluginFromMarketplaceInstall — bundle preference", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kz-pm-"));
+    process.env.KAIZEN_HOME_OVERRIDE = home;
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env.KAIZEN_HOME_OVERRIDE;
+  });
+
+  it("prefers dist/index.js when present, ignores raw entry", async () => {
+    const { sep } = await import("path");
+    const target = pluginInstallDir("m", "preferbundle", "1.0.0");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ name: "preferbundle", version: "1.0.0", type: "module", main: "index.js" }),
+    );
+    // Raw entry exports a sentinel that should NOT be loaded.
+    writeFileSync(
+      join(target, "index.js"),
+      "export default { name: 'WRONG', apiVersion: '2', setup(){} };",
+    );
+    // Bundle exports the correct sentinel.
+    mkdirSync(join(target, "dist"));
+    writeFileSync(
+      join(target, "dist", "index.js"),
+      "export default { name: 'preferbundle', apiVersion: '2', setup(){} };",
+    );
+
+    const { loadPluginFromMarketplaceInstallForTesting } = await import("./plugin-manager.js");
+    const loaded = await loadPluginFromMarketplaceInstallForTesting("m", "preferbundle", "1.0.0", "preferbundle");
+    expect(loaded?.plugin.name).toBe("preferbundle");
+    expect(loaded?.resolvedPath).toContain(`dist${sep}index.js`);
+  });
+
+  it("falls back to pkg.module/pkg.main when no dist/index.js", async () => {
+    const target = pluginInstallDir("m", "fallback", "1.0.0");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({ name: "fallback", version: "1.0.0", type: "module", main: "index.js" }),
+    );
+    writeFileSync(
+      join(target, "index.js"),
+      "export default { name: 'fallback', apiVersion: '2', setup(){} };",
+    );
+
+    const { loadPluginFromMarketplaceInstallForTesting } = await import("./plugin-manager.js");
+    const loaded = await loadPluginFromMarketplaceInstallForTesting("m", "fallback", "1.0.0", "fallback");
+    expect(loaded?.plugin.name).toBe("fallback");
+    expect(loaded?.resolvedPath).toMatch(/index\.js$/);
+    expect(loaded?.resolvedPath).not.toContain("dist");
+  });
+});

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -493,6 +493,13 @@ describe("isInstalled(marketplaceId, name, version)", () => {
     writeFileSync(join(dir, "package.json"), JSON.stringify({ dependencies: { foo: "1.0.0" } }));
     expect(await isInstalled("m", "demo", "1.0.0")).toBe(true);
   });
+  it("returns true when bundled (dist/index.js) even if node_modules absent", async () => {
+    const dir = pluginInstallDir("m", "demo", "1.0.0");
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ dependencies: { foo: "1.0.0" } }));
+    writeFileSync(join(dir, "dist", "index.js"), "export default {};");
+    expect(await isInstalled("m", "demo", "1.0.0")).toBe(true);
+  });
 });
 
 describe("loadPluginFromMarketplaceInstall — bundle preference", () => {

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -112,9 +112,20 @@ async function loadPluginFromMarketplaceInstall(
   const dir = pluginInstallDir(marketplaceId, pluginName, version);
   const pkgPath = join(dir, "package.json");
   if (!existsSync(pkgPath)) return null;
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { main?: string; module?: string };
-  const entry = pkg.module ?? pkg.main ?? "index.js";
-  const abs = join(dir, entry);
+
+  // Prefer the bundled output produced by installPlugin(). Falls through to the
+  // raw entry for two cases: pre-bundle-era installs on disk, and uncompiled
+  // `bun src/cli.ts` against a freshly checked-out plugin without a build step.
+  const bundlePath = join(dir, "dist", "index.js");
+  let abs: string;
+  if (existsSync(bundlePath)) {
+    abs = bundlePath;
+  } else {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { main?: string; module?: string };
+    const entry = pkg.module ?? pkg.main ?? "index.js";
+    abs = join(dir, entry);
+  }
+
   try {
     const mod = (await import(abs)) as { default?: unknown };
     const plugin = mod.default;
@@ -132,6 +143,9 @@ async function loadPluginFromMarketplaceInstall(
     return null;
   }
 }
+
+// Test-only export. Not part of the public API.
+export const loadPluginFromMarketplaceInstallForTesting = loadPluginFromMarketplaceInstall;
 
 async function resolvePlugin(name: string): Promise<LoadedPlugin | null> {
   const isPath = name.startsWith("./") || name.startsWith("/") || name.startsWith("../");

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -52,6 +52,8 @@ export async function isInstalled(
   const dir = pluginInstallDir(marketplaceId, name, version);
   const pkgPath = join(dir, "package.json");
   if (!existsSync(pkgPath)) return false;
+  // Bundled plugins drop node_modules; presence of dist/index.js means installed.
+  if (existsSync(join(dir, "dist", "index.js"))) return true;
   try {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { dependencies?: Record<string, string> };
     if (pkg.dependencies && Object.keys(pkg.dependencies).length > 0) {


### PR DESCRIPTION
## Summary
- Bundle each marketplace plugin install with `bun build --target=bun` after `bun install --production`, dropping `node_modules/` and bun lockfiles. Source files survive for inspection.
- Loader (`loadPluginFromMarketplaceInstall`) prefers `<install-dir>/dist/index.js`; falls back to `pkg.module ?? pkg.main ?? "index.js"` for pre-bundle installs and uncompiled-bun dev paths.
- New `kaizen.bundleExternals: string[]` field in plugin `package.json` forwards entries to `bun build --external`. Establishes the `kaizen.*` namespace for kaizen-specific static metadata. No curation — mechanism, not policy.
- Strict failure: any bundle error rolls back the install dir and throws with bun's stderr (mirrors existing `installDeps` rollback shape).
- Local-path plugins (`./path/to/plugin`) are intentionally NOT bundled (dev-only escape hatch).

Resolves the compiled-binary load failure for plugins with runtime deps or JSX entries (e.g. `claude-tui@0.2.0`'s `Cannot find package 'ink'` from the standalone `kaizen` binary).

Spec: `docs/superpowers/specs/2026-04-30-plugin-bundling-design.md`
Plan: `docs/superpowers/plans/2026-04-30-plugin-bundling.md`

## Test Plan
- [x] `bun test` — 467 pass / 1 skip / 0 fail (added 11 net new tests across `plugin-installer.test.ts` and `plugin-manager.test.ts`)
- [x] `bun run typecheck` — clean
- [x] E2E with compiled darwin binary: `claude-events@0.1.1` installs cleanly with `dist/index.js`, `node_modules` removed
- [x] E2E confirms spec failure mode: `claude-tui@0.2.0` install fails strictly with `Could not resolve: react-devtools-core` (upstream needs `kaizen.bundleExternals: ["react-devtools-core"]`)
- [ ] Reviewer: skim docs updates (`plugin-authoring.md` Bundling section, `plugin-standards.md` kaizen namespace, `architecture.md` install tree)

## Follow-up (out of scope)
- `claude-tui@0.2.0` upstream `package.json` needs `kaizen.bundleExternals: ["react-devtools-core"]` added before its compiled-binary load can succeed end-to-end.