### PR TITLE
feat: expose ctx.harness with raw harness identity (#74)

### DIFF
--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -264,6 +264,43 @@ event handshake. Define a vocabulary event in a shared events plugin, have
 the driver emit it during `start()`, and subscribe to it in `setup()` of any
 plugin that needs to react.
 
+### Harness identity {#harness-identity}
+
+Plugins that persist state to disk often need to partition that state by
+harness — otherwise data captured under harness A (with plugins X, Y, Z)
+can be silently loaded under harness B with a different plugin set,
+producing missing tools or mismatched message shapes.
+
+`ctx.harness` exposes raw metadata about the harness the plugin is loaded
+under:
+
+```ts
+ctx.harness.jsonPath  // absolute path to the resolved harness JSON, or undefined
+ctx.harness.ref       // the user's --harness ref / defaults.harness value, or undefined
+```
+
+Both inner fields may be absent — `kaizen` invoked from a directory
+containing `kaizen.json` (no `--harness`) will populate `jsonPath` only;
+programmatic `runHarness()` calls may populate neither. Kaizen does not
+derive a canonical "name" — plugins choose their own namespacing rule.
+
+A typical pattern:
+
+```ts
+async setup(ctx) {
+  const key =
+    ctx.harness.jsonPath ??
+    ctx.harness.ref ??
+    "default";
+  const stateDir = path.join(os.homedir(), ".kaizen", "my-plugin", slugify(key));
+  // …
+}
+```
+
+Decide your own fallback when both fields are absent: a sentinel like
+`"default"`, a refusal to persist, or whatever fits your plugin's
+guarantees.
+
 ## Publishing types {#publishing-types}
 
 When your plugin provides a service, consumers need your types at compile time

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -131,6 +131,7 @@ export interface PluginContext {
 
   // --- Config and logging ---
   config: Record<string, unknown>;                        // merged, non-secret
+  harness: HarnessIdentity;                               // raw harness metadata; inner fields optional
   log(msg: string): void;                                 // prefixed with plugin name
   pluginManager: PluginManagerPublicApi;                  // runtime load/unload
 
@@ -171,6 +172,19 @@ Method semantics:
 - `emit` calls all handlers serially in initialization order, returns every
   handler's return value (including `undefined`), and logs-and-continues on
   handler throw. Emitting an undefined event warns but never blocks.
+- `harness` — raw metadata about the harness this plugin was loaded under.
+  The outer field is always present; both inner fields may be absent.
+  Plugins that need to partition on-disk state by harness derive their own
+  namespacing key from these inputs — kaizen does not pick a canonical name.
+  See [`guides/plugin-authoring.md#harness-identity`](../guides/plugin-authoring.md#harness-identity)
+  for the recommended fallback pattern.
+
+```ts
+export interface HarnessIdentity {
+  jsonPath?: string;  // absolute path to the resolved harness JSON
+  ref?: string;       // user's --harness ref or defaults.harness, if any
+}
+```
 
 ### PluginManagerPublicApi / PluginManagerLifecycleApi
 

--- a/docs/superpowers/plans/2026-05-06-harness-identity-on-context.md
+++ b/docs/superpowers/plans/2026-05-06-harness-identity-on-context.md
@@ -1,0 +1,574 @@
+# Harness Identity on PluginContext — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose raw harness metadata (`jsonPath`, `ref`) on `PluginContext` so plugins can derive a stable namespacing key for on-disk state.
+
+**Architecture:** Thread two optional strings (`jsonPath`, `ref`) from `cli.ts` bootstrap through `runHarness` → `initializePluginSystem` → `PluginManager` → `createPluginContext`, surfacing them as `ctx.harness = { jsonPath?, ref? }`. The outer field is always present; inner fields are individually optional. No canonical name derivation in core — plugins manipulate the raw metadata themselves.
+
+**Tech Stack:** TypeScript, Bun (runtime + test runner).
+
+**Spec:** `docs/superpowers/specs/2026-05-06-harness-identity-on-context-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/types/plugin.ts` — add `harness` to `PluginContext` interface
+- `src/core/context.ts` — add parameter to `createPluginContext`, spread onto returned ctx
+- `src/core/plugin-manager.ts` — add trailing optional constructor param, store as private field, forward to `createPluginContext` call
+- `src/core/index.ts` — add `harness?` to `InitializePluginSystemOpts` and `RunHarnessOpts`, forward to `PluginManager` ctor and to the driver's `createPluginContext`
+- `src/cli.ts` — populate `harness` from `resolvedHarnessJsonPath` and `harnessArg` and pass to `runHarness`
+- `docs/guides/plugin-authoring.md` — add "Harness identity" section
+- `docs/concepts/architecture.md` — mention `ctx.harness` if context fields are enumerated
+
+**Create:**
+- `src/core/plugin-manager-harness.test.ts` — integration test that loads a plugin and verifies `ctx.harness` flows from the constructor
+
+No existing files need to be split. The constructor of `PluginManager` is already long; we add a trailing optional param to avoid churning all `new PluginManager(...)` call sites.
+
+---
+
+## Task 1: Failing integration test for `ctx.harness`
+
+**Files:**
+- Create: `src/core/plugin-manager-harness.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/core/plugin-manager-harness.test.ts
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { PluginManager } from "./plugin-manager.js";
+import { EventBus } from "./event-bus.js";
+import { ServiceRegistry } from "./service-registry.js";
+import { PermissionEnforcer } from "./permission-enforcer.js";
+import { AuditLog } from "./audit-log.js";
+
+const createdDirs: string[] = [];
+afterEach(() => {
+  for (const d of createdDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function writeProbePlugin(name: string, bridgeKey: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `kz-pm-harness-${name}-`));
+  createdDirs.push(dir);
+  writeFileSync(join(dir, "package.json"), JSON.stringify({
+    name, version: "1.0.0", type: "module", main: "index.mjs",
+  }));
+  // Capture ctx.harness from setup() AND onReady() into the bridge so the
+  // test can assert both phases see the same metadata.
+  writeFileSync(join(dir, "index.mjs"), `
+export default {
+  name: ${JSON.stringify(name)},
+  apiVersion: "3",
+  driver: true,
+  async setup(ctx) {
+    globalThis[${JSON.stringify(bridgeKey)}].setup = ctx.harness;
+  },
+  async onReady(ctx) {
+    globalThis[${JSON.stringify(bridgeKey)}].onReady = ctx.harness;
+  },
+  async start(ctx) {
+    globalThis[${JSON.stringify(bridgeKey)}].start = ctx.harness;
+  },
+};
+`);
+  return dir;
+}
+
+function makeStubs() {
+  const enforcer = new PermissionEnforcer({ mode: "log-only" });
+  const auditLog = new AuditLog({
+    rootDir: mkdtempSync(join(tmpdir(), "kaizen-test-audit-")),
+    sessionId: "test",
+    enabled: false,
+  });
+  const lockfilePath = join(mkdtempSync(join(tmpdir(), "kaizen-test-lock-")), "permissions.lock");
+  const options = { trustLockfile: false, allowUnscoped: false, nonInteractive: true };
+  return { enforcer, auditLog, lockfilePath, options };
+}
+
+describe("PluginContext.harness", () => {
+  test("populated from PluginManager harness opt", async () => {
+    const bridgeKey = `__kz_harness_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = {};
+    const driverDir = writeProbePlugin("driver", bridgeKey);
+
+    const { enforcer, auditLog, lockfilePath, options } = makeStubs();
+    const manager = new PluginManager(
+      { plugins: [driverDir] },
+      new EventBus(), new ServiceRegistry(),
+      enforcer, auditLog,
+      lockfilePath, options,
+      undefined, // globalConfig
+      { jsonPath: "/abs/path/kaizen.json", ref: "official/openai-compatible@1.2.3" },
+    );
+
+    await manager.initialize();
+
+    const bridge = (globalThis as Record<string, { setup: unknown; onReady: unknown }>)[bridgeKey]!;
+    expect(bridge.setup).toEqual({
+      jsonPath: "/abs/path/kaizen.json",
+      ref: "official/openai-compatible@1.2.3",
+    });
+    expect(bridge.onReady).toEqual(bridge.setup);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
+
+  test("defaults to empty object when no harness opt provided", async () => {
+    const bridgeKey = `__kz_harness_default_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = {};
+    const driverDir = writeProbePlugin("driver", bridgeKey);
+
+    const { enforcer, auditLog, lockfilePath, options } = makeStubs();
+    const manager = new PluginManager(
+      { plugins: [driverDir] },
+      new EventBus(), new ServiceRegistry(),
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+
+    await manager.initialize();
+
+    const bridge = (globalThis as Record<string, { setup: unknown }>)[bridgeKey]!;
+    expect(bridge.setup).toEqual({});
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test src/core/plugin-manager-harness.test.ts`
+Expected: FAIL — TypeScript error or runtime error indicating `PluginManager` constructor takes 8 args but 9 were passed; OR `ctx.harness` is undefined.
+
+**Do not commit yet — the test is allowed to be red until Tasks 2 and 3 land.**
+
+---
+
+## Task 2: Add `harness` field to `PluginContext` and `createPluginContext`
+
+**Files:**
+- Modify: `src/types/plugin.ts` (PluginContext interface)
+- Modify: `src/core/context.ts:15-79`
+
+- [ ] **Step 1: Add `harness` field to the `PluginContext` interface**
+
+In `src/types/plugin.ts`, find the `interface PluginContext { ... }` block (starts near line 83). Add the following field. Place it adjacent to `config` (the other static-metadata field) for readability:
+
+```ts
+  /**
+   * Raw metadata about the harness this plugin was loaded under. Both inner
+   * fields may be absent (e.g. programmatic `runHarness()` without a file on
+   * disk, or `kaizen` invoked from a directory containing `kaizen.json` with
+   * no `--harness` ref). Kaizen does not derive a canonical `name`. Plugins
+   * that need a stable namespacing key derive one from these inputs themselves
+   * — typically by preferring `jsonPath` over `ref` and falling back to a
+   * literal default when both are absent.
+   */
+  harness: {
+    /** Absolute path to the resolved harness JSON, if bootstrapped from a file. */
+    jsonPath?: string;
+    /** The ref the user passed (`--harness <ref>` or `defaults.harness`), if any. */
+    ref?: string;
+  };
+```
+
+- [ ] **Step 2: Add parameter and spread to `createPluginContext`**
+
+In `src/core/context.ts`, modify the `createPluginContext` signature and return value:
+
+```ts
+export function createPluginContext(
+  pluginName: string,
+  pluginConfig: Record<string, unknown>,
+  secretsContext: SecretsContext,
+  eventBus: EventBus,
+  serviceRegistry: ServiceRegistry,
+  enforcer: PermissionEnforcer,
+  getState: () => CoreState,
+  pluginManagerPublicApi: PluginManagerPublicApi,
+  pluginManagerLifecycleApi: PluginManagerLifecycleApi,
+  harness: { jsonPath?: string; ref?: string } = {},
+): PluginContext {
+  const io = createCtxIo(pluginName, enforcer);
+  return {
+    config: pluginConfig,
+    harness,
+
+    log(msg: string): void {
+      console.log(`[${pluginName}] ${msg}`);
+    },
+    // ...rest unchanged...
+```
+
+The `harness` parameter is the new last argument with a default of `{}`. Spread the field onto the returned object via `harness,` (one line under `config`).
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run build` (or `bunx tsc --noEmit` if a typecheck-only script exists)
+Expected: PASS — no callers of `createPluginContext` are broken because the new param is optional.
+
+---
+
+## Task 3: Thread `harness` through `PluginManager`
+
+**Files:**
+- Modify: `src/core/plugin-manager.ts:329-341` (constructor) and `:731` (`createPluginContext` call)
+
+- [ ] **Step 1: Add constructor parameter and forward**
+
+In `src/core/plugin-manager.ts`, modify the constructor (around `:329`) to add a trailing optional parameter. Place it after `globalConfig?` so existing call sites that pass 8 args still work:
+
+```ts
+  constructor(
+    private readonly config: KaizenConfig,
+    private readonly eventBus: EventBus,
+    private readonly serviceRegistry: ServiceRegistry,
+    private readonly enforcer: PermissionEnforcer,
+    private readonly auditLog: AuditLog,
+    private readonly lockfilePath: string,
+    private readonly options: { trustLockfile: boolean; allowUnscoped: boolean; nonInteractive: boolean },
+    private readonly globalConfig?: KaizenGlobalConfig,
+    private readonly harness: { jsonPath?: string; ref?: string } = {},
+  ) {
+    // Wire denial listener → audit log.
+    this.enforcer.onDenial((r) => this.auditLog.record(r));
+  }
+```
+
+- [ ] **Step 2: Forward `this.harness` to `createPluginContext`**
+
+In `src/core/plugin-manager.ts`, find the `createPluginContext(...)` call (around `:731`) and add `this.harness` as the trailing argument:
+
+```ts
+    const ctx = createPluginContext(
+      plugin.name,
+      pluginConfig,
+      secretsCtx,
+      this.eventBus,
+      this.serviceRegistry,
+      this.enforcer,
+      () => stateRef.current,
+      this.getPublicApi(),
+      this.getLifecycleApi(),
+      this.harness,
+    );
+```
+
+- [ ] **Step 3: Run the Task 1 test to verify the populated case passes**
+
+Run: `bun test src/core/plugin-manager-harness.test.ts`
+Expected: BOTH tests PASS.
+
+- [ ] **Step 4: Run the broader test suite**
+
+Run: `bun test src/core/`
+Expected: PASS. Existing `new PluginManager(...)` sites omit the new param; the default `{}` keeps them green.
+
+- [ ] **Step 5: Commit Tasks 1, 2, 3 together**
+
+```bash
+git add \
+  src/types/plugin.ts \
+  src/core/context.ts \
+  src/core/plugin-manager.ts \
+  src/core/plugin-manager-harness.test.ts
+git commit -m "feat(plugin-manager): expose ctx.harness with jsonPath and ref"
+```
+
+---
+
+## Task 4: Thread `harness` through `runHarness` / `initializePluginSystem`
+
+**Files:**
+- Modify: `src/core/index.ts` (opts types, `initializePluginSystem`, `runHarness`)
+- Modify: `src/core/plugin-manager-harness.test.ts` (add a `runHarness`-level test)
+
+- [ ] **Step 1: Add a failing test that drives `runHarness` and asserts `ctx.harness`**
+
+Append the following test to `src/core/plugin-manager-harness.test.ts` inside the existing `describe("PluginContext.harness", ...)` block:
+
+```ts
+  test("runHarness forwards harness opt to driver ctx", async () => {
+    const { runHarness } = await import("./index.js");
+    const bridgeKey = `__kz_harness_runharness_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = {};
+    const driverDir = writeProbePlugin("driver", bridgeKey);
+
+    const lockfilePath = join(
+      mkdtempSync(join(tmpdir(), "kaizen-test-lock-")),
+      "permissions.lock",
+    );
+
+    await runHarness({
+      kaizenConfig: { plugins: [driverDir] },
+      lockfilePath,
+      enforcer: new PermissionEnforcer({ mode: "log-only" }),
+      harness: { jsonPath: "/abs/path/kaizen.json", ref: "x/y@1.0.0" },
+    });
+
+    const bridge = (globalThis as Record<string, { start: unknown }>)[bridgeKey]!;
+    expect(bridge.start).toEqual({
+      jsonPath: "/abs/path/kaizen.json",
+      ref: "x/y@1.0.0",
+    });
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
+```
+
+Run: `bun test src/core/plugin-manager-harness.test.ts`
+Expected: FAIL — `runHarness` doesn't accept a `harness` opt yet (TypeScript error), or `ctx.harness` in the driver `start()` is `{}`.
+
+- [ ] **Step 2: Extend opts types and forward in `src/core/index.ts`**
+
+Modify `InitializePluginSystemOpts` and `RunHarnessOpts`:
+
+```ts
+export interface InitializePluginSystemOpts {
+  lockfilePath: string;
+  injectedEnforcer?: PermissionEnforcer;
+  harness?: { jsonPath?: string; ref?: string };
+}
+```
+
+```ts
+export interface RunHarnessOpts {
+  kaizenConfig: KaizenConfig;
+  lockfilePath: string;
+  enforcer?: PermissionEnforcer;
+  harness?: { jsonPath?: string; ref?: string };
+}
+```
+
+Update `initializePluginSystem` to accept and forward:
+
+```ts
+export async function initializePluginSystem(
+  kaizenConfig: KaizenConfig,
+  opts: InitializePluginSystemOpts,
+): Promise<InitializedSystem> {
+  const { lockfilePath, injectedEnforcer, harness = {} } = opts;
+  // ...existing eventBus/serviceRegistry/enforcer/auditLog setup unchanged...
+
+  const manager = new PluginManager(
+    kaizenConfig,
+    eventBus, serviceRegistry,
+    enforcer, auditLog,
+    lockfilePath, { trustLockfile, allowUnscoped, nonInteractive },
+    undefined, // globalConfig
+    harness,
+  );
+  const { driver } = await manager.initialize();
+  return {
+    manager, eventBus, serviceRegistry,
+    enforcer, auditLog, driver,
+  };
+}
+```
+
+Update `runHarness` to forward `harness` into `initializePluginSystem` and into the driver's `createPluginContext` call (around `:97`):
+
+```ts
+export async function runHarness(opts: RunHarnessOpts): Promise<void> {
+  const { kaizenConfig, lockfilePath, enforcer: injectedEnforcer, harness = {} } = opts;
+  const init: InitializePluginSystemOpts = {
+    lockfilePath,
+    harness,
+    ...(injectedEnforcer !== undefined ? { injectedEnforcer } : {}),
+  };
+  const {
+    manager, eventBus, serviceRegistry, enforcer, auditLog, driver,
+  } = await initializePluginSystem(kaizenConfig, init);
+
+  const driverConfig =
+    (kaizenConfig[driver.name] as Record<string, unknown> | undefined) ?? {};
+  const secretsCtx = createSecretsContext(new SecretsRegistry(), driver.name, {});
+  const ctx = createPluginContext(
+    driver.name, driverConfig, secretsCtx, eventBus, serviceRegistry,
+    enforcer, () => "RUNNING", manager.getPublicApi(), manager.getLifecycleApi(),
+    harness,
+  );
+
+  try {
+    await runInPluginScope(driver.name, async () => { await driver.start!(ctx); });
+  } finally {
+    try { await manager.unloadAll(); } catch (err) {
+      console.error("[kaizen] error during plugin teardown:", err);
+    }
+    await auditLog.flush();
+  }
+}
+```
+
+- [ ] **Step 3: Run the new test to verify it passes**
+
+Run: `bun test src/core/plugin-manager-harness.test.ts`
+Expected: ALL three tests PASS.
+
+- [ ] **Step 4: Run the broader test suite**
+
+Run: `bun test src/core/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/index.ts src/core/plugin-manager-harness.test.ts
+git commit -m "feat(core): forward harness opt through runHarness and initializePluginSystem"
+```
+
+---
+
+## Task 5: Wire `harness` from `cli.ts` bootstrap
+
+**Files:**
+- Modify: `src/cli.ts:410-440` (or wherever `runHarness`/`initializePluginSystem` is invoked from the main run path)
+
+- [ ] **Step 1: Locate the main `runHarness` invocation**
+
+Search:
+
+```bash
+grep -n "runHarness\|initializePluginSystem" src/cli.ts
+```
+
+Identify the call site that drives the harness for the default `kaizen` / `kaizen run` path. The plugin subcommand path (`consent`, `review`, `audit`) does not currently call `runHarness`; leave it alone.
+
+- [ ] **Step 2: Build the `harness` object from already-resolved values and pass it through**
+
+The bootstrap already computes `resolvedHarnessJsonPath` and knows `harnessArg` (the raw user-supplied `--harness` value or `defaults.harness`). At the call site, build:
+
+```ts
+const harness: { jsonPath?: string; ref?: string } = {};
+if (resolvedHarnessJsonPath) harness.jsonPath = resolvedHarnessJsonPath;
+if (harnessArg) harness.ref = harnessArg;
+
+await runHarness({
+  kaizenConfig: resolvedHarnessConfig!,
+  lockfilePath,
+  harness,
+});
+```
+
+If `runHarness` is called via a different shape in the actual code, preserve that shape and add `harness` alongside the existing options.
+
+If `harnessArg` is not in scope at the call site (it's resolved earlier inside an `if (needsHarness)` block at `:410-428`), hoist its declaration so it survives to the call site, or move the `harness` object construction up next to where the values are resolved.
+
+- [ ] **Step 3: Typecheck and run all tests**
+
+Run: `bun run build`
+Expected: PASS.
+
+Run: `bun test`
+Expected: PASS — no test regressions.
+
+- [ ] **Step 4: Manual smoke test**
+
+Build kaizen and run a sample harness with a temporary probe plugin (or against an existing harness in your dev tree). One way:
+
+```bash
+# In a temp dir with a kaizen.json that loads any plugin with a setup() that logs ctx.harness
+bun run /path/to/kaizen/dist/cli.js --harness official/<some-harness>@<some-version>
+# Expected: ctx.harness logged as { jsonPath: "<absolute path>", ref: "official/<some-harness>@<some-version>" }
+
+# Without --harness, from a directory with a local kaizen.json
+bun run /path/to/kaizen/dist/cli.js
+# Expected: ctx.harness logged as { jsonPath: "<absolute path>" } (no `ref`)
+```
+
+If you don't have a probe plugin handy, skip the smoke test and rely on Task 4's `runHarness` test plus a manual diff review of `cli.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.ts
+git commit -m "feat(cli): populate ctx.harness from bootstrap-resolved jsonPath and ref"
+```
+
+---
+
+## Task 6: Documentation
+
+**Files:**
+- Modify: `docs/guides/plugin-authoring.md`
+- Modify: `docs/concepts/architecture.md` (if it enumerates `PluginContext` fields)
+
+- [ ] **Step 1: Add "Harness identity" section to plugin-authoring.md**
+
+Open `docs/guides/plugin-authoring.md`. Add the following section. Place it near other context-related guidance (e.g. after the `onReady` section or alongside the discussion of `ctx.config`):
+
+````markdown
+### Harness identity {#harness-identity}
+
+Plugins that persist state to disk often need to partition that state by
+harness — otherwise data captured under harness A (with plugins X, Y, Z)
+can be silently loaded under harness B with a different plugin set,
+producing missing tools or mismatched message shapes.
+
+`ctx.harness` exposes raw metadata about the harness the plugin is loaded
+under:
+
+```ts
+ctx.harness.jsonPath  // absolute path to the resolved harness JSON, or undefined
+ctx.harness.ref       // the user's --harness ref / defaults.harness value, or undefined
+```
+
+Both inner fields may be absent — `kaizen` invoked from a directory
+containing `kaizen.json` (no `--harness`) will populate `jsonPath` only;
+programmatic `runHarness()` calls may populate neither. Kaizen does not
+derive a canonical "name" — plugins choose their own namespacing rule.
+
+A typical pattern:
+
+```ts
+async setup(ctx) {
+  const key =
+    ctx.harness.jsonPath ??
+    ctx.harness.ref ??
+    "default";
+  const stateDir = path.join(os.homedir(), ".kaizen", "my-plugin", slugify(key));
+  // …
+}
+```
+
+Decide your own fallback when both fields are absent: a sentinel like
+`"default"`, a refusal to persist, or whatever fits your plugin's
+guarantees.
+````
+
+- [ ] **Step 2: Update PluginContext doc comment in `src/types/plugin.ts` if it has a top-level summary**
+
+The interface comment block above `PluginContext` (around `:82`) — if it lists fields, add a one-line mention of `harness`. The per-field doc on `harness` itself (added in Task 2) is already authoritative; this is just for the table-of-contents-style summary if one exists.
+
+- [ ] **Step 3: Update architecture.md if it enumerates ctx fields**
+
+```bash
+grep -n "PluginContext\|ctx\." docs/concepts/architecture.md | head -30
+```
+
+If the file has a section listing context fields (e.g. config, fs, net, secrets, exec), add `harness` to that list with a one-sentence description ("raw harness metadata; see plugin-authoring.md#harness-identity"). If it has no such enumeration, skip this step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guides/plugin-authoring.md src/types/plugin.ts docs/concepts/architecture.md 2>/dev/null
+git commit -m "docs: document ctx.harness for plugin authors"
+```
+
+(`git add` of `architecture.md` is a no-op if the file wasn't modified; that's fine.)
+
+---
+
+## Self-review checklist (run after all tasks complete)
+
+- [ ] All three tests in `plugin-manager-harness.test.ts` pass.
+- [ ] `bun test` runs clean across the whole repo.
+- [ ] `bun run build` typechecks.
+- [ ] `git log --oneline -6` shows four feature/docs commits in the expected order.
+- [ ] Manual smoke (Task 5 Step 4) produced the expected `ctx.harness` shape both with and without `--harness`.

--- a/docs/superpowers/specs/2026-05-06-harness-identity-on-context-design.md
+++ b/docs/superpowers/specs/2026-05-06-harness-identity-on-context-design.md
@@ -1,0 +1,173 @@
+# Harness identity on PluginContext
+
+## Context
+
+Plugins have no way to know which harness they're loaded under. The bootstrap
+code in `src/cli.ts:410-428` resolves the harness ref and the absolute path to
+the harness JSON, but neither value flows into `PluginContext`
+(`src/types/plugin.ts`, `src/core/context.ts`).
+
+This matters for any plugin that persists state to disk and needs to partition
+that state by harness — otherwise data captured under harness A (with plugins
+X, Y, Z) can be silently loaded under harness B (with a different plugin set),
+producing missing tools, mismatched message shapes, etc.
+
+The motivating case is a forthcoming `llm-session-manager` plugin that owns
+conversation persistence at `~/.kaizen/sessions/<harness>/<session-id>/...`.
+Without a harness identifier exposed at runtime, it can't safely partition.
+
+GitHub issue: <https://github.com/CraightonH/kaizen/issues/74>.
+
+## Design principle
+
+Kaizen exposes **raw bootstrap metadata only** — no canonical `name`, no
+derived slug, no policy. Plugins manipulate the raw inputs to produce whatever
+namespacing key they want (basename, hash, ref-without-version, content hash
+of the JSON, etc.).
+
+This is consistent with kaizen's stated stance of mechanism over policy:
+the harness identity contract is "here is what we know," not "here is what
+you should call it."
+
+## API addition
+
+A new `harness` field on `PluginContext`:
+
+```ts
+// src/types/plugin.ts (inside interface PluginContext)
+
+/**
+ * Raw metadata about the harness this plugin was loaded under. Both inner
+ * fields may be absent (e.g. programmatic `runHarness()` without a file on
+ * disk, or `kaizen` invoked from a directory containing `kaizen.json` with
+ * no `--harness` ref).
+ *
+ * Kaizen does not derive a canonical `name`. Plugins that need a stable
+ * namespacing key derive one from these inputs themselves — typically by
+ * preferring `jsonPath` over `ref` and falling back to a literal default
+ * when both are absent.
+ */
+harness: {
+  /** Absolute path to the resolved harness JSON, if bootstrapped from a file. */
+  jsonPath?: string;
+  /** The ref the user passed (`--harness <ref>` or `defaults.harness`), if any. */
+  ref?: string;
+};
+```
+
+The outer `harness` field is **always present**. The inner fields are
+individually optional. This keeps the common path (`ctx.harness.jsonPath`)
+ceremony-free; plugins only have to deal with `undefined` on the leaves.
+
+No permission gate. This is static metadata, parallel in spirit to
+`ctx.config`.
+
+## Plumbing
+
+The harness metadata is threaded through the existing bootstrap path. No new
+module-level state, no globals.
+
+### Call graph
+
+```
+cli.ts (resolves harnessArg + resolvedHarnessJsonPath)
+  └─> runHarness({ kaizenConfig, lockfilePath, harness })
+        └─> initializePluginSystem(kaizenConfig, { lockfilePath, harness })
+              └─> new PluginManager(..., harness)
+                    └─> createPluginContext(..., harness)   // every call site
+```
+
+### Files to change
+
+**`src/types/plugin.ts`**
+- Add the `harness` field to `PluginContext` (see API above).
+
+**`src/core/context.ts`**
+- `createPluginContext()` gains a new parameter `harness: { jsonPath?: string; ref?: string }`.
+- Spread `{ harness }` onto the returned object.
+
+**`src/core/plugin-manager.ts`**
+- Constructor (`:329`) gains a new parameter `harness: { jsonPath?: string; ref?: string }`, stored as `private readonly harness`.
+- The single `createPluginContext()` call site at `:731` passes `this.harness`. (Reload paths route back through this same builder, so no other call sites need updating.)
+
+**`src/core/index.ts`**
+- `InitializePluginSystemOpts` gains `harness?: { jsonPath?: string; ref?: string }`.
+- `RunHarnessOpts` gains `harness?: { jsonPath?: string; ref?: string }`.
+- Default to `{}` when not provided.
+- Pass through to `new PluginManager(...)` and to the driver's `createPluginContext(...)` call (`:97`).
+
+**`src/cli.ts`**
+- After computing `resolvedHarnessJsonPath` and `harnessArg` (`:410-428`),
+  build `harness = { jsonPath: resolvedHarnessJsonPath, ref: harnessArg }`
+  (omit fields that are empty/undefined).
+- Forward `harness` into the `runHarness` / `initializePluginSystem` call.
+- The plugin subcommand path (`consent`, `review`, `audit`) also resolves
+  `resolvedHarnessJsonPath` (`cli.ts:434-435` and adjacent dispatch sites)
+  but does not currently drive the plugin lifecycle through `runHarness`.
+  No change needed there for this spec — but if any of those paths gain
+  plugin-loading behavior later, they must thread `harness` through too.
+
+### Behavior when nothing is known
+
+- Programmatic `runHarness({ kaizenConfig, lockfilePath })` with no `harness`
+  opt → `ctx.harness === {}`.
+- `kaizen` invoked from a directory with `kaizen.json` and no `--harness` →
+  `ctx.harness === { jsonPath: "<absolute path>" }` (no `ref`).
+- `kaizen --harness official/openai-compatible@1.2.3` → both fields populated.
+
+## Tests
+
+**`src/core/context.test.ts`** (or new `harness-identity.test.ts`)
+- `createPluginContext` with `harness: { jsonPath: "/x", ref: "y" }` exposes both.
+- `createPluginContext` with `harness: {}` exposes `ctx.harness === {}`.
+
+**`src/core/plugin-manager-harness.test.ts`** (new, modeled on `plugin-manager-onready.test.ts`)
+- A plugin reads `ctx.harness.jsonPath` in `setup()`, `onReady()`, and (as the
+  driver) `start()`; assert identical values across all three phases.
+- A plugin loaded under no-harness conditions sees `ctx.harness === {}`.
+
+**Bootstrap-level coverage** (`src/cli.test.ts` if it exists, otherwise the
+nearest integration harness)
+- Driving `kaizen` with `--harness <ref>` populates both fields.
+- Driving `kaizen` from a cwd with `kaizen.json` and no `--harness` populates
+  `jsonPath` only.
+
+## Documentation
+
+- Update the `PluginContext` doc comment in `src/types/plugin.ts` to mention
+  `harness`.
+- Add a short "Harness identity" section to `docs/guides/plugin-authoring.md`
+  showing the canonical derivation pattern:
+
+  ```ts
+  const key =
+    ctx.harness.jsonPath ??
+    ctx.harness.ref ??
+    "default";
+  // namespacing key for on-disk state
+  ```
+
+  Be explicit that **both inner fields may be absent** and the plugin owns
+  the fallback decision (refuse to persist, use a sentinel, etc.).
+
+- Update `docs/concepts/architecture.md` if it enumerates `PluginContext`
+  fields elsewhere.
+
+## Out of scope
+
+- Exposing the full resolved `KaizenConfig` (e.g. for plugins that want to
+  namespace by `extends` chain). YAGNI; can be added later as a separate
+  field if a real plugin needs it.
+- Any "canonical name" derivation in core. Plugins do this themselves.
+- Permission-gating `ctx.harness`. It is static metadata; no I/O.
+
+## Verification
+
+Run end to end:
+
+1. `bun test src/core/context.test.ts src/core/plugin-manager-harness.test.ts` — unit + integration cover the field plumbing.
+2. `bun run build` — type changes compile cleanly.
+3. Manual: in a sample harness, add a plugin whose `setup()` logs
+   `ctx.harness`. Run `kaizen --harness official/<x>@<v>`; confirm both
+   fields are populated. Run `kaizen` from a directory with a local
+   `kaizen.json`; confirm only `jsonPath` is populated.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -646,6 +646,9 @@ if (harnessArg === undefined) {
   harnessArg = globalCfgForHarness.defaults?.harness;
 }
 
+// Capture the user-facing ref BEFORE materialization replaces it with a path.
+const harnessRef = harnessArg;
+
 // Materialize a marketplace-ref --harness to a concrete path.
 if (harnessArg !== undefined && looksLikeHarnessRef(harnessArg)) {
   harnessArg = await materializeHarnessRef(harnessArg);
@@ -688,4 +691,8 @@ if (parsed.prompt) {
   }
 }
 
-await bootstrap(kaizenConfig, lockfilePath);
+const harness: import("./types/plugin.js").HarnessIdentity = {};
+if (harnessJsonPath) harness.jsonPath = harnessJsonPath;
+if (harnessRef !== undefined) harness.ref = harnessRef;
+
+await bootstrap(kaizenConfig, lockfilePath, harness);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { bootstrap } from "./core/index.js";
+import type { HarnessIdentity } from "./types/plugin.js";
 import { resolveHarnessOrFatal, KAIZEN_HOME, KAIZEN_HOME_CONFIG } from "./core/config.js";
 import { loadKaizenGlobalConfig, kaizenHome, kaizenHomeConfigPath } from "./core/kaizen-config.js";
 import { fatal, warn } from "./core/errors.js";
@@ -691,7 +692,7 @@ if (parsed.prompt) {
   }
 }
 
-const harness: import("./types/plugin.js").HarnessIdentity = {};
+const harness: HarnessIdentity = {};
 if (harnessJsonPath) harness.jsonPath = harnessJsonPath;
 if (harnessRef !== undefined) harness.ref = harnessRef;
 

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -22,10 +22,12 @@ export function createPluginContext(
   getState: () => CoreState,
   pluginManagerPublicApi: PluginManagerPublicApi,
   pluginManagerLifecycleApi: PluginManagerLifecycleApi,
+  harness: { jsonPath?: string; ref?: string } = {},
 ): PluginContext {
   const io = createCtxIo(pluginName, enforcer);
   return {
     config: pluginConfig,
+    harness,
 
     log(msg: string): void {
       console.log(`[${pluginName}] ${msg}`);

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,4 +1,4 @@
-import type { PluginContext, PluginManagerPublicApi, PluginManagerLifecycleApi, SecretsContext } from "../types/plugin.js";
+import type { PluginContext, PluginManagerPublicApi, PluginManagerLifecycleApi, SecretsContext, HarnessIdentity } from "../types/plugin.js";
 import type { EventBus } from "./event-bus.js";
 import type { ServiceRegistry } from "./service-registry.js";
 import type { PermissionEnforcer } from "./permission-enforcer.js";
@@ -22,7 +22,7 @@ export function createPluginContext(
   getState: () => CoreState,
   pluginManagerPublicApi: PluginManagerPublicApi,
   pluginManagerLifecycleApi: PluginManagerLifecycleApi,
-  harness: { jsonPath?: string; ref?: string } = {},
+  harness: HarnessIdentity = {},
 ): PluginContext {
   const io = createCtxIo(pluginName, enforcer);
   return {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -115,8 +115,12 @@ export async function runHarness(opts: RunHarnessOpts): Promise<void> {
   }
 }
 
-export async function bootstrap(kaizenConfig: KaizenConfig, lockfilePath: string): Promise<void> {
-  return runHarness({ kaizenConfig, lockfilePath });
+export async function bootstrap(
+  kaizenConfig: KaizenConfig,
+  lockfilePath: string,
+  harness: HarnessIdentity = {},
+): Promise<void> {
+  return runHarness({ kaizenConfig, lockfilePath, harness });
 }
 
 /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import { randomUUID } from "crypto";
-import type { KaizenConfig } from "../types/plugin.js";
+import type { KaizenConfig, HarnessIdentity } from "../types/plugin.js";
 import { EventBus } from "./event-bus.js";
 import { ServiceRegistry } from "./service-registry.js";
 import { PluginManager } from "./plugin-manager.js";
@@ -33,13 +33,14 @@ interface InitializedSystem {
 export interface InitializePluginSystemOpts {
   lockfilePath: string;
   injectedEnforcer?: PermissionEnforcer;
+  harness?: HarnessIdentity;
 }
 
 export async function initializePluginSystem(
   kaizenConfig: KaizenConfig,
   opts: InitializePluginSystemOpts,
 ): Promise<InitializedSystem> {
-  const { lockfilePath, injectedEnforcer } = opts;
+  const { lockfilePath, injectedEnforcer, harness = {} } = opts;
   const eventBus = new EventBus();
   const serviceRegistry = new ServiceRegistry();
 
@@ -67,6 +68,8 @@ export async function initializePluginSystem(
     eventBus, serviceRegistry,
     enforcer, auditLog,
     lockfilePath, { trustLockfile, allowUnscoped, nonInteractive },
+    undefined, // globalConfig
+    harness,
   );
   const { driver } = await manager.initialize();
   return {
@@ -79,12 +82,14 @@ export interface RunHarnessOpts {
   kaizenConfig: KaizenConfig;
   lockfilePath: string;
   enforcer?: PermissionEnforcer;
+  harness?: HarnessIdentity;
 }
 
 export async function runHarness(opts: RunHarnessOpts): Promise<void> {
-  const { kaizenConfig, lockfilePath, enforcer: injectedEnforcer } = opts;
+  const { kaizenConfig, lockfilePath, enforcer: injectedEnforcer, harness = {} } = opts;
   const init: InitializePluginSystemOpts = {
     lockfilePath,
+    harness,
     ...(injectedEnforcer !== undefined ? { injectedEnforcer } : {}),
   };
   const {
@@ -97,6 +102,7 @@ export async function runHarness(opts: RunHarnessOpts): Promise<void> {
   const ctx = createPluginContext(
     driver.name, driverConfig, secretsCtx, eventBus, serviceRegistry,
     enforcer, () => "RUNNING", manager.getPublicApi(), manager.getLifecycleApi(),
+    harness,
   );
 
   try {

--- a/src/core/plugin-manager-harness.test.ts
+++ b/src/core/plugin-manager-harness.test.ts
@@ -70,7 +70,7 @@ describe("PluginContext.harness", () => {
 
     await manager.initialize();
 
-    const bridge = (globalThis as Record<string, { setup: unknown; onReady: unknown }>)[bridgeKey]!;
+    const bridge = (globalThis as unknown as Record<string, { setup: unknown; onReady: unknown }>)[bridgeKey]!;
     expect(bridge.setup).toEqual({
       jsonPath: "/abs/path/kaizen.json",
       ref: "official/openai-compatible@1.2.3",
@@ -94,7 +94,7 @@ describe("PluginContext.harness", () => {
 
     await manager.initialize();
 
-    const bridge = (globalThis as Record<string, { setup: unknown }>)[bridgeKey]!;
+    const bridge = (globalThis as unknown as Record<string, { setup: unknown }>)[bridgeKey]!;
     expect(bridge.setup).toEqual({});
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
@@ -118,7 +118,7 @@ describe("PluginContext.harness", () => {
       harness: expected,
     });
 
-    const bridge = (globalThis as Record<string, { setup: unknown; onReady: unknown; start: unknown }>)[bridgeKey]!;
+    const bridge = (globalThis as unknown as Record<string, { setup: unknown; onReady: unknown; start: unknown }>)[bridgeKey]!;
     expect(bridge.setup).toEqual(expected);
     expect(bridge.onReady).toEqual(expected);
     expect(bridge.start).toEqual(expected);

--- a/src/core/plugin-manager-harness.test.ts
+++ b/src/core/plugin-manager-harness.test.ts
@@ -1,0 +1,100 @@
+// src/core/plugin-manager-harness.test.ts
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { PluginManager } from "./plugin-manager.js";
+import { EventBus } from "./event-bus.js";
+import { ServiceRegistry } from "./service-registry.js";
+import { PermissionEnforcer } from "./permission-enforcer.js";
+import { AuditLog } from "./audit-log.js";
+
+const createdDirs: string[] = [];
+afterEach(() => {
+  for (const d of createdDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function writeProbePlugin(name: string, bridgeKey: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `kz-pm-harness-${name}-`));
+  createdDirs.push(dir);
+  writeFileSync(join(dir, "package.json"), JSON.stringify({
+    name, version: "1.0.0", type: "module", main: "index.mjs",
+  }));
+  writeFileSync(join(dir, "index.mjs"), `
+export default {
+  name: ${JSON.stringify(name)},
+  apiVersion: "3",
+  driver: true,
+  async setup(ctx) {
+    globalThis[${JSON.stringify(bridgeKey)}].setup = ctx.harness;
+  },
+  async onReady(ctx) {
+    globalThis[${JSON.stringify(bridgeKey)}].onReady = ctx.harness;
+  },
+  async start(ctx) {
+    globalThis[${JSON.stringify(bridgeKey)}].start = ctx.harness;
+  },
+};
+`);
+  return dir;
+}
+
+function makeStubs() {
+  const enforcer = new PermissionEnforcer({ mode: "log-only" });
+  const auditLog = new AuditLog({
+    rootDir: mkdtempSync(join(tmpdir(), "kaizen-test-audit-")),
+    sessionId: "test",
+    enabled: false,
+  });
+  const lockfilePath = join(mkdtempSync(join(tmpdir(), "kaizen-test-lock-")), "permissions.lock");
+  const options = { trustLockfile: false, allowUnscoped: false, nonInteractive: true };
+  return { enforcer, auditLog, lockfilePath, options };
+}
+
+describe("PluginContext.harness", () => {
+  test("populated from PluginManager harness opt", async () => {
+    const bridgeKey = `__kz_harness_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = {};
+    const driverDir = writeProbePlugin("driver", bridgeKey);
+
+    const { enforcer, auditLog, lockfilePath, options } = makeStubs();
+    const manager = new PluginManager(
+      { plugins: [driverDir] },
+      new EventBus(), new ServiceRegistry(),
+      enforcer, auditLog,
+      lockfilePath, options,
+      undefined, // globalConfig
+      { jsonPath: "/abs/path/kaizen.json", ref: "official/openai-compatible@1.2.3" },
+    );
+
+    await manager.initialize();
+
+    const bridge = (globalThis as Record<string, { setup: unknown; onReady: unknown }>)[bridgeKey]!;
+    expect(bridge.setup).toEqual({
+      jsonPath: "/abs/path/kaizen.json",
+      ref: "official/openai-compatible@1.2.3",
+    });
+    expect(bridge.onReady).toEqual(bridge.setup);
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
+
+  test("defaults to empty object when no harness opt provided", async () => {
+    const bridgeKey = `__kz_harness_default_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = {};
+    const driverDir = writeProbePlugin("driver", bridgeKey);
+
+    const { enforcer, auditLog, lockfilePath, options } = makeStubs();
+    const manager = new PluginManager(
+      { plugins: [driverDir] },
+      new EventBus(), new ServiceRegistry(),
+      enforcer, auditLog,
+      lockfilePath, options,
+    );
+
+    await manager.initialize();
+
+    const bridge = (globalThis as Record<string, { setup: unknown }>)[bridgeKey]!;
+    expect(bridge.setup).toEqual({});
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
+});

--- a/src/core/plugin-manager-harness.test.ts
+++ b/src/core/plugin-manager-harness.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { PluginManager } from "./plugin-manager.js";
+import { runHarness } from "./index.js";
 import { EventBus } from "./event-bus.js";
 import { ServiceRegistry } from "./service-registry.js";
 import { PermissionEnforcer } from "./permission-enforcer.js";
@@ -98,9 +99,8 @@ describe("PluginContext.harness", () => {
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 
-  test("runHarness forwards harness opt to driver ctx", async () => {
-    const { runHarness } = await import("./index.js");
-    const bridgeKey = `__kz_harness_runharness_${Date.now()}_${Math.random()}__`;
+  test("runHarness forwards harness opt across all lifecycle phases", async () => {
+    const bridgeKey = `__kz_harness_e2e_${Date.now()}_${Math.random()}__`;
     (globalThis as Record<string, unknown>)[bridgeKey] = {};
     const driverDir = writeProbePlugin("driver", bridgeKey);
 
@@ -109,18 +109,19 @@ describe("PluginContext.harness", () => {
       "permissions.lock",
     );
 
+    const expected = { jsonPath: "/abs/path/kaizen.json", ref: "x/y@1.0.0" };
+
     await runHarness({
       kaizenConfig: { plugins: [driverDir] },
       lockfilePath,
       enforcer: new PermissionEnforcer({ mode: "log-only" }),
-      harness: { jsonPath: "/abs/path/kaizen.json", ref: "x/y@1.0.0" },
+      harness: expected,
     });
 
-    const bridge = (globalThis as Record<string, { start: unknown }>)[bridgeKey]!;
-    expect(bridge.start).toEqual({
-      jsonPath: "/abs/path/kaizen.json",
-      ref: "x/y@1.0.0",
-    });
+    const bridge = (globalThis as Record<string, { setup: unknown; onReady: unknown; start: unknown }>)[bridgeKey]!;
+    expect(bridge.setup).toEqual(expected);
+    expect(bridge.onReady).toEqual(expected);
+    expect(bridge.start).toEqual(expected);
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
 });

--- a/src/core/plugin-manager-harness.test.ts
+++ b/src/core/plugin-manager-harness.test.ts
@@ -97,4 +97,30 @@ describe("PluginContext.harness", () => {
     expect(bridge.setup).toEqual({});
     delete (globalThis as Record<string, unknown>)[bridgeKey];
   });
+
+  test("runHarness forwards harness opt to driver ctx", async () => {
+    const { runHarness } = await import("./index.js");
+    const bridgeKey = `__kz_harness_runharness_${Date.now()}_${Math.random()}__`;
+    (globalThis as Record<string, unknown>)[bridgeKey] = {};
+    const driverDir = writeProbePlugin("driver", bridgeKey);
+
+    const lockfilePath = join(
+      mkdtempSync(join(tmpdir(), "kaizen-test-lock-")),
+      "permissions.lock",
+    );
+
+    await runHarness({
+      kaizenConfig: { plugins: [driverDir] },
+      lockfilePath,
+      enforcer: new PermissionEnforcer({ mode: "log-only" }),
+      harness: { jsonPath: "/abs/path/kaizen.json", ref: "x/y@1.0.0" },
+    });
+
+    const bridge = (globalThis as Record<string, { start: unknown }>)[bridgeKey]!;
+    expect(bridge.start).toEqual({
+      jsonPath: "/abs/path/kaizen.json",
+      ref: "x/y@1.0.0",
+    });
+    delete (globalThis as Record<string, unknown>)[bridgeKey];
+  });
 });

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, statSync } from "fs";
 import { dirname, join } from "path";
 import { pathToFileURL } from "url";
-import type { KaizenPlugin, KaizenConfig, KaizenGlobalConfig, PluginEntry, PluginManagerPublicApi, PluginManagerLifecycleApi, PluginContext } from "../types/plugin.js";
+import type { KaizenPlugin, KaizenConfig, KaizenGlobalConfig, PluginEntry, PluginManagerPublicApi, PluginManagerLifecycleApi, PluginContext, HarnessIdentity } from "../types/plugin.js";
 import { PLUGIN_API_VERSION } from "../types/plugin.js";
 import { mergePluginConfig, separateSecrets, applyEnvOverrides } from "./config-merge.js";
 import { validateConfig, validateSchemaItself } from "./config-validator.js";
@@ -335,7 +335,7 @@ export class PluginManager {
     private readonly lockfilePath: string,
     private readonly options: { trustLockfile: boolean; allowUnscoped: boolean; nonInteractive: boolean },
     private readonly globalConfig?: KaizenGlobalConfig,
-    private readonly harness: { jsonPath?: string; ref?: string } = {},
+    private readonly harness: HarnessIdentity = {},
   ) {
     // Wire denial listener → audit log.
     this.enforcer.onDenial((r) => this.auditLog.record(r));

--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -335,6 +335,7 @@ export class PluginManager {
     private readonly lockfilePath: string,
     private readonly options: { trustLockfile: boolean; allowUnscoped: boolean; nonInteractive: boolean },
     private readonly globalConfig?: KaizenGlobalConfig,
+    private readonly harness: { jsonPath?: string; ref?: string } = {},
   ) {
     // Wire denial listener → audit log.
     this.enforcer.onDenial((r) => this.auditLog.record(r));
@@ -738,6 +739,7 @@ export class PluginManager {
       () => stateRef.current,
       this.getPublicApi(),
       this.getLifecycleApi(),
+      this.harness,
     );
     await runInPluginScope(plugin.name, async () => { await plugin.setup(ctx); });
     stateRef.current = "READY";

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -80,6 +80,18 @@ export interface PluginServices {
 // Plugin context — passed to setup() and start()
 // ---------------------------------------------------------------------------
 
+/**
+ * Raw metadata about the harness a plugin is loaded under. Both fields are
+ * individually optional. See `PluginContext.harness` for usage and absence
+ * scenarios.
+ */
+export interface HarnessIdentity {
+  /** Absolute path to the resolved harness JSON, if bootstrapped from a file. */
+  jsonPath?: string;
+  /** The ref the user passed (`--harness <ref>` or `defaults.harness`), if any. */
+  ref?: string;
+}
+
 export interface PluginContext {
   /**
    * Raw metadata about the harness this plugin was loaded under. Both inner
@@ -90,12 +102,7 @@ export interface PluginContext {
    * — typically by preferring `jsonPath` over `ref` and falling back to a
    * literal default when both are absent.
    */
-  harness: {
-    /** Absolute path to the resolved harness JSON, if bootstrapped from a file. */
-    jsonPath?: string;
-    /** The ref the user passed (`--harness <ref>` or `defaults.harness`), if any. */
-    ref?: string;
-  };
+  harness: HarnessIdentity;
 
   // --- Service registry ----------------------------------------------------
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -81,6 +81,22 @@ export interface PluginServices {
 // ---------------------------------------------------------------------------
 
 export interface PluginContext {
+  /**
+   * Raw metadata about the harness this plugin was loaded under. Both inner
+   * fields may be absent (e.g. programmatic `runHarness()` without a file on
+   * disk, or `kaizen` invoked from a directory containing `kaizen.json` with
+   * no `--harness` ref). Kaizen does not derive a canonical `name`. Plugins
+   * that need a stable namespacing key derive one from these inputs themselves
+   * — typically by preferring `jsonPath` over `ref` and falling back to a
+   * literal default when both are absent.
+   */
+  harness: {
+    /** Absolute path to the resolved harness JSON, if bootstrapped from a file. */
+    jsonPath?: string;
+    /** The ref the user passed (`--harness <ref>` or `defaults.harness`), if any. */
+    ref?: string;
+  };
+
   // --- Service registry ----------------------------------------------------
 
   /** Declare a service. Only valid during INITIALIZING (setup()). Service names are global; redefining a name another plugin already defined throws. Convention is `<owner>:<service>`, but any unique non-empty token (no whitespace) is accepted. */


### PR DESCRIPTION
## Summary

- Adds `ctx.harness: HarnessIdentity` (`{ jsonPath?, ref? }`) so plugins can partition on-disk state by harness without core picking a canonical name. Closes #74.
- Threads the value from `cli.ts` bootstrap (capturing the user's `--harness` ref *before* `materializeHarnessRef()` rewrites it to a path) through `bootstrap` → `runHarness` → `initializePluginSystem` → `PluginManager` → `createPluginContext`. Outer field always present, inner fields individually optional, default `{}`.
- Backward-compatible: every new param is optional; existing `bootstrap`/`runHarness`/`PluginManager` callers keep working.

Spec: `docs/superpowers/specs/2026-05-06-harness-identity-on-context-design.md`
Plan: `docs/superpowers/plans/2026-05-06-harness-identity-on-context.md`

## Test Plan

- [x] `bun test` — 469 pass / 2 skip / 0 fail
- [x] `bun run build` — clean
- [x] Integration test (`src/core/plugin-manager-harness.test.ts`) covers:
  - PluginManager direct: populated and default-empty cases
  - `runHarness` e2e: same `harness` reaches `setup()`, `onReady()`, and `start()`
- [ ] Manual: run `kaizen --harness <ref>` with a probe plugin logging `ctx.harness`; confirm both fields populated. Run `kaizen` from a dir with `kaizen.json` (no `--harness`); confirm `jsonPath` only.

## Docs

- `docs/guides/plugin-authoring.md` — new `### Harness identity` section with the recommended fallback pattern.
- `docs/reference/plugin-api.md` — adds `harness` to the `PluginContext` interface block and exports `HarnessIdentity`.

## Follow-ups (not in this PR)

- `PluginManager` constructor is now 9 positional params; an options-bag refactor would be worthwhile if a 10th identity-ish field shows up.
- Optional: a mixed-case test (only `jsonPath` populated, no `ref`) would lock the cli.ts conditional-assignment logic against future regression.