### PR TITLE
feat!: drop service-name owner-prefix rule (v0.3.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaizen",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Platform for LLM harnesses",
   "type": "module",
   "module": "src/cli.ts",

--- a/src/core/plugin-manager.test.ts
+++ b/src/core/plugin-manager.test.ts
@@ -441,23 +441,29 @@ describe("PluginManager service validation", () => {
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 
-  test("owner-prefix mismatch throws during setup (plugin flagged as failed when not critical)", async () => {
+  test("duplicate defineService across plugins throws during setup (second plugin flagged as failed when not critical)", async () => {
     const regs = baseRegistries();
     const lifeDir = writePlugin({ name: "core-driver", driver: true, hasStart: true });
-    const badDir = writePlugin({
-      name: "bad",
+    const firstDir = writePlugin({
+      name: "first",
       services: { provides: [] },
-      setupBody: `ctx.defineService("someoneElse:thing", { description: "" });`,
+      setupBody: `ctx.defineService("shared:thing", { description: "first" });`,
+    });
+    const secondDir = writePlugin({
+      name: "second",
+      services: { provides: [] },
+      setupBody: `ctx.defineService("shared:thing", { description: "second" });`,
     });
     const manager = new PluginManager(
-      { plugins: [badDir, lifeDir] },
+      { plugins: [firstDir, secondDir, lifeDir] },
       regs.eventBus, regs.serviceRegistry,
       regs.enforcer, regs.auditLog,
       regs.lockfilePath, regs.options,
     );
     await manager.initialize();
     const entries = manager.list();
-    expect(entries.find((e) => e.name === "bad")?.status).toBe("failed");
+    expect(entries.find((e) => e.name === "first")?.status).not.toBe("failed");
+    expect(entries.find((e) => e.name === "second")?.status).toBe("failed");
   });
 });
 

--- a/src/core/service-registry.test.ts
+++ b/src/core/service-registry.test.ts
@@ -3,31 +3,52 @@ import { ServiceRegistry } from "./service-registry.js";
 
 describe("ServiceRegistry", () => {
   describe("define", () => {
-    it("accepts a well-prefixed name", () => {
+    it("accepts a name prefixed with the plugin's own name", () => {
       const reg = new ServiceRegistry();
       reg.define("owner:thing", "owner", { description: "ok" });
       expect(reg.getSpec("owner:thing")).toEqual({ description: "ok" });
     });
 
-    it("rejects a name that doesn't start with the plugin's prefix", () => {
+    it("accepts a shared-namespace name (definer prefix need not match plugin name)", () => {
       const reg = new ServiceRegistry();
-      expect(() => reg.define("other:thing", "owner", { description: "x" })).toThrow(
-        /must be prefixed with plugin name 'owner'/,
+      reg.define("llm:complete", "openai-llm", { description: "shared contract" });
+      expect(reg.getSpec("llm:complete")).toEqual({ description: "shared contract" });
+    });
+
+    it("accepts a name with no colon prefix", () => {
+      const reg = new ServiceRegistry();
+      reg.define("thing", "owner", { description: "x" });
+      expect(reg.getSpec("thing")).toEqual({ description: "x" });
+    });
+
+    it("rejects an empty name", () => {
+      const reg = new ServiceRegistry();
+      expect(() => reg.define("", "owner", { description: "x" })).toThrow(
+        /Service name '' is invalid/,
       );
     });
 
-    it("rejects a name with no prefix", () => {
+    it("rejects a name containing whitespace", () => {
       const reg = new ServiceRegistry();
-      expect(() => reg.define("thing", "owner", { description: "x" })).toThrow(
-        /must be prefixed with plugin name 'owner'/,
+      expect(() => reg.define("owner: bad", "owner", { description: "x" })).toThrow(
+        /must be non-empty and contain no whitespace/,
       );
     });
 
-    it("keeps the first definition and warns on duplicate", () => {
+    it("throws when a different plugin tries to redefine an existing service", () => {
+      const reg = new ServiceRegistry();
+      reg.define("llm:complete", "openai-llm", { description: "first" });
+      expect(() =>
+        reg.define("llm:complete", "anthropic-llm", { description: "second" }),
+      ).toThrow(/already defined by plugin 'openai-llm'.*'anthropic-llm' cannot redefine/s);
+    });
+
+    it("throws when the same plugin redefines a service", () => {
       const reg = new ServiceRegistry();
       reg.define("owner:x", "owner", { description: "first" });
-      reg.define("owner:x", "owner", { description: "second" });
-      expect(reg.getSpec("owner:x")).toEqual({ description: "first" });
+      expect(() => reg.define("owner:x", "owner", { description: "second" })).toThrow(
+        /already defined by plugin 'owner'/,
+      );
     });
   });
 

--- a/src/core/service-registry.ts
+++ b/src/core/service-registry.ts
@@ -1,5 +1,4 @@
 import type { ServiceSpec } from "../types/plugin.js";
-import { warn } from "./errors.js";
 
 export interface ServiceEntry {
   name: string;
@@ -24,16 +23,19 @@ export class ServiceRegistry {
   private readonly consumers = new Map<string, Set<string>>();
 
   define(name: string, pluginName: string, spec: ServiceSpec): void {
-    const colon = name.indexOf(":");
-    if (colon < 0 || name.slice(0, colon) !== pluginName) {
+    if (name.length === 0 || name.includes(" ")) {
       throw new Error(
-        `Service '${name}' must be prefixed with plugin name '${pluginName}' ` +
-        `(e.g. '${pluginName}:...').`,
+        `Service name '${name}' is invalid: must be non-empty and contain no whitespace.`,
       );
     }
-    if (this.entries.has(name)) {
-      warn(`Service '${name}' already defined. Ignoring duplicate from '${pluginName}'.`);
-      return;
+    const existing = this.entries.get(name);
+    if (existing) {
+      throw new Error(
+        `Service '${name}' is already defined by plugin '${existing.definedBy}'; ` +
+        `plugin '${pluginName}' cannot redefine it. ` +
+        `If both plugins implement the same contract, only one should defineService(); ` +
+        `the other should provideService() against the existing definition.`,
+      );
     }
     this.entries.set(name, {
       name, spec, definedBy: pluginName,

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -83,7 +83,7 @@ export interface PluginServices {
 export interface PluginContext {
   // --- Service registry ----------------------------------------------------
 
-  /** Declare a service. Only valid during INITIALIZING (setup()). Name must be prefixed with the calling plugin's name. */
+  /** Declare a service. Only valid during INITIALIZING (setup()). Service names are global; redefining a name another plugin already defined throws. Convention is `<owner>:<service>`, but any unique non-empty token (no whitespace) is accepted. */
   defineService(name: string, spec: ServiceSpec): void;
 
   /** Provide an implementation for a previously-defined service. Only valid during INITIALIZING. */


### PR DESCRIPTION
## Summary

- Drop the `defineService(name)` rule that required `name` to be prefixed with the calling plugin's name.
- Promote duplicate `defineService` of the same name from a silent warn-and-ignore to a hard error that names both plugins.

## Why

The owner-prefix rule made shared-contract services awkward. Any service intended to have multiple swappable providers (the canonical case: `llm:complete` implemented by `openai-llm`, future `anthropic-llm`, `bedrock-llm`, …) had no clean home — the prefix locked the contract into whichever provider plugin happened to ship first, or required a vocabulary-only plugin per namespace just to satisfy the prefix.

The rule's real job — collision detection — is now done by the upgraded duplicate-define error, which is strictly better than the old behavior (silent ignore + warn). Authors get an actionable error at load time naming both plugins involved.

## Behavior

- `defineService("llm:complete", ...)` from plugin `openai-llm` → ✅ accepted (was: thrown).
- Two plugins both calling `defineService("llm:complete", ...)` → ❌ second throws with a message naming both plugins (was: silent warn + first wins).
- Service names must be non-empty and contain no whitespace; otherwise unrestricted.

## Breaking

Plugins that relied on the silent duplicate-ignore behavior will now fail to load. Audit any harness with two plugins defining the same service — pick one as the definer; the other should call `provideService()` only (which already enforces cardinality-of-one with a clear error).

## Test plan

- [x] `bun test` (468 tests, 466 pass / 2 skip / 0 fail)
- [x] `bun x tsc --noEmit`
- [x] New tests cover: shared-namespace define, no-prefix define, empty/whitespace rejection, cross-plugin duplicate throws, same-plugin duplicate throws.