### PR TITLE
fix(installer): preserve node_modules when bundleExternals declared

### DIFF
--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -528,6 +528,11 @@ over the raw entry point. Once the build succeeds, `node_modules/` and any bun
 lockfile are removed from the install directory — source files (`package.json`,
 `README.md`, `index.tsx`, etc.) stay on disk for inspection.
 
+When `kaizen.bundleExternals` is non-empty, `node_modules/` is **preserved**
+post-build. Externals are imports the bundle deliberately leaves as bare
+specifiers, so the runtime needs them on disk to resolve. The lockfile is also
+preserved in that case.
+
 **Why bundling is required.** The compiled `kaizen` binary cannot resolve
 `node_modules/` at runtime or transform JSX/TypeScript at import time. A bundle
 produces a self-contained ESM module that loads from the binary without further
@@ -558,6 +563,13 @@ Declare these externals in your `package.json` under a top-level `kaizen` key:
 `bundleExternals` is a `string[]`. Each entry is passed verbatim to
 `bun build --external <entry>`. Kaizen does not curate or validate the list —
 it is your responsibility to declare only what you need.
+
+Anything you list here must be resolvable from disk at runtime: include it
+(directly or transitively) in your `dependencies`, since `node_modules/` is
+preserved when externals are declared. If a transitive dep pulls in a package
+you can't easily install (e.g., `ink` → `react-devtools-core`, which is
+gated behind `import.meta.resolve`), the missing-package case still works —
+externals just need to fail-soft at the consumer's call site.
 
 ### Dynamic imports {#dynamic-imports}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaizen",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Platform for LLM harnesses",
   "type": "module",
   "module": "src/cli.ts",

--- a/src/core/plugin-installer.test.ts
+++ b/src/core/plugin-installer.test.ts
@@ -376,4 +376,46 @@ exit 0
     expect(argv).toContain("--target=bun");
     expect(existsSync(join(target, "dist", "index.js"))).toBe(true);
   });
+
+  it("preserves node_modules when bundleExternals is non-empty", async () => {
+    // Same fake-bun stub strategy as the externals-arg test.
+    const fakeBun = join(target, "fake-bun.sh");
+    writeFileSync(
+      fakeBun,
+      `#!/bin/sh
+for a in "$@"; do
+  case "$a" in
+    --outfile=*)
+      out="\${a#--outfile=}"
+      mkdir -p "$(dirname "$out")"
+      echo "// stub" > "$out"
+      ;;
+  esac
+done
+exit 0
+`,
+    );
+    chmodSync(fakeBun, 0o755);
+
+    writeFileSync(
+      join(target, "package.json"),
+      JSON.stringify({
+        name: "with-ext",
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        kaizen: { bundleExternals: ["react-devtools-core"] },
+      }),
+    );
+    writeFileSync(join(target, "index.js"), "export default { name: 'x', apiVersion: '2', setup(){} };");
+    mkdirSync(join(target, "node_modules", "react-devtools-core"), { recursive: true });
+    writeFileSync(join(target, "node_modules", "react-devtools-core", "package.json"), "{}");
+    writeFileSync(join(target, "bun.lock"), "{}\n");
+
+    await bundlePluginForTesting(target, "with-ext", "1.0.0", () => fakeBun);
+
+    expect(existsSync(join(target, "dist", "index.js"))).toBe(true);
+    expect(existsSync(join(target, "node_modules", "react-devtools-core"))).toBe(true);
+    expect(existsSync(join(target, "bun.lock"))).toBe(true);
+  });
 });

--- a/src/core/plugin-installer.ts
+++ b/src/core/plugin-installer.ts
@@ -210,9 +210,15 @@ async function bundlePlugin(
     );
   }
 
-  rmSync(join(target, "node_modules"), { recursive: true, force: true });
-  rmSync(join(target, "bun.lockb"), { force: true });
-  rmSync(join(target, "bun.lock"), { force: true });
+  // Externals are deliberately not in the bundle, so the bundle imports them
+  // by bare specifier at load time. That requires node_modules to remain on
+  // disk. If no externals are declared, drop node_modules so the install dir
+  // is a self-contained bundle.
+  if (externals.length === 0) {
+    rmSync(join(target, "node_modules"), { recursive: true, force: true });
+    rmSync(join(target, "bun.lockb"), { force: true });
+    rmSync(join(target, "bun.lock"), { force: true });
+  }
 }
 
 // Test-only export. Not part of the public API.


### PR DESCRIPTION
## Summary
- bundleExternals declared imports as bare specifiers in the bundle, but `installPlugin()` then dropped `node_modules` unconditionally — so the runtime had nothing to resolve them against. The doc'd canonical case (`ink` → `react-devtools-core`) failed at load time with \`Cannot find package 'react-devtools-core' from .../dist/index.js\`.
- Now `node_modules` and the bun lockfile are preserved when `kaizen.bundleExternals` is non-empty. Plugins without externals continue to ship as a self-contained bundle.
- Plugin authors must still install externals as real `dependencies` so they land in `node_modules` (bun build's `--external` does not stage them).
- Docs updated. Release: v0.3.5.

## Test plan
- [x] \`bun test\` (471 pass / 2 skip)
- [x] \`bun x tsc --noEmit\`
- [x] New unit test: bundlePlugin preserves node_modules and bun.lock when bundleExternals is non-empty.
- [ ] After merge + release: re-install llm-tui (with react-devtools-core added as dep) and confirm \`plugin consent --all\` consents it.