### PR TITLE
fix(loader): prefer dist/index.js bundle in install-dir loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaizen",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Platform for LLM harnesses",
   "type": "module",
   "module": "src/cli.ts",

--- a/src/core/plugin-loader.ts
+++ b/src/core/plugin-loader.ts
@@ -12,9 +12,17 @@ export async function loadPluginFromInstallDir(
   }
   const pkgPath = join(dir, "package.json");
   if (!existsSync(pkgPath)) throw new Error(`no package.json at ${dir}`);
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { main?: string; module?: string };
-  const entry = pkg.module ?? pkg.main ?? "index.js";
-  const abs = isAbsolute(entry) ? entry : join(dir, entry);
+  // Prefer the bundled output produced by installPlugin(). Falls back to the raw
+  // entry for pre-bundle-era installs and uncompiled-cli local development.
+  const bundlePath = join(dir, "dist", "index.js");
+  let abs: string;
+  if (existsSync(bundlePath)) {
+    abs = bundlePath;
+  } else {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { main?: string; module?: string };
+    const entry = pkg.module ?? pkg.main ?? "index.js";
+    abs = isAbsolute(entry) ? entry : join(dir, entry);
+  }
 
   const mod = (await import(abs)) as { default?: KaizenPlugin };
   if (!mod.default || typeof mod.default !== "object") {


### PR DESCRIPTION
## Summary
- `loadPluginFromInstallDir` (used by `plugin consent --all`) read `pkg.module/main` directly, ignoring the bundle produced by `installPlugin()`.
- At runtime `loadPluginFromMarketplaceInstall` already prefers `dist/index.js`; this PR mirrors that preference in the install-dir loader so both code paths resolve the same artifact.
- Repros as `ResolveMessage: Cannot find module ...` against the raw `.ts` entry during consent for any plugin with bundled runtime deps.
- Release: v0.3.4.

## Test plan
- [x] `bun test` (470 pass, 2 skip)
- [x] `bun x tsc --noEmit`
- [x] Manual: `kaizen plugin consent --harness official/openai-compatible --all` against installed marketplace plugins now consents bundled plugins (mcp-bridge, slash-commands, codemode-dispatch).